### PR TITLE
Fix Nvidia Wayland EGL

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -144,5 +144,8 @@ in
     };
 
     environment.systemPackages = with pkgs.nvidia-jetpack; [ l4t-tools ];
+
+    # Used by libEGL_nvidia.so.0
+    environment.etc."egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
   };
 }


### PR DESCRIPTION
By default libEGL_nvidia.so.0 tries to find EGL configurations in either /usr/share/egl/egl_external_platform.d or /etc/egl/egl_external_platform.d but in NixOS it is stored in /run/opengl-driver/share/egl/egl_external_platform.d. In order to fix it we can set an undocumented variable __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS to the correct path. With this change it is possible to run Weston with nvidia-drm driver on Nvidia Jetson AGX Orin.