### PR TITLE
Symlink libcuda.so.1

### DIFF
--- a/cuda-packages.nix
+++ b/cuda-packages.nix
@@ -108,7 +108,13 @@ let
 
   cudaPackages = {
     cuda_cccl = buildFromSourcePackage { name = "cuda-thrust"; };
-    cuda_cudart = buildFromSourcePackage { name = "cuda-cudart"; };
+    cuda_cudart = buildFromSourcePackage {
+      name = "cuda-cudart";
+      preFixup = ''
+        # Some build systems look for libcuda.so.1 expliticly:
+        ln -s $out/lib/stubs/libcuda.so $out/lib/stubs/libcuda.so.1
+      '';
+    };
     cuda_cuobjdump = buildFromSourcePackage { name = "cuda-cuobjdump"; };
     cuda_cupti = buildFromSourcePackage { name = "cuda-cupti"; };
     cuda_cuxxfilt = buildFromSourcePackage { name = "cuda-cuxxfilt"; };


### PR DESCRIPTION
Add a symlink from `libcuda.so` to `libcuda.so.1` in order to appease certain libraries that explicitly look for `libcuda.so.1`.