### PR TITLE
Remove outdated kernel build fail comment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,5 @@
 {
   inputs = {
-    # Kernel build fails with nixpkgs master, but not 22.05. (During dtc compilation)
-    # Bisected to this commit:  https://github.com/NixOS/nixpkgs/commit/907b497d7e7669f3c2794ab313f8c42f80929bd6
-    # Likely due to DTC_FLAGS=-@ in kernel build
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
   };
 


### PR DESCRIPTION
Remove outdated comment related to failing kernel build. This issue was already fixed in Pull Request #7.

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>

###### Description of changes

The outdated comment causes confusion
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
This change doesn't actually cause any functional changes, merely removes a comment from the flake.nix.

As a test, succesfully did `nix build .#packages.aarch64-linux.iso_minimal` against the latest nixpkgs master. There are no kernel build errors.