### PR TITLE
Fix NixOS booting issue on Jetson AGX Orin with Jetson Linux 34

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -114,7 +114,7 @@ in rec {
     hardware.nvidia-jetpack.enable = true;
     networking.hostName = n; # Just so it sets the flash binary name.
   }).config)) {
-    "orin-agx-devkit" = { som = "orin-agx"; carrierBoard = "devkit"; };
+    "orin-agx-devkit" = { som = "orin-agx"; carrierBoard = "devkit"; bootloader.edk2NvidiaPatches = [ ./edk2-uefi-dtb.patch ]; };
     "xavier-agx-devkit" = { som = "xavier-agx"; carrierBoard = "devkit"; };
     "xavier-nx-devkit" = { som = "xavier-nx"; carrierBoard = "devkit"; };
     "xavier-nx-devkit-emmc" = { som = "xavier-nx-emmc"; carrierBoard = "devkit"; };

--- a/edk2-uefi-dtb.patch
+++ b/edk2-uefi-dtb.patch
@@ -1,0 +1,13 @@
+diff --git a/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c b/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
+index f08ca03..a5c9cc1 100644
+--- a/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
++++ b/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
+@@ -664,8 +664,6 @@ DtPlatformLoadDtb (
+   Status = gBS->CreateEventEx (
+                   EVT_NOTIFY_SIGNAL,
+                   TPL_CALLBACK,
+-                  PlatformType == TEGRA_PLATFORM_SILICON ?
+-                  InstallFdt :
+                   UpdateFdt,
+                   NULL,
+                   &gEfiEventReadyToBootGuid,


### PR DESCRIPTION
###### Description of changes

Currently some Jetson AGX Orin development kits are shipped with Jetson Linux 34. After UEFI firmware is updated using flash-orin-agx-devkit script the system fails to boot from a USB stick with NixOS ISO image.

As it turned out the reason why NixOS fails to boot is that UEFI firmware [loads device tree from the EMMC](https://github.com/NVIDIA/edk2-nvidia/blob/main/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c#L525) even though we are booting from a USB device. The flash script only updates QSPI because EMMC entry is completely deleted from the flash.xml using this XPath expression: `'//device[@type="sdmmc_user"]’`. It means that in this case we still have device tree from version 34 on EMMC but NixOS is built based on version 35 and it fails to boot because the device tree is not compatible.

The simplest fix would be to keep kernel-dtb partitions in the flash.xml so that the flash script updates device tree on EMMC as well. Another idea is to change the XPath expression to `'//device[@type="sdmmc_user"]/*’` so that it keeps an empty sdmmc_user tag to make the flash script erase the EMMC. When EMMC is erased the UEFI firmware will use the device tree from the QSPI. However the problem with these ideas is that they both make changes to the EMMC which may not be expected when flashing a bootloader.

In order to not to make any changes to EMMC I decided to create a small patch for UEFI firmware so that it doesn't try to load the device tree from EMMC at all. With this patch it will use the device tree from QSPI.

We could also try to copy device tree files to the ISO image and then load it in GRUB but it's probably a lot harder to implement especially considering that the same images is supposed to work on different models.

###### Testing

- Flash [Jetson Linux 34.1](https://developer.nvidia.com/embedded/jetson-linux-r341) on Jetson AGX Orin devkit.
- Flash UEFI firmware.
- Insert a USB stick with NixOS ISO image.
- NixOS fails to boot but with this patch it boots fine.
