### PR TITLE
Add realtime.kernel option to enable PREEMPT_RT patches

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,10 +55,13 @@ let
   samples = callPackages ./samples.nix { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t cudaPackages; };
 
   kernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; };
-  kernelPackages = (pkgs.linuxPackagesFor kernel).extend (self: super: {
+  kernelPackagesOverlay = self: super: {
     nvidia-display-driver = self.callPackage ./kernel/display-driver.nix {};
-  });
+  };
+  kernelPackages = (pkgs.linuxPackagesFor kernel).extend kernelPackagesOverlay;
 
+  rtkernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; realtime = true; };
+  rtkernelPackages = (pkgs.linuxPackagesFor rtkernel).extend kernelPackagesOverlay;
 in rec {
   inherit jetpackVersion l4tVersion cudaVersion;
 
@@ -69,6 +72,7 @@ in rec {
   inherit flash-tools;
 
   inherit kernel kernelPackages;
+  inherit rtkernel rtkernelPackages;
 
   # TODO: Source packages. source_sync.sh from bspSrc
   # OPTEE

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -97,8 +97,8 @@ in
       options nvidia-drm modeset=1
     '';
 
-    # For Orin
-    boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-display-driver ];
+    # For Orin. Unsupported with PREEMPT_RT.
+    boot.extraModulePackages = lib.optional (!cfg.realtimeKernel) config.boot.kernelPackages.nvidia-display-driver;
 
     hardware.firmware = with pkgs.nvidia-jetpack; [
       l4t-firmware

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -55,13 +55,22 @@ in
         type = types.nullOr (types.enum [ "devkit" ]);
         description = "Jetson carrier board to target.";
       };
+
+      realtimeKernel = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Enable PREEMPT_RT patches";
+      };
     };
   };
 
   config = mkIf cfg.enable {
     nixpkgs.overlays = [ (import ../overlay.nix) ];
 
-    boot.kernelPackages = pkgs.nvidia-jetpack.kernelPackages;
+    boot.kernelPackages =
+      if cfg.realtimeKernel
+      then pkgs.nvidia-jetpack.rtkernelPackages
+      else pkgs.nvidia-jetpack.kernelPackages;
 
     boot.kernelParams = [
       "console=ttyTCU0,115200" # Provides console on "Tegra Combined UART" (TCU)

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -56,7 +56,7 @@ in
         description = "Jetson carrier board to target.";
       };
 
-      realtimeKernel = mkOption {
+      kernel.realtime = mkOption {
         default = false;
         type = types.bool;
         description = "Enable PREEMPT_RT patches";
@@ -68,7 +68,7 @@ in
     nixpkgs.overlays = [ (import ../overlay.nix) ];
 
     boot.kernelPackages =
-      if cfg.realtimeKernel
+      if cfg.kernel.realtime
       then pkgs.nvidia-jetpack.rtkernelPackages
       else pkgs.nvidia-jetpack.kernelPackages;
 
@@ -98,7 +98,7 @@ in
     '';
 
     # For Orin. Unsupported with PREEMPT_RT.
-    boot.extraModulePackages = lib.optional (!cfg.realtimeKernel) config.boot.kernelPackages.nvidia-display-driver;
+    boot.extraModulePackages = lib.optional (!cfg.kernel.realtime) config.boot.kernelPackages.nvidia-display-driver;
 
     hardware.firmware = with pkgs.nvidia-jetpack; [
       l4t-firmware


### PR DESCRIPTION
###### Description of changes

NVIDIA seems to have some level of support for running a kernel with the PREEMPT_RT patchset. They include the patches under `rt-patches/` and have instructions to enable the realtime kernel here:
https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/SD/Kernel/KernelCustomization.html#to-build-the-real-time-kernel

This adds a `hardware.nvidia-jetpack.kernel.realtime` option which, if set to true, enables the PREEMPT_RT patches and kernel options.

###### Testing

Only tested this builds. Will test on device soon.