### PR TITLE
Fix NVRTC and build NVRTC samples

### DIFF
--- a/cuda-packages.nix
+++ b/cuda-packages.nix
@@ -138,7 +138,13 @@ let
     cuda_nvdisasm = buildFromSourcePackage { name = "cuda-nvdisasm"; };
     cuda_nvml_dev = buildFromSourcePackage { name = "cuda-nvml-dev"; };
     cuda_nvprune = buildFromSourcePackage { name = "cuda-nvprune"; };
-    cuda_nvrtc = buildFromSourcePackage { name = "cuda-nvrtc"; };
+    cuda_nvrtc = buildFromSourcePackage {
+      name = "cuda-nvrtc";
+      postFixup = ''
+        # libnvrtc.so uses libnvrtc-builtins.so
+        patchelf --add-rpath $out/lib $(readlink -f $out/lib/libnvrtc.so)
+      '';
+    };
     cuda_nvtx = buildFromSourcePackage { name = "cuda-nvtx"; };
     cuda_sanitizer_api = buildFromDebs {
       # There are 11-4 and 11-7 versions in the deb repo, and we only want one for now.

--- a/cuda-samples.patch
+++ b/cuda-samples.patch
@@ -1,0 +1,14 @@
+diff -Naur source/0_Simple/matrixMul_nvrtc/Makefile source-new/0_Simple/matrixMul_nvrtc/Makefile
+--- source/0_Simple/matrixMul_nvrtc/Makefile	2022-05-04 18:33:45.000000000 +0000
++++ source-new/0_Simple/matrixMul_nvrtc/Makefile	2023-02-01 22:43:15.652000000 +0000
+@@ -390,8 +390,8 @@
+ all: build
+ 
+ build: matrixMul_nvrtc
+-	$(EXEC) cp "$(CUDA_PATH)/$(CUDA_INSTALL_TARGET_DIR)include/cooperative_groups.h" .
+-	$(EXEC) cp -r "$(CUDA_PATH)/$(CUDA_INSTALL_TARGET_DIR)include/cooperative_groups" .
++	$(EXEC) cp "$(CUDA_PATH)/include/cooperative_groups.h" .
++	$(EXEC) cp -r "$(CUDA_PATH)/include/cooperative_groups" .
+ 
+ check.deps:
+ ifeq ($(SAMPLE_ENABLED),0)

--- a/samples.nix
+++ b/samples.nix
@@ -19,11 +19,14 @@ let
     unpackCmd = "dpkg -x $src source";
     sourceRoot = "source/usr/local/cuda-${cudaVersion}/samples";
 
+    patches = [ ./cuda-samples.patch ];
+
     nativeBuildInputs = [ dpkg pkg-config autoAddOpenGLRunpathHook ];
     buildInputs = [ cudaPackages.cudatoolkit ];
 
     preConfigure = ''
       export CUDA_PATH=${cudaPackages.cudatoolkit}
+      export CUDA_SEARCH_PATH=${cudaPackages.cudatoolkit}/lib/stubs
     '';
 
     enableParallelBuilding = true;
@@ -32,6 +35,9 @@ let
       runHook preInstall
 
       install -Dm755 -t $out/bin bin/${stdenv.hostPlatform.parsed.cpu.name}/${stdenv.hostPlatform.parsed.kernel.name}/release/*
+
+      # *_nvrtc samples require your current working directory contains the corresponding .cu file
+      find -ipath "*_nvrtc/*.cu" -exec install -Dt $out/data {} \;
 
       runHook postInstall
     '';


### PR DESCRIPTION
###### Description of changes

The NVRTC (Runtime Compiler) in `libnvrtc.so` wasn't correctly loading `libnvrtc-builtins.so` at runtime, since its own lib directory was missing from the RPATH.  Additionally, this PR fixes building the `*_nvrtc` examples from cuda-samples.

###### Testing

Tested by running the following on a Xavier AGX:
```
$ nix build .#samples.cuda-samples
$ cd ./result/data
$ ../bin/clock_nvrtc
CUDA Clock sample
> Using CUDA Device [0]: Xavier
> Using CUDA Device [0]: Xavier
> GPU Device has SM 7.2 compute capability
Average clocks/block = 3272.921875
```
