### PR TITLE
Add the ability to flash NixOS to eMMC on AGX Orin

### DIFF
--- a/emmc-image.nix
+++ b/emmc-image.nix
@@ -1,0 +1,54 @@
+{ jetson-firmware, cfg }: { config, pkgs, modulesPath, lib, ... }:
+
+with lib;
+
+{
+  imports = [
+    ./modules/default.nix
+    (modulesPath + "/profiles/base.nix")
+    (modulesPath + "/profiles/installation-device.nix")
+    (modulesPath + "/installer/sd-card/sd-image.nix")
+  ];
+
+  hardware.nvidia-jetpack = cfg;
+
+  # Avoids a bunch of extra modules we don't have in the tegra_defconfig, like "ata_piix",
+  disabledModules = [ (modulesPath + "/profiles/all-hardware.nix") ];
+
+  boot.loader.grub.enable = false;
+
+  sdImage = let
+    kernelPath = "${config.boot.kernelPackages.kernel}/" + "${config.system.boot.loader.kernelFile}";
+    initrdPath = "${config.system.build.initialRamdisk}/" + "${config.system.boot.loader.initrdFile}";
+    fdtPath = "${config.hardware.deviceTree.package}/" + "${config.hardware.nvidia-jetpack.dtbName}";
+    extlinux = pkgs.writeText "extlinux.conf" ''
+      TIMEOUT 30
+      DEFAULT primary
+
+      MENU TITLE NixOS boot options
+
+      LABEL primary
+        MENU LABEL primary kernel
+        LINUX /boot/${config.system.boot.loader.kernelFile}
+        FDT /boot/${config.hardware.nvidia-jetpack.dtbName}
+        INITRD /boot/${config.system.boot.loader.initrdFile}
+        APPEND init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+    '';
+  in {
+    populateFirmwareCommands = ''
+        mkdir -p firmware/EFI/BOOT
+        cp ${jetson-firmware}/L4TLauncher.efi firmware/EFI/BOOT/BOOTAA64.efi
+    '';
+    postBuildCommands = ''
+        cp firmware_part.img $out
+        cp root-fs.img $out
+    '';
+    populateRootCommands = ''
+        mkdir -p ./files/boot/extlinux
+        cp ${extlinux} ./files/boot/extlinux/extlinux.conf
+        cp ${kernelPath} "./files/boot/${config.system.boot.loader.kernelFile}"
+        cp ${initrdPath} "./files/boot/${config.system.boot.loader.initrdFile}"
+        cp ${fdtPath} "./files/boot/${config.hardware.nvidia-jetpack.dtbName}"
+    '';
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -61,6 +61,12 @@ in
         type = types.bool;
         description = "Enable PREEMPT_RT patches";
       };
+
+      dtbName = mkOption {
+        default = "";
+        type = types.str;
+        description = "Devicetree filename";
+      };
     };
   };
 


### PR DESCRIPTION
###### Description of changes

This pull request adds the ability to flash NixOS to the eMMC on Nvidia AGX Orin.

In this implementation I'm copying boot and rootfs partitions from the sd-image to the place where the flashing script expects them to be and passing the -r flag so that it doesn't try to rebuild them. I decided to use L4TLauncher as a UEFI bootloader in order to make it similar to how it is done in Nvidia SDK and for simplicity. However it shouldn't be to hard to switch to systemd-boot or something similar if needed.

I'm not sure if this is the best possible implementation because I'm still new to Nix. Feel free to improve it or suggest changes.

Hopefully it resolves #16 

###### Testing

Tested on Nvidia AGX Orin Developer Kit using the following commands:
```
nix build .#flash-scripts.flash-orin-agx-devkit-emmc
sudo ./result/bin/flash-orin-agx-devkit
```