### PR TITLE
cudaPackages: fix discovery of gcc libraries for cross builds

### DIFF
--- a/cuda-packages.nix
+++ b/cuda-packages.nix
@@ -50,10 +50,9 @@ let
       # libraries is actually under a target-specific directory such as
       # `${stdenv.cc.cc.lib}/aarch64-unknown-linux-gnu/lib/` rather than just plain `/lib` which
       # makes `autoPatchelfHook` fail at finding them libraries.
-      postFixup = ''
+      postFixup = (lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
         addAutoPatchelfSearchPath ${stdenv.cc.cc.lib}/*/lib/
-        ${postFixup}
-      '';
+      '') + postFixup;
 
       postPatch = ''
         if [[ -d usr ]]; then

--- a/cuda-packages.nix
+++ b/cuda-packages.nix
@@ -45,6 +45,16 @@ let
       dontBuild = true;
       noDumpEnvVars = true;
 
+
+      # In cross-compile scenarios, the directory containing `libgcc_s.so` and other such
+      # libraries is actually under a target-specific directory such as
+      # `${stdenv.cc.cc.lib}/aarch64-unknown-linux-gnu/lib/` rather than just plain `/lib` which
+      # makes `autoPatchelfHook` fail at finding them libraries.
+      postFixup = ''
+        addAutoPatchelfSearchPath ${stdenv.cc.cc.lib}/*/lib/
+        ${postFixup}
+      '';
+
       postPatch = ''
         if [[ -d usr ]]; then
           cp -r usr/. .


### PR DESCRIPTION
###### Description of changes

In cross-compile scenarios, the directory containing `libgcc_s.so` and other such
libraries is actually under a target-specific directory such as
`${stdenv.cc.cc.lib}/aarch64-unknown-linux-gnu/lib/` rather than just plain `/lib` which
makes `autoPatchelfHook` fail at finding them libraries.

###### Testing

I cross-built a system that contains `tensorrt` in its `systemPackages`, deployed it, verified that `trtexec` manages to print out its usage when invoked without arguments.
