### PR TITLE
Fix UEFI dtb patch, apply for all devices.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -126,7 +126,7 @@ in rec {
     hardware.nvidia-jetpack.enable = true;
     networking.hostName = n; # Just so it sets the flash binary name.
   }).config)) {
-    "orin-agx-devkit" = { som = "orin-agx"; carrierBoard = "devkit"; bootloader.edk2NvidiaPatches = [ ./edk2-uefi-dtb.patch ]; };
+    "orin-agx-devkit" = { som = "orin-agx"; carrierBoard = "devkit"; };
     "xavier-agx-devkit" = { som = "xavier-agx"; carrierBoard = "devkit"; };
     "xavier-nx-devkit" = { som = "xavier-nx"; carrierBoard = "devkit"; };
     "xavier-nx-devkit-emmc" = { som = "xavier-nx-emmc"; carrierBoard = "devkit"; };

--- a/edk2-uefi-dtb.patch
+++ b/edk2-uefi-dtb.patch
@@ -1,13 +1,15 @@
 diff --git a/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c b/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
-index f08ca03..a5c9cc1 100644
+index 1defbed..d16b86e 100644
 --- a/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
 +++ b/Silicon/NVIDIA/Library/DxeDtPlatformDtbLoaderLib/DxeDtPlatformDtbKernelLoaderLib.c
-@@ -664,8 +664,6 @@ DtPlatformLoadDtb (
+@@ -705,9 +705,7 @@ DtPlatformLoadDtb (
    Status = gBS->CreateEventEx (
                    EVT_NOTIFY_SIGNAL,
                    TPL_CALLBACK,
--                  PlatformType == TEGRA_PLATFORM_SILICON ?
--                  InstallFdt :
-                   UpdateFdt,
+-                  UefiDtbBoot ?
+-                  UpdateFdt :
+-                  InstallFdt,
++                  UpdateFdt,
                    NULL,
                    &gEfiEventReadyToBootGuid,
+                   &ReadyToBootEvent

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -82,5 +82,12 @@ in
     # is probably not the right way to do it, since overlays wouldn't get
     # applied in the new import of nixpkgs.
     hardware.nvidia-jetpack.flashScript = ((import pkgs.path { system = "x86_64-linux"; }).callPackage ../default.nix {}).flashScriptFromNixos config;
+
+    hardware.nvidia-jetpack.bootloader.edk2NvidiaPatches = [
+      # Have UEFI use the device tree compiled into the firmware, instead of
+      # using one from the kernel-dtb partition.
+      # See: https://github.com/anduril/jetpack-nixos/pull/18
+      ../edk2-uefi-dtb.patch
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The Jetpack 5.1 update inadvertantly broke this patch--which was inadvertantly not being applied to the configurations I was testing on.  Additionally, this PR just applies this fix unconditionally.

###### Testing

Tested flashing on Xavier AGX, Xavier NX, and Orin AGX