### PR TITLE
Support for Orin NX

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ This repository packages components from NVIDIA's [Jetpack SDK](https://develope
 
 This package is based on the Jetpack 5 release, and will only work with devices supported by Jetpack 5.1:
  * Jetson Orin AGX
+ * Jetson Orin NX
  * Jetson Xavier AGX
  * Jetson Xavier NX
 
 The Jetson Nano, TX2, and TX1 devices are _not_ supported, since support for them was dropped upstream in Jetpack 5.
-In the future, when the Orin NX and Orin Nano are released, it should be possible to make them work as well.
+In the future, when the Orin Nano is released, it should be possible to make it work as well.
 
 ## Getting started
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -46,7 +46,7 @@ in
         # You can add your own som or carrierBoard by merging the enum type
         # with additional possibilies in an external NixOS module. See:
         # "Extensible option types" in the NixOS manual
-        type = types.nullOr (types.enum [ "orin-agx" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ]);
+        type = types.nullOr (types.enum [ "orin-agx" "orin-nx" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ]);
         description = "Jetson SoM (System-on-Module) to target. Can be null to target a generic jetson device, but some things may not work.";
       };
 

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -85,4 +85,18 @@ in {
       partitionTemplate = mkDefault (filterPartitions "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_l4t_t194_spi_emmc_p3668.xml");
     })
   ];
+
+  boot.kernelPatches = lib.mkIf (cfg.som == "orin-nx") [
+    {
+      name = "disable-usb-otg";
+      patch = null;
+      # TODO: Having these options enabled on the Orin NX currently causes a
+      # kernel panic with a failure in tegra_xudc_unpowergate. We should figure
+      # this out
+      extraStructuredConfig = with lib.kernel; {
+        USB_OTG = no;
+        USB_GADGET = no;
+      };
+    }
+  ];
 }

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -11,6 +11,7 @@ let
 
   nvpModelConf = {
     "orin-agx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3701_0000.conf";
+    "orin-nx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3767_0000.conf";
     "xavier-agx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194.conf";
     "xavier-nx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
     "xavier-nx-emmc" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
@@ -18,6 +19,7 @@ let
 
   nvfancontrolConf = {
     "orin-agx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3701_0000.conf";
+    "orin-nx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
     "xavier-agx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p2888.conf";
     "xavier-nx" ="${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
     "xavier-nx-emmc" ="${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
@@ -58,6 +60,11 @@ in {
           ${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi_sdmmc.xml \
           >$out
       '');
+    })
+
+    (mkIf (cfg.som == "orin-nx") {
+      targetBoard = mkDefault "p3509-a02+p3767-0000";
+      partitionTemplate = mkDefault (filterPartitions "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi.xml");
     })
 
     (mkIf (cfg.som == "xavier-agx") {


### PR DESCRIPTION
###### Description of changes

This PR adds support for the Orin NX, running on the Xavier NX devkit.

There are two known issues:
1) Flashing a factory Orin NX works the first time, but fails the second time: https://github.com/anduril/jetpack-nixos/issues/33
2) It currently requires the USB_OTG kernel config option to be disabled, or else the kernel crashes at boot: https://github.com/anduril/jetpack-nixos/issues/34

###### Testing

Flashed and booted NixOS on an Orin NX