### PR TITLE
Added initial jetson benchmarks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -62,6 +62,19 @@ let
 
   rtkernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; realtime = true; };
   rtkernelPackages = (pkgs.linuxPackagesFor rtkernel).extend kernelPackagesOverlay;
+
+  nxJetsonBenchmarks = pkgs.callPackage ./jetson-benchmarks/default.nix {
+    targetSom = "nx";
+    inherit cudaPackages;
+  };
+  xavierAgxJetsonBenchmarks = pkgs.callPackage ./jetson-benchmarks/default.nix {
+    targetSom = "xavier-agx";
+    inherit cudaPackages;
+  };
+  orinAgxJetsonBenchmarks = pkgs.callPackage ./jetson-benchmarks/default.nix {
+    targetSom = "orin-agx";
+    inherit cudaPackages;
+  };
 in rec {
   inherit jetpackVersion l4tVersion cudaVersion;
 
@@ -75,6 +88,8 @@ in rec {
 
   inherit kernel kernelPackages;
   inherit rtkernel rtkernelPackages;
+
+  inherit nxJetsonBenchmarks xavierAgxJetsonBenchmarks orinAgxJetsonBenchmarks;
 
   # TODO: Source packages. source_sync.sh from bspSrc
   # OPTEE

--- a/jetson-benchmarks/0001-disable-disruptive-system_check.patch
+++ b/jetson-benchmarks/0001-disable-disruptive-system_check.patch
@@ -1,0 +1,41 @@
+From 52217f797026ad226e3799132b7d554458485c58 Mon Sep 17 00:00:00 2001
+From: ktrinh <ktrinh@anduril.com>
+Date: Sat, 11 Feb 2023 15:56:15 -0800
+Subject: [PATCH] disable some system_check
+
+The system_check disabled are either unnecessary(such as the close all app one) or disruptive like the ones that try to set the power model and clock
+---
+ benchmark.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/benchmark.py b/benchmark.py
+index 72e7dcb..acef9cd 100755
+--- a/benchmark.py
++++ b/benchmark.py
+@@ -17,16 +17,16 @@ def main():
+ 
+     # System Check
+     system_check = utilities(jetson_devkit=args.jetson_devkit, gpu_freq=args.gpu_freq, dla_freq=args.dla_freq)
+-    system_check.close_all_apps()
++    # system_check.close_all_apps()
+     if system_check.check_trt():
+         sys.exit()
+-    system_check.set_power_mode(args.power_mode, args.jetson_devkit)
++    # system_check.set_power_mode(args.power_mode, args.jetson_devkit)
+     system_check.clear_ram_space()
+-    if args.jetson_clocks:
+-        system_check.set_jetson_clocks()
+-    else:
+-        system_check.run_set_clocks_withDVFS()
+-        system_check.set_jetson_fan(255)
++    # if args.jetson_clocks:
++    #     system_check.set_jetson_clocks()
++    # else:
++    #     system_check.run_set_clocks_withDVFS()
++    #     system_check.set_jetson_fan(255)
+ 
+     # Read CSV and Write Data
+     benchmark_data = read_write_data(csv_file_path=csv_file_path, model_path=model_path)
+-- 
+2.38.3
+

--- a/jetson-benchmarks/default.nix
+++ b/jetson-benchmarks/default.nix
@@ -1,0 +1,114 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, python3
+, runCommand
+, lib
+, writeShellApplication
+, writeShellScript
+, coreutils
+, unzip
+, wget
+, gnupatch
+, cudaPackages
+, makeWrapper
+
+, targetSom
+
+, benchmarkSrc ? fetchFromGitHub {
+    owner = "NVIDIA-AI-IOT";
+    repo = "jetson_benchmarks";
+    rev = "43892b9ec64abdfabb4c18e19f301d9d4358f5ea";
+    sha256 = "sha256-u11iBbEALOMite/ivm95TAnmXB71i9OjdNnRd0e1cHg=";
+  }
+
+  # disable some system checks such as closing all apps which prevent the benchmark
+  # from being run non-interactively and others like the ones that set the
+  # clocks and nvpmodels
+, disableDisruptiveSystemCheck ? true
+}:
+let
+  pythonEnv = python3.withPackages (ps: with ps; [ numpy pandas ]);
+
+  benchmarkFileMapping = rec {
+    "orin-agx" = {
+      csvFile = "orin-benchmarks.csv";
+      modelDir = "agx_orin_benchmarks_models";
+    };
+    "xavier-agx" = {
+      csvFile = "xavier-benchmarks.csv";
+      modelDir = "agx_xavier_benchmarks_models";
+    };
+    "nx" = {
+      csvFile = "nx-benchmarks.csv";
+      modelDir = "nx_benchmarks_models";
+    };
+  };
+  # nvidia uses a custom script to download the model so make a derivation to do it
+  models = stdenvNoCC.mkDerivation {
+    name = "jetson-benchmarks-models";
+    nativeBuildInputs = [ pythonEnv wget unzip coreutils ];
+
+    builder = writeShellScript "builder.sh" ''
+      source $stdenv/setup
+
+      mkdir -p $out/${benchmarkFileMapping.orin-agx.modelDir}
+      python3 "${benchmarkSrc}/utils/download_models.py" \
+        --all \
+        --csv_file_path "${benchmarkSrc}/benchmark_csv/${benchmarkFileMapping.orin-agx.csvFile}" \
+        --save_dir $out/${benchmarkFileMapping.orin-agx.modelDir}
+
+      mkdir -p $out/${benchmarkFileMapping.xavier-agx.modelDir}
+      python3 "${benchmarkSrc}/utils/download_models.py" \
+        --all \
+        --csv_file_path "${benchmarkSrc}/benchmark_csv/${benchmarkFileMapping.xavier-agx.csvFile}" \
+        --save_dir $out/${benchmarkFileMapping.xavier-agx.modelDir}
+
+      mkdir -p $out/${benchmarkFileMapping.nx.modelDir}
+      python3 "${benchmarkSrc}/utils/download_models.py" \
+        --all \
+        --csv_file_path "${benchmarkSrc}/benchmark_csv/${benchmarkFileMapping.nx.csvFile}" \
+        --save_dir $out/${benchmarkFileMapping.nx.modelDir}
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-gcuWf/Vt1p8aZLt3tnTpUcTD0ZIpL76JxofZQjAlGjg=";
+  };
+
+  runScriptDep = [ pythonEnv cudaPackages.tensorrt coreutils ];
+in
+stdenvNoCC.mkDerivation {
+  name = "jetson-benchmarks";
+
+  src = benchmarkSrc;
+  inherit models;
+
+  patches = [ ]
+    ++ lib.optional disableDisruptiveSystemCheck ./0001-disable-disruptive-system_check.patch;
+
+  nativeBuildInputs = [ coreutils makeWrapper ];
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace utils/load_store_engine.py --replace "/usr/src/tensorrt" "${cudaPackages.tensorrt}"
+    substituteInPlace utils/utilities.py --replace "/usr/src/tensorrt" "${cudaPackages.tensorrt}"
+  '';
+  installPhase = ''
+    mkdir -p models
+    cp -r $models/. models
+
+    mkdir -p $out
+    cp -r ./. $out
+
+    mkdir -p $out/bin
+    cp -r ${./scripts}/. $out/bin
+    chmod +x $out/bin/*
+  '';
+  postFixup = ''
+    wrapProgram $out/bin/run-jetson-benchmarks \
+      --prefix PATH ":" ${lib.makeBinPath runScriptDep} \
+      --set BENCHMARK_CSV_FILE ${benchmarkFileMapping.${targetSom}.csvFile} \
+      --set MODEL_DIR ${benchmarkFileMapping.${targetSom}.modelDir}
+  '';
+}

--- a/jetson-benchmarks/scripts/run-all-jetson-benchmarks
+++ b/jetson-benchmarks/scripts/run-all-jetson-benchmarks
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+${script_dir}/run-jetson-benchmarks --all

--- a/jetson-benchmarks/scripts/run-jetson-benchmarks
+++ b/jetson-benchmarks/scripts/run-jetson-benchmarks
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+WORKDIR=$(mktemp -d)
+function on_exit() {
+    sudo rm -rf "$WORKDIR"
+}
+trap on_exit EXIT
+
+cp -r ${script_dir}/../. "$WORKDIR"
+chmod -R u+w "$WORKDIR"
+cd "$WORKDIR"
+
+csv_file="$PWD/benchmark_csv/${BENCHMARK_CSV_FILE}"
+model_dir="$PWD/models/${MODEL_DIR}"
+
+echo "Running jetson benchmark with csv ${csv_file} and models at ${model_dir}"
+
+sudo python3 benchmark.py --csv_file_path "${csv_file}" --model_dir "${model_dir}" "$@"

--- a/jetson-benchmarks/scripts/run-resnet-jetson-benchmarks
+++ b/jetson-benchmarks/scripts/run-resnet-jetson-benchmarks
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+${script_dir}/run-jetson-benchmarks --model_name resnet


### PR DESCRIPTION
###### Description of changes
Added support for building the jetson benchmark result from nvidia at: https://github.com/NVIDIA-AI-IOT/jetson_benchmarks/, these benchmarks are valuable since Nvidia publishes expected results that allow users to compare whether their platform is performing as expected

###### Testing
Tested on Orin NX. The benchmark is built differently based on whether it runs on NX, Orin AGX, Xavier, AGX, etc. Right now only the one for NX is predefined but others can be defined as well
