### PR TITLE
Disable VPI2 test for now

### DIFF
--- a/samples.nix
+++ b/samples.nix
@@ -366,12 +366,12 @@ let
       echo "Running Multimedia test"
       echo "====="
       ${multimedia-test}/bin/multimedia-test
-
-      echo "====="
-      echo "Running VPI2 test"
-      echo "====="
-      ${vpi2-test}/bin/vpi2-test
     '';
+    # Disabling VPI2 test until its working on JP5.1 again....
+      #echo "====="
+      #echo "Running VPI2 test"
+      #echo "====="
+      #${vpi2-test}/bin/vpi2-test
   };
 in {
   inherit


### PR DESCRIPTION
###### Description of changes

Disables the VPI2 test for now due to the failure here: https://github.com/anduril/jetpack-nixos/issues/44
This lets us continue automated testing for the tests that actually do work.