### PR TITLE
Add tegra-eeprom-tool

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,9 @@ let
 
   python-jetson = python3.pkgs.callPackage ./python-jetson.nix { };
 
+  tegra-eeprom-tool = callPackage ./tegra-eeprom-tool.nix { };
+  tegra-eeprom-tool-static = pkgs.pkgsStatic.callPackage ./tegra-eeprom-tool.nix { };
+
   l4t = callPackages ./l4t.nix { inherit debs l4tVersion; };
 
   cudaPackages = callPackages ./cuda-packages.nix { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t; };
@@ -85,6 +88,7 @@ in rec {
   inherit flash-tools;
   inherit board-automation; # Allows automation of Orin AGX devkit
   inherit python-jetson; # Allows automation of Xavier AGX devkit
+  inherit tegra-eeprom-tool;
 
   inherit kernel kernelPackages;
   inherit rtkernel rtkernelPackages;

--- a/tegra-eeprom-tool.nix
+++ b/tegra-eeprom-tool.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, libedit }:
+
+stdenv.mkDerivation rec {
+  pname = "tegra-eeprom-tool";
+  version = "v2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "OE4T";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-H0BjgFLWf2eruyL5HF4Xu8IImiBra3qCofF4wfL1ebU=";
+  };
+
+  patches = [
+    # Use CMAKE_INSTALL_FULL_* for absolute paths
+    # https://github.com/OE4T/tegra-eeprom-tool/pull/8
+    (fetchpatch {
+      url = "https://github.com/danielfullmer/tegra-eeprom-tool/commit/25381fb3bd780f0e588744509edc17cf58003296.patch";
+      sha256 = "sha256-QYcBglF6Ri0ZhJkVm4cIogkqbhm5e7tfDfWDim+IlhA=";
+    })
+    # Allow building using static libraries
+    # https://github.com/OE4T/tegra-eeprom-tool/pull/9
+    (fetchpatch {
+      url = "https://github.com/danielfullmer/tegra-eeprom-tool/commit/e1b9349becb4ad5c28af19702d181751aa8ca52f.patch";
+      sha256 = "sha256-BAQ0m9M+PAaiR+uaWXY4emClhpaxDOGyM1nKe8+F/FI=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libedit ];
+
+  outputs = [ "bin" "out" "dev" ];
+
+  meta = with lib; {
+    description = "Tools for reading and writing identification EEPROMs on NVIDIA Jetson platforms";
+    homepage = "https://github.com/OE4T/tegra-eeprom-tool";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Adds [tegra-eeprom-tool](https://github.com/oe4t/tegra-eeprom-tool), which is useful for reading and writing from the EEPROM on jetson devices: https://docs.nvidia.com/jetson/archives/r34.1/DeveloperGuide/text/HR/JetsonEepromLayout.html

###### Testing

Builds and runs successfully on a Xavier AGX.