### PR TITLE
Add /etc/nv_tegra_release file from l4t-core deb

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -140,6 +140,9 @@ in
     # Used by libjetsonpower.so, which is used by nvfancontrol at least.
     environment.etc."nvpower/libjetsonpower".source = "${pkgs.nvidia-jetpack.l4t-tools}/etc/nvpower/libjetsonpower";
 
+    # Include nv_tegra_release, just so we can tell what version our NixOS machine was built from.
+    environment.etc."nv_tegra_release".source = "${pkgs.nvidia-jetpack.l4t-core}/etc/nv_tegra_release";
+
     # https://developer.ridgerun.com/wiki/index.php/Xavier/JetPack_5.0.2/Performance_Tuning
     systemd.services.jetson_clocks = mkIf cfg.maxClock {
       enable = true;


### PR DESCRIPTION
###### Description of changes

Add /etc/nv_tegra_release file from l4t-core deb.  Upstream L4T linux has this file, and it makes it easier for a user to tell what version of L4T their NixOS system was built from.

###### Testing

Ensured a Xavier AGX image builds
