### PR TITLE
Set UEFI version to be the l4tVersion

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ let
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: p: "echo Unpacking ${n}; dpkg -x ${p.src} $out/${n}") debs.t234)}
   '';
 
-  jetson-firmware = (pkgsAarch64.callPackages ./jetson-firmware.nix {}).jetson-firmware;
+  jetson-firmware = (pkgsAarch64.callPackages ./jetson-firmware.nix { inherit l4tVersion; }).jetson-firmware;
 
   flash-tools = callPackage ./flash-tools.nix {
     inherit bspSrc l4tVersion;
@@ -142,4 +142,4 @@ in rec {
   });
 }
 // l4t
-// callPackage ./jetson-firmware.nix { }
+// callPackage ./jetson-firmware.nix { inherit l4tVersion; }

--- a/jetson-firmware.nix
+++ b/jetson-firmware.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, buildPackages, fetchFromGitHub, runCommand, edk2, acpica-tools,
   dtc, python3, bc, imagemagick, applyPatches,
+  l4tVersion,
 
   # Optional path to a boot logo that will be converted and cropped into the format required
   bootLogo ? null,
@@ -12,8 +13,6 @@
 }:
 
 let
-  version = "jetson-r35.2.1";
-
   # TODO: Move this generation out of jetson-firmware.nix, because this .nix
   # file is callPackage'd using an aarch64 version of nixpkgs, and we don't
   # want to have to recompilie imagemagick
@@ -30,7 +29,7 @@ let
   edk2-src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "edk2";
-    rev = "r35.2.1-edk2-stable202208";
+    rev = "r${l4tVersion}-edk2-stable202208";
     fetchSubmodules = true;
     sha256 = "sha256-PTbNxbncfSvxLW2XmdRHzUy+w5+1Blpk62DJpxDmedA=";
   };
@@ -38,21 +37,21 @@ let
   edk2-platforms = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "edk2-platforms";
-    rev = "r35.2.1-upstream-20220830";
+    rev = "r${l4tVersion}-upstream-20220830";
     sha256 = "sha256-PjAJEbbswOLYupMg/xEqkAOJuAC8SxNsQlb9YBswRfo=";
   };
 
   edk2-non-osi = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "edk2-non-osi";
-    rev = "r35.2.1-upstream-20220830";
+    rev = "r${l4tVersion}-upstream-20220830";
     sha256 = "sha256-EPtI63jYhEIo4uVTH3lUt9NC/lK5vPVacUAc5qgmz9M=";
   };
 
   _edk2-nvidia = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "edk2-nvidia";
-    rev = "r35.2.1";
+    rev = "r${l4tVersion}";
     sha256 = "sha256-W2kt3r2ymmAj/bKahjEfc8B9orI1o4GYCkByDJ6JORA=";
   };
   edk2-nvidia =
@@ -100,7 +99,7 @@ let
     # Make it not via passthru ?
     stdenv.mkDerivation  {
       name = "edk2-jetson";
-      inherit version;
+      version = l4tVersion;
 
       # Initialize the build dir with the build tools from edk2
       src = edk2-src;
@@ -141,7 +140,7 @@ let
         # The BUILDID_STRING and BUILD_DATE_TIME are used
         # just by nvidia, not generic edk2
         build -a ${targetArch} -b ${buildTarget} -t ${buildType} -p Platform/NVIDIA/Jetson/Jetson.dsc -n $NIX_BUILD_CORES \
-          -D BUILDID_STRING=${version} \
+          -D BUILDID_STRING=${l4tVersion} \
           -D BUILD_DATE_TIME="$(date --utc --iso-8601=seconds --date=@$SOURCE_DATE_EPOCH)" \
           $buildFlags
 


### PR DESCRIPTION
###### Description of changes

Simplify the version a bit to just be `l4tVersion`. This version is accessible from Linux via /sys/class/dmi/id/bios_version

###### Testing

None
