### PR TITLE
Fix config.boot.kernelPatches not being applied

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,7 +57,7 @@ let
 
   samples = callPackages ./samples.nix { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t cudaPackages; };
 
-  kernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; };
+  kernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; kernelPatches = []; };
   kernelPackagesOverlay = self: super: {
     nvidia-display-driver = self.callPackage ./kernel/display-driver.nix {};
   };


### PR DESCRIPTION
###### Description of changes

[This PR](https://github.com/anduril/jetpack-nixos/pull/55) inadvertently broke the `boot.kernelPatches` NixOS option, and those settings were not being applied.

---

This PR uses buildLinux arguments like is done in upstream nixpkgs, where append or merge our kernel's default.nix extra (structured) config with what is passed va callPackage

See `pkgs/os-specific/linux/kernel` in nixpkgs for examples.

###### Testing

Tested by building `config.boot.kernelPackages.kernel.configfile` on a NixOS machine that sets `boot.kernelPatches` and noted that it was working before, is broken currently on master, and is working again after merging this PR.