### PR TITLE
Add initrd-based flashing scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Bus 003 Device 013: ID 0955:7023 NVIDIA Corp. APX
 
 On an x86_64 machine (some of NVIDIA's precompiled components like `tegrarcm_v2` are only built for x86_64),
 build and run (as root) the flashing script which corresponds to your device (making sure to
-replace `xavier-agx` with the name of your device):
+replace `xavier-agx` with the name of your device, use `nix flake show` to see options):
 
 ```shell
-$ nix build github:anduril/jetpack-nixos#flash-scripts.flash-xavier-agx-devkit
+$ nix build github:anduril/jetpack-nixos#flash-xavier-agx-devkit
 $ sudo ./result/bin/flash-xavier-agx-devkit
 ```
 

--- a/bup-bl-only.patch
+++ b/bup-bl-only.patch
@@ -1,0 +1,24 @@
+diff -ur bsp-5.1/bootloader/l4t_bup_gen.func bsp-5.1-new/bootloader/l4t_bup_gen.func
+--- bsp-5.1/bootloader/l4t_bup_gen.func	1969-12-31 16:00:01.000000000 -0800
++++ bsp-5.1-new/bootloader/l4t_bup_gen.func	2023-03-31 15:06:25.659044120 -0700
+@@ -23,9 +23,6 @@
+ 
+ declare -A ENTRY_LIST
+ ENTRY_LIST[bl]=""
+-ENTRY_LIST[kernel]=""
+-ENTRY_LIST[xusb]=""
+-ENTRY_LIST[bl_and_kernel]=""
+ 
+ PART_NAME=""
+ IMAGE_SIGNED=0
+@@ -454,10 +451,6 @@
+ 		rollback_opt="-r ${rollback_bin}"
+ 	fi
+ 
+-	if [ "${ENTRY_LIST[bl_and_kernel]}" == "" ]; then
+-		ENTRY_LIST[bl_and_kernel]="${ENTRY_LIST[bl]};${ENTRY_LIST[kernel]}"
+-	fi
+-
+ 	for list_name in "${!ENTRY_LIST[@]}"; do
+ 		if [ "${ENTRY_LIST["${list_name}"]}" == "" ]; then
+ 			continue

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,0 +1,169 @@
+{ lib, runCommand, writeScript, writeShellScriptBin, makeInitrd, makeModulesClosure,
+  flashFromDevice, jetson-firmware, flash-tools,
+  l4tVersion,
+  pkgsAarch64,
+}:
+
+config:
+
+let
+  # These are from l4t_generate_soc_bup.sh, plus some additional ones found in the wild.
+  variants = rec {
+    xavier-agx = [
+      { boardid="2888"; boardsku="0001"; fab="400"; boardrev="D.0"; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="2888"; boardsku="0001"; fab="400"; boardrev="E.0"; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="2888"; boardsku="0004"; fab="400"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="2888"; boardsku="0005"; fab="402"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+    ];
+    xavier-nx = [ # Dev variant
+      { boardid="3668"; boardsku="0000"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0000"; fab="200"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0000"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+    ];
+    xavier-nx-emmc = [ # Prod variant
+      { boardid="3668"; boardsku="0001"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0001"; fab="200"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0001"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0001"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0003"; fab="301"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+    ];
+
+    orin-agx = [
+      { boardid="3701"; boardsku="0000"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; }
+      { boardid="3701"; boardsku="0004"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 32GB
+      { boardid="3701"; boardsku="0005"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 64GB
+    ];
+
+    orin-nano = [
+      { boardid = "3767"; boardsku = "0000"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin NX 16GB
+      { boardid = "3767"; boardsku = "0001"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin NX 8GB
+      { boardid = "3767"; boardsku = "0003"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin Nano 8GB
+      { boardid = "3767"; boardsku = "0005"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } #
+      { boardid = "3767"; boardsku = "0004"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin Nano 4GB
+    ];
+    orin-nx = orin-nano;
+  };
+
+  cfg = config.hardware.nvidia-jetpack;
+  hostName = config.networking.hostName;
+
+  inherit (cfg.flashScriptOverrides)
+    flashArgs partitionTemplate;
+
+  mkFlashScript = args: import ./flash-script.nix ({
+    inherit lib flashArgs partitionTemplate;
+
+    flash-tools = flash-tools.overrideAttrs ({ postPatch ? "", ... }: {
+      postPatch = postPatch + cfg.flashScriptOverrides.postPatch;
+    });
+
+    jetson-firmware = jetson-firmware.override {
+      bootLogo = cfg.bootloader.logo;
+      debugMode = cfg.bootloader.debugMode;
+      errorLevelInfo = cfg.bootloader.errorLevelInfo;
+      edk2NvidiaPatches = cfg.bootloader.edk2NvidiaPatches;
+    };
+
+    dtbsDir = config.hardware.deviceTree.package;
+  } // args);
+
+  # Generate a flash script using the built configuration options set in a NixOS configuration
+  flashScript = writeShellScriptBin "flash-${hostName}" (mkFlashScript {});
+
+  # TODO: The flash script should not have the kernel output in its runtime closure
+  initrdFlashScript = let
+    modules = [ "qspi_mtd" "spi_tegra210_qspi" "at24" "spi_nor" ];
+    modulesClosure = makeModulesClosure {
+      rootModules = modules;
+      kernel = config.system.modulesTree;
+      firmware = config.hardware.firmware;
+      allowMissing = false;
+    };
+    jetpack-init = writeScript "init" ''
+      #!${pkgsAarch64.pkgsStatic.busybox}/bin/sh
+      export PATH=${pkgsAarch64.pkgsStatic.busybox}/bin
+      mkdir -p /proc /dev /sys
+      mount -t proc proc -o nosuid,nodev,noexec /proc
+      mount -t devtmpfs none -o nosuid /dev
+      mount -t sysfs sysfs -o nosuid,nodev,noexec /sys
+
+      for mod in ${builtins.toString modules}; do
+        modprobe -v $mod
+      done
+
+      if ${flashFromDevice}/bin/${flashFromDevice.name} ${signedFirmware}; then
+        echo "Flashing platform firmware successful. Rebooting now."
+        sync
+        reboot -f
+      else
+        echo "Flashing platform firmware unsuccessful. Entering console"
+        exec ${pkgsAarch64.pkgsStatic.busybox}/bin/sh
+      fi
+    '';
+    initrd = makeInitrd {
+      contents = let
+        kernel = config.boot.kernelPackages.kernel;
+      in [
+        { object = jetpack-init; symlink = "/init"; }
+        { object = "${modulesClosure}/lib/modules"; symlink = "/lib/modules"; }
+        { object = "${modulesClosure}/lib/firmware"; symlink = "/lib/firmware"; }
+      ];
+    };
+  in writeShellScriptBin "initrd-flash-${hostName}" (mkFlashScript {
+    preFlashCommands = ''
+      cp ${config.boot.kernelPackages.kernel}/Image kernel/Image
+      cp ${initrd}/initrd bootloader/l4t_initrd.img
+
+      export CMDLINE="initrd=initrd console=ttyTCU0,115200"
+      export INITRD_IN_BOOTIMG="yes"
+    '';
+    flashArgs = [ "--rcm-boot" ] ++ cfg.flashScriptOverrides.flashArgs;
+    postFlashCommands = ''
+      echo
+      echo "Jetson device should now be flashing and will reboot when complete."
+      echo "You may watch the progress of this on the device's serial port"
+    '';
+  });
+
+  # This must be built on x86_64-linux
+  signedFirmware = runCommand "signed-${hostName}-${l4tVersion}" {} (mkFlashScript {
+    flashCommands = lib.concatMapStringsSep "\n" (v: with v; ''
+      BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
+
+      outdir=$out/${boardid}-${fab}-${boardsku}-${boardrev}-${if fuselevel == "fuselevel_production" then "1" else "0"}-${chiprev}--
+      mkdir -p $outdir
+
+      cp -v bootloader/signed/flash.idx $outdir/
+
+      # Copy files referenced by flash.idx
+      while IFS=", " read -r partnumber partloc start_location partsize partfile partattrs partsha; do
+        if [[ "$partfile" != "" ]]; then
+          if [[ -f "bootloader/signed/$partfile" ]]; then
+            cp -v "bootloader/signed/$partfile" $outdir/
+          elif [[ -f "bootloader/$partfile" ]]; then
+            cp -v "bootloader/$partfile" $outdir/
+          else
+            echo "Unable to find $partfile"
+            exit 1
+          fi
+        fi
+      done < bootloader/signed/flash.idx
+
+      rm -rf bootloader/signed
+    '') variants.${cfg.som};
+  });
+
+  # Bootloader Update Package (BUP)
+  # TODO: Try to make this run on aarch64-linux?
+  bup = runCommand "bup-${hostName}-${l4tVersion}" {} ((mkFlashScript {
+    flashCommands = let
+    in lib.concatMapStringsSep "\n" (v: with v;
+      "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString flashArgs}"
+    ) variants.${cfg.som};
+  }) + ''
+    mkdir -p $out
+    cp -r bootloader/payloads_*/* $out/
+  '');
+in {
+  inherit flashScript initrdFlashScript signedFirmware bup;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,19 +32,23 @@
       x86_64-linux = {
         # TODO: Untested
         iso_minimal = self.nixosConfigurations.installer_minimal_cross.config.system.build.isoImage;
+
+        inherit (x86_packages)
+          board-automation python-jetson;
+        inherit (x86_packages.cudaPackages)
+          nsight_systems_host nsight_compute_host;
       }
       # Flashing and board automation scripts _only_ work on x86_64-linux
-      // {
-        inherit (x86_packages) flash-scripts board-automation python-jetson;
-        inherit (x86_packages.cudaPackages) nsight_systems_host nsight_compute_host;
-      };
+      // x86_packages.flashScripts
+      // x86_packages.initrdFlashScripts;
 
       aarch64-linux = {
         iso_minimal = self.nixosConfigurations.installer_minimal.config.system.build.isoImage;
       };
     };
 
-    legacyPackages.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.callPackage ./default.nix {};
+    # Not everything here should be cross-compiled to aarch64-linux
+    legacyPackages.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.callPackage ./default.nix {};
     legacyPackages.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.callPackage ./default.nix {};
   };
 }

--- a/flash-from-device.nix
+++ b/flash-from-device.nix
@@ -1,0 +1,15 @@
+{ pkgsAarch64, lib, writeScriptBin, runCommand, tegra-eeprom-tool-static }:
+
+let
+  # Make the package smaller so it doesn't blow up the initrd size
+  staticDeps = runCommand "static-deps" {} ''
+    mkdir -p $out/bin
+    cp ${pkgsAarch64.pkgsStatic.mtdutils}/bin/mtd_debug $out/bin
+    cp ${pkgsAarch64.pkgsStatic.mtdutils}/bin/flash_erase $out/bin
+    cp ${tegra-eeprom-tool-static}/bin/tegra-boardspec $out/bin
+  '';
+in
+writeScriptBin "flash-from-device" (''
+  #!${pkgsAarch64.pkgsStatic.busybox}/bin/sh
+  export PATH="${lib.makeBinPath [ pkgsAarch64.pkgsStatic.busybox staticDeps ]}:$PATH"
+'' + (builtins.readFile ./flash-from-device.sh))

--- a/flash-from-device.sh
+++ b/flash-from-device.sh
@@ -1,0 +1,226 @@
+#
+# This file contains modified helper functions from meta-tegra recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+# Copyright (c) 2023 The OE4Tegra Project
+# Licensed under MIT.
+
+set -euo pipefail
+
+signed_images=$1
+
+matching_boardspec=
+
+find_matching_spec() {
+    boardspec=$(tegra-boardspec)
+    my_boardid=$(echo "$boardspec" | cut -d- -f1)
+    my_fab=$(echo "$boardspec" | cut -d- -f2)
+    my_boardsku=$(echo "$boardspec" | cut -d- -f3)
+    my_boardrev=$(echo "$boardspec" | cut -d- -f4)
+    my_fuselevel=$(echo "$boardspec" | cut -d- -f5)
+    my_chiprev=$(echo "$boardspec" | cut -d- -f6)
+
+    # Ignore FAB for everything except Xaviers. It doesn't appear to be necessary. And the TegraPlatformCompatSpec that gets created ignores it.
+    if [[ "$my_boardid" != "2888" ]] && [[ "$my_boardid" != "3668" ]]; then
+        my_fab=
+    fi
+
+    for dirpath in "$signed_images"/*; do
+        curspec=$(basename "$dirpath")
+        cur_boardid=$(echo "$curspec" | cut -d- -f1)
+        cur_fab=$(echo "$curspec" | cut -d- -f2)
+        cur_boardsku=$(echo "$curspec" | cut -d- -f3)
+        cur_boardrev=$(echo "$curspec" | cut -d- -f4)
+        cur_fuselevel=$(echo "$curspec" | cut -d- -f5)
+        cur_chiprev=$(echo "$curspec" | cut -d- -f6)
+
+        if [[ "$my_boardid" != "" ]]   && [[ "$cur_boardid" != "" ]]   && [[ "$cur_boardid" != "$my_boardid" ]]; then continue; fi
+        if [[ "$my_fab" != "" ]]       && [[ "$cur_fab" != "" ]]       && [[ "$cur_fab" != "$my_fab" ]]; then continue; fi
+        if [[ "$my_boardsku" != "" ]]  && [[ "$cur_boardsku" != "" ]]  && [[ "$cur_boardsku" != "$my_boardsku" ]]; then continue; fi
+        if [[ "$my_boardrev" != "" ]]  && [[ "$cur_boardrev" != "" ]]  && [[ "$cur_boardrev" != "$my_boardrev" ]]; then continue; fi
+        if [[ "$my_fuselevel" != "" ]] && [[ "$cur_fuselevel" != "" ]] && [[ "$cur_fuselevel" != "$my_fuselevel" ]]; then continue; fi
+        if [[ "$my_chiprev" != "" ]]   && [[ "$cur_chiprev" != "" ]]   && [[ "$cur_chiprev" != "$my_chiprev" ]]; then continue; fi
+
+        matching_boardspec=$curspec
+        break
+    done
+}
+
+program_spi_partition() {
+    local partname="$1"
+    local part_offset="$2"
+    local part_size="$3"
+    local part_file="$4"
+    local file_size=0
+
+    if [[ -n "$part_file" ]]; then
+        file_size=$(stat -c "%s" "$part_file")
+        if [[ -z "$file_size" ]]; then
+            echo "ERR: could not retrieve file size of $part_file" >&2
+            return 1
+        fi
+    fi
+    if [[ "$file_size" != 0 ]]; then
+        echo "Writing $part_file (size=$file_size) to $partname (offset=$part_offset)"
+        if ! mtd_debug write /dev/mtd0 "$part_offset" "$file_size" "$part_file"; then
+            return 1
+        fi
+    fi
+    # Multiple copies of the BCT get installed at erase-block boundaries
+    # within the defined BCT partition
+    if [ "$partname" = "BCT" ]; then
+        local slotsize
+        slotsize=$(cat /sys/class/mtd/mtd0/erasesize)
+        if [ -z "$slotsize" ]; then
+            return 1
+        fi
+        local rounded_slot_size=$(( ((slotsize + 511) / 512) * 512 ))
+        local curr_offset=$(( part_offset + rounded_slot_size ))
+        local copycount=$(( part_size / rounded_slot_size ))
+        local i=1
+        while [[ $i -lt $copycount ]]; do
+            echo "Writing $part_file to BCT+$i (offset=$curr_offset)"
+            if ! mtd_debug write /dev/mtd0 "$curr_offset" "$file_size" "$part_file"; then
+                return 1
+            fi
+            i=$((i + 1))
+            curr_offset=$((curr_offset + rounded_slot_size))
+        done
+    fi
+    return 0
+}
+
+program_mmcboot_partition() {
+    local partname="$1"
+    local part_offset="$2"
+    local part_size="$3"
+    local part_file="$4"
+    local file_size=0
+    local bootpart="/dev/mmcblk0boot0"
+
+    if [[ -z "$BOOTPART_SIZE" ]]; then
+        echo "ERR: boot partition size not set" >&2
+        return 1
+    fi
+    if [[ "$part_offset" -ge "$BOOTPART_SIZE" ]]; then
+        part_offset=$((part_offset - BOOTPART_SIZE))
+        bootpart="/dev/mmcblk0boot1"
+    fi
+    if [[ -n "$part_file" ]]; then
+        file_size=$(stat -c "%s" "$part_file")
+        if [ -z "$file_size" ]; then
+            echo "ERR: could not retrieve file size of $part_file" >&2
+            return 1
+        fi
+    fi
+    if [[ "$file_size" -ne 0 ]]; then
+        echo "Writing $part_file (size=$file_size) to $partname on $bootpart (offset=$part_offset)"
+        if ! dd if="$part_file" of="$bootpart" bs=4096 seek="$part_offset" oflag=seek_bytes > /dev/null; then
+            return 1
+        fi
+        # Multiple copies of the BCT get installed at 16KiB boundaries
+        # within the defined BCT partition
+        if [[ "$partname" = "BCT" ]]; then
+            local slotsize=16384
+            local curr_offset=$((part_offset + slotsize))
+            local copycount=$((part_size / slotsize))
+            local i=1
+            while [[ $i -lt $copycount ]]; do
+                echo "Writing $part_file (size=$file_size) to BCT+$i (offset=$curr_offset)"
+                if ! dd if="$part_file" of="$bootpart" bs=4096 seek="$curr_offset" oflag=seek_bytes > /dev/null; then
+                    return 1
+                fi
+                i=$((i + 1))
+                curr_offset=$((curr_offset + slotsize))
+            done
+        fi
+    fi
+    return 0
+}
+
+erase_bootdev() {
+    BOOTDEV_TYPE=
+
+    # Detect type to erase
+    while IFS=", " read -r partnumber partloc start_location partsize partfile partattrs partsha; do
+        devnum=$(echo "$partloc" | cut -d':' -f 1)
+        instnum=$(echo "$partloc" | cut -d':' -f 2)
+        partname=$(echo "$partloc" | cut -d':' -f 3)
+        # SPI is 3:0
+        # eMMC boot blocks (boot0/boot1) are 0:3
+        if [[ "$devnum" -eq 3 && "$instnum" -eq 0 ]]; then
+            BOOTDEV_TYPE=spi
+        elif [[ "$devnum" -eq 0 && "$instnum" -eq 3 ]]; then
+            BOOTDEV_TYPE=mmcboot
+        fi
+    done < flash.idx
+
+    if [ "$BOOTDEV_TYPE" = "mmcboot" ]; then
+        if [[ ! -b /dev/mmcblk0boot0 ]] || [[ ! -b /dev/mmcblk0boot1 ]]; then
+            echo "ERR: eMMC boot device, but mmcblk0bootX devices do not exist" >&2
+            return 1
+        fi
+        BOOTPART_SIZE=$(( $(cat /sys/block/mmcblk0boot0/size) * 512))
+        echo "0" > /sys/block/mmcblk0boot0/force_ro
+        echo "0" > /sys/block/mmcblk0boot1/force_ro
+        echo "Erasing /dev/mmcblk0boot0"
+        blkdiscard -f /dev/mmcblk0boot0
+        echo "Erasing /dev/mmcblk0boot1"
+        blkdiscard -f /dev/mmcblk0boot1
+    elif [ "$BOOTDEV_TYPE" = "spi" ]; then
+        if [ ! -e /dev/mtd0 ]; then
+            echo "ERR: SPI boot device, but mtd0 device does not exist" >&2
+            return 1
+        fi
+        echo "Erasing /dev/mtd0"
+        flash_erase /dev/mtd0 0 0
+    else
+        echo "ERR: unknown boot device type: $BOOTDEV_TYPE" >&2
+        return 1
+    fi
+}
+
+write_partitions() {
+    # shellcheck disable=SC2034
+    while IFS=", " read -r partnumber partloc start_location partsize partfile partattrs partsha; do
+        # Need to trim off leading blanks
+        devnum=$(echo "$partloc" | cut -d':' -f 1)
+        instnum=$(echo "$partloc" | cut -d':' -f 2)
+        partname=$(echo "$partloc" | cut -d':' -f 3)
+        # SPI is 3:0
+        # eMMC boot blocks (boot0/boot1) are 0:3
+        # eMMC user is 1:3
+        # SDCard on SoM is 6:0 (Like on Xavier NX dev module)
+        # NVMe (any external device) is 9:0
+        if [[ "$devnum" -eq 3 && "$instnum" -eq 0 ]]; then
+            if [[ "$partfile" != "" ]]; then
+                program_spi_partition "$partname" "$start_location" "$partsize" "$partfile"
+            fi
+        elif [[ "$devnum" -eq 0 && "$instnum" -eq 3 ]]; then
+            if [[ "$partfile" != "" ]]; then
+                program_mmcboot_partition "$partname" "$start_location" "$partsize" "$partfile"
+            fi
+        elif [[ "$devnum" -eq 1 && "$instnum" -eq 3 ]] || [[ "$devnum" -eq 6 && "$instnum" -eq 0 ]]; then
+            if [[ "$partfile" != "" ]]; then
+            echo "Writing $partfile (size=$partsize) to $partname on /dev/mmcblk0 (offset=$start_location)"
+            file_size=$(stat -c "%s" "$partfile")
+            if ! dd if="$partfile" of="/dev/mmcblk0" bs=4096 seek="$start_location" oflag=seek_bytes > /dev/null; then
+                return 1
+            fi
+        fi
+    fi
+    done < flash.idx
+}
+
+find_matching_spec
+if [[ -z "$matching_boardspec" ]]; then
+    echo "Could not find a matching boardspec in signed firmware directory for: $boardspec"
+    echo "Are you sure you created the right signed firmware for this type of device?"
+    exit 1
+fi
+
+# Enter directory containing firmware
+cd "$signed_images"/"$matching_boardspec"
+
+erase_bootdev
+write_partitions
+
+echo Finished flashing device

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -1,6 +1,6 @@
-{ lib, writeShellScriptBin, flash-tools, fetchurl, runtimeShell,
+{ lib, flash-tools,
 
-  name ? "generic", flashArgs ? null, partitionTemplate ? null,
+  preFlashCommands ? "", flashCommands ? "", postFlashCommands ? "", flashArgs ? [], partitionTemplate ? null,
 
   # Optional directory containing DTBs to be used by flashing script, which can
   # be used by the bootloader(s) and passed to the kernel.
@@ -9,15 +9,16 @@
   # Optional package containing uefi_jetson.efi to replace prebuilt version
   jetson-firmware ? null,
 }:
-
-writeShellScriptBin "flash-${name}" (''
+''
   set -euo pipefail
 
-  WORKDIR=$(mktemp -d)
-  function on_exit() {
-    rm -rf "$WORKDIR"
-  }
-  trap on_exit EXIT
+  if [[ -z ''${WORKDIR-} ]]; then
+    WORKDIR=$(mktemp -d)
+    function on_exit() {
+      rm -rf "$WORKDIR"
+    }
+    trap on_exit EXIT
+  fi
 
   cp -r ${flash-tools}/. "$WORKDIR"
   chmod -R u+w "$WORKDIR"
@@ -28,6 +29,7 @@ writeShellScriptBin "flash-${name}" (''
 
   export NO_ROOTFS=1
   export NO_RECOVERY_IMG=1
+  export NO_ESP_IMG=1
 
   ${lib.optionalString (partitionTemplate != null) "cp ${partitionTemplate} flash.xml"}
   ${lib.optionalString (dtbsDir != null) "cp -r ${dtbsDir}/. kernel/dtb/"}
@@ -42,10 +44,14 @@ writeShellScriptBin "flash-${name}" (''
   cp ${jetson-firmware}/dtbs/*.dtbo kernel/dtb/
   ''}
 
+  ${preFlashCommands}
+
   chmod -R u+w .
 
-'' + (if (flashArgs != null) then ''
-  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} $@ ${builtins.toString flashArgs}
+'' + (if (flashCommands != "") then ''
+  ${flashCommands}
 '' else ''
-  ${runtimeShell}
-''))
+  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} $@ ${builtins.toString flashArgs}
+'') + ''
+  ${postFlashCommands}
+''

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -45,7 +45,7 @@ writeShellScriptBin "flash-${name}" (''
   chmod -R u+w .
 
 '' + (if (flashArgs != null) then ''
-  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} $@ ${flashArgs}
+  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} $@ ${builtins.toString flashArgs}
 '' else ''
   ${runtimeShell}
 ''))

--- a/flash-tools.nix
+++ b/flash-tools.nix
@@ -19,6 +19,8 @@ let
       perl
     ]; # BUP_payload needs python2 :(  Others need python3
 
+    patches = [ ./flash.sh.patch ./bup-bl-only.patch ];
+
     postPatch = ''
       for filename in bootloader/BUP_generator.py bootloader/rollback/rollback_parser.py; do
         substituteInPlace $filename \

--- a/flash.sh.patch
+++ b/flash.sh.patch
@@ -1,0 +1,13 @@
+diff -Naur bsp-5.1/flash.sh bsp-new/flash.sh
+--- bsp-5.1/flash.sh	1969-12-31 16:00:01.000000000 -0800
++++ bsp-new/flash.sh	2023-03-09 11:07:44.833408932 -0800
+@@ -2410,6 +2410,9 @@
+ 			cmdline+="${string} ";
+ 		fi
+ 	done
++
++	# Yeah, lets just not....
++	cmdline="${CMDLINE}"
+ fi;
+ 
+ ##########################################################################

--- a/jetson-firmware.nix
+++ b/jetson-firmware.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages, fetchFromGitHub, runCommand, edk2, acpica-tools,
-  dtc, python3, bc, imagemagick, applyPatches,
+  dtc, python3, bc, imagemagick, applyPatches, nukeReferences,
   l4tVersion,
 
   # Optional path to a boot logo that will be converted and cropped into the format required
@@ -154,7 +154,9 @@ let
       '';
     };
 
-    jetson-firmware = runCommand "jetson-firmware" { nativeBuildInputs = [ python3 ]; } ''
+    jetson-firmware = runCommand "jetson-firmware" {
+      nativeBuildInputs = [ python3 nukeReferences ];
+    } ''
       mkdir -p $out
       python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
         ${edk2-jetson}/FV/UEFI_NS.Fv \
@@ -168,6 +170,9 @@ let
       for filename in ${edk2-jetson}/AARCH64/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree/OUTPUT/*.dtb; do
         cp $filename $out/dtbs/$(basename "$filename" ".dtb").dtbo
       done
+
+      # Get rid of any string references to source(s)
+      nuke-refs $out/uefi_jetson.bin
   '';
 in {
   inherit edk2-jetson jetson-firmware;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -73,10 +73,11 @@ in
       else pkgs.nvidia-jetpack.kernelPackages;
 
     boot.kernelParams = [
-      "console=ttyTCU0,115200" # Provides console on "Tegra Combined UART" (TCU)
       "console=tty0" # Output to HDMI/DP
       "fbcon=map:0" # Needed for HDMI/DP
       "video=efifb:off" # Disable efifb driver, which crashes Xavier AGX/NX
+
+      "console=ttyTCU0,115200" # Provides console on "Tegra Combined UART" (TCU)
 
       # Needed on Orin at least, but upstream has it for both
       "nvidia.rm_firmware_active=all"

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -51,9 +51,8 @@ in
         };
 
         flashArgs = mkOption {
-          type = types.str;
+          type = types.listOf types.str;
           description = "Arguments to apply to flashing script";
-          default = "${cfg.flashScriptOverrides.targetBoard} mmcblk0p1";
         };
 
         partitionTemplate = mkOption {
@@ -82,6 +81,8 @@ in
     # is probably not the right way to do it, since overlays wouldn't get
     # applied in the new import of nixpkgs.
     hardware.nvidia-jetpack.flashScript = ((import pkgs.path { system = "x86_64-linux"; }).callPackage ../default.nix {}).flashScriptFromNixos config;
+
+    hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = [ cfg.flashScriptOverrides.targetBoard "mmcblk0p1" ];
 
     hardware.nvidia-jetpack.bootloader.edk2NvidiaPatches = [
       # Have UEFI use the device tree compiled into the firmware, instead of

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -73,14 +73,24 @@ in
         internal = true;
         description = "Script to flash the xavier device";
       };
+
+      devicePkgs = mkOption {
+        type = types.attrsOf types.anything;
+        readOnly = true;
+        internal = true;
+        description = "Flashing packages associated with this NixOS configuration";
+      };
     };
   };
 
-  config = {
+  config = let
     # Totally ugly reimport of nixpkgs so we can get a native x86 version. This
     # is probably not the right way to do it, since overlays wouldn't get
     # applied in the new import of nixpkgs.
-    hardware.nvidia-jetpack.flashScript = ((import pkgs.path { system = "x86_64-linux"; }).callPackage ../default.nix {}).flashScriptFromNixos config;
+    devicePkgs = ((import pkgs.path { system = "x86_64-linux"; }).callPackage ../default.nix {}).devicePkgsFromNixosConfig config;
+  in {
+    hardware.nvidia-jetpack.flashScript = devicePkgs.flashScript; # Left for backwards-compatibility
+    hardware.nvidia-jetpack.devicePkgs = devicePkgs;
 
     hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = [ cfg.flashScriptOverrides.targetBoard "mmcblk0p1" ];
 


### PR DESCRIPTION
###### Description of changes

As an alternative to the traditional flashing scripts, we now have the
option to RCM boot into a minimal Linux system that can write out the
firmware itself.  This is done by upstream in
`tools/kernel_flash/initrd_flash` in the BSP package.  Flashing in this
manner also resolved the issue (https://github.com/anduril/jetpack-nixos/issues/33) where we were unable to flash an
Orin NX after it had been initially flashed from the factory.
Initrd-based flashing will likely be necessary if we ever want to have
the flashing script write out a full NixOS system to an NVMe drive.

Unlike the initrd flashing scripts from NVIDIA's BSP, or from OE4T
meta-tegra, our script is explicitly "multi-spec" and includes firmware
for all Jetson variants associated with a given soc/carrierboard combo.
This means we do not need to query the device first then build the
firmware (like is done in the BSP), or just built for a single variant
(like in OE4T).

In the short-term, we'll still recommend using the existing flash
script, and only recommend using initrd-based flashing if you have a
need (like for the Orin NX).

Closes https://github.com/anduril/jetpack-nixos/issues/33 and https://github.com/anduril/jetpack-nixos/issues/35

###### Testing

Tested on Orin AGX, Orin NX, Xavier AGX, and Xavier NX devkits.