### PR TITLE
Fix display-driver build on GCC 12

### DIFF
--- a/kernel/add-mno-outline-atomics-for-aarch64.patch
+++ b/kernel/add-mno-outline-atomics-for-aarch64.patch
@@ -1,0 +1,15 @@
+diff --git a/src/nvidia/Makefile b/src/nvidia/Makefile
+index 17f680e..a38eeed 100644
+--- a/src/nvidia/Makefile
++++ b/src/nvidia/Makefile
+@@ -79,6 +79,7 @@ ifeq ($(TARGET_ARCH),aarch64)
+   CFLAGS += -mgeneral-regs-only
+   CFLAGS += -march=armv8-a
+   CFLAGS += -mstrict-align
++  CONDITIONAL_CFLAGS += $(call TEST_CC_ARG, -mno-outline-atomics)
+ endif
+ 
+ #CFLAGS += -ffunction-sections
+-- 
+2.38.4
+

--- a/kernel/display-driver.nix
+++ b/kernel/display-driver.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "nv-kernel-display-driver-5f54f1d/NVIDIA-kernel-module-source-TempVersion";
 
+  patches = [
+    # This is needed because of nixos-unstable change from GCC 9 to 12. This
+    # change has been backported from jetson_35.3.1, and because of that,
+    # it should also be removed when moving to jetson_35.3.1
+    ./add-mno-outline-atomics-for-aarch64.patch
+  ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = kernel.makeFlags ++ [


### PR DESCRIPTION
Recent versions of nixos-unstable have moved from GCC 9 to 12, which breaks to build. Flag -mno-outline-atomics is needed for the kernel module, to avoid errors sucs as:

ERROR: modpost: "__aarch64_cas4_sync" [nvidia.ko] undefined!
ERROR: modpost: "__aarch64_ldadd8_sync" [nvidia.ko] undefined!
ERROR: modpost: "__aarch64_ldadd4_sync" [nvidia.ko] undefined!
ERROR: modpost: "__aarch64_cas8_sync" [/nvidia.ko] undefined!

This change has been backported from jetson_35.3.1

###### Description of changes

**What has changed as a result of this PR? Why was the change made?**

display-driver did not build with nixos-unstable channel. A small change adding one flag to kernel module build was backported from 35.3.1 to 35.2.1 to make it builable with recent nixos-unstable versions.

###### Testing

Tested that it builds with latest nixos-unstable, which is an improvement because previously it didn't build at all. I don't at this very moment have physical access to the AGX Orin with display to see does the driver really work or not