### PR TITLE
Add derivations for OPTEE and ATF

### DIFF
--- a/0001-nvoptee-no-install-makefile.patch
+++ b/0001-nvoptee-no-install-makefile.patch
@@ -1,0 +1,39 @@
+diff --git a/optee/samples/hwkey-agent/host/Makefile b/optee/samples/hwkey-agent/host/Makefile
+index b7c2113..613c3e7 100644
+--- a/optee/samples/hwkey-agent/host/Makefile
++++ b/optee/samples/hwkey-agent/host/Makefile
+@@ -19,7 +19,7 @@ OBJS = $(patsubst %.c,$(O)/%.o,$(SRCS))
+ BINARY = nvhwkey-app
+ 
+ .PHONY: all install
+-all: $(BINARY) install
++all: $(BINARY)
+ 
+ $(BINARY): $(OBJS)
+ 	$(CC) -o $(O)/$@ $< $(LDADD)
+diff --git a/optee/samples/luks-srv/host/Makefile b/optee/samples/luks-srv/host/Makefile
+index c9a2dcc..2c3087e 100644
+--- a/optee/samples/luks-srv/host/Makefile
++++ b/optee/samples/luks-srv/host/Makefile
+@@ -11,19 +11,17 @@ CC ?= $(CROSS_COMPILE)gcc
+ LD ?= $(CROSS_COMPILE)ld
+ STRIP ?= $(CROSS_COMPILE)strip
+ 
+-CFLAGS += -Wall -I../ta/include -I./include
++CFLAGS += -Wall -I../ta/include
+ CFLAGS += -I$(OPTEE_CLIENT_EXPORT)/include
+ CFLAGS += -fstack-protector-strong
+-LDADD += -pthread -lpthread
+ LDADD += -lteec -L$(OPTEE_CLIENT_EXPORT)/lib
+-LDFLAGS := -static
+ 
+ SRCS = luks_srv_ca.c
+ OBJS = $(patsubst %.c,$(O)/%.o,$(SRCS))
+ BINARY = nvluks-srv-app
+ 
+ .PHONY: all install
+-all: $(BINARY) install
++all: $(BINARY)
+ 
+ $(BINARY): $(OBJS)
+ 	$(CC) $(LDFLAGS) -o $(O)/$@ $< $(LDADD)

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,10 @@ let
 
   jetson-firmware = (pkgsAarch64.callPackages ./jetson-firmware.nix { inherit l4tVersion; }).jetson-firmware;
 
+  inherit (pkgsAarch64.callPackages ./optee.nix {
+    inherit l4tVersion bspSrc;
+  }) buildTOS opteeClient;
+
   flash-tools = callPackage ./flash-tools.nix {
     inherit bspSrc l4tVersion;
   };
@@ -102,10 +106,8 @@ let
 
   # Packages whose contents are paramterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs.nix {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice jetson-firmware;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice jetson-firmware buildTOS;
   };
-
-  devicePkgs = lib.mapAttrs (n: c: devicePkgsFromNixosConfig (pkgs.nixos c).config) supportedConfigurations;
 in rec {
   inherit jetpackVersion l4tVersion cudaVersion;
 
@@ -121,12 +123,11 @@ in rec {
   inherit kernel kernelPackages;
   inherit rtkernel rtkernelPackages;
 
+  inherit opteeClient;
+
   inherit nxJetsonBenchmarks xavierAgxJetsonBenchmarks orinAgxJetsonBenchmarks;
 
   # TODO: Source packages. source_sync.sh from bspSrc
-  # OPTEE
-  #   nv-tegra.nvidia.com/tegra/optee-src/atf.git
-  #   nv-tegra.nvidia.com/tegra/optee-src/nv-optee.git
   # GST plugins
 
   inherit flashFromDevice;

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,5 +1,5 @@
 { lib, runCommand, writeScript, writeShellScriptBin, makeInitrd, makeModulesClosure,
-  flashFromDevice, jetson-firmware, flash-tools,
+  flashFromDevice, jetson-firmware, flash-tools, buildTOS,
   l4tVersion,
   pkgsAarch64,
 }:
@@ -50,6 +50,16 @@ let
   inherit (cfg.flashScriptOverrides)
     flashArgs partitionTemplate;
 
+  tosImage = buildTOS {
+    platform = {
+      orin-agx = "t234";
+      orin-nx = "t234";
+      xavier-agx = "t194";
+      xavier-nx = "t194";
+      xavier-nx-emmc = "t194";
+    }.${cfg.som};
+  };
+
   mkFlashScript = args: import ./flash-script.nix ({
     inherit lib flashArgs partitionTemplate;
 
@@ -63,6 +73,8 @@ let
       errorLevelInfo = cfg.bootloader.errorLevelInfo;
       edk2NvidiaPatches = cfg.bootloader.edk2NvidiaPatches;
     };
+
+    inherit tosImage;
 
     dtbsDir = config.hardware.deviceTree.package;
   } // args);
@@ -165,5 +177,6 @@ let
     cp -r bootloader/payloads_*/* $out/
   '');
 in {
+  inherit (tosImage) nvLuksSrv hwKeyAgent;
   inherit flashScript initrdFlashScript signedFirmware bup;
 }

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -8,6 +8,9 @@
 
   # Optional package containing uefi_jetson.efi to replace prebuilt version
   jetson-firmware ? null,
+
+  # Optional package containing tos.img to replace prebuilt version
+  tosImage ? null,
 }:
 ''
   set -euo pipefail
@@ -42,6 +45,9 @@
 
   # Replace additional dtbos
   cp ${jetson-firmware}/dtbs/*.dtbo kernel/dtb/
+  ''}
+  ${lib.optionalString (tosImage != null) ''
+  cp ${tosImage}/tos.img bootloader/tos-optee_${tosImage.platform}.img
   ''}
 
   ${preFlashCommands}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -156,6 +156,15 @@ in
       wantedBy = [ "multi-user.target" ];
     };
 
+    systemd.services.tee-supplicant = {
+      description = "Userspace supplicant for OPTEE-OS";
+      serviceConfig = {
+        ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant";
+        Restart = "always";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
     environment.systemPackages = with pkgs.nvidia-jetpack; [ l4t-tools ];
 
     # Used by libEGL_nvidia.so.0

--- a/optee.nix
+++ b/optee.nix
@@ -1,0 +1,218 @@
+{ l4tVersion
+, bspSrc
+, buildPackages
+, lib
+, stdenv
+, fetchgit
+, pkg-config
+, libuuid
+, dtc
+}:
+
+let
+  atfSrc = fetchgit {
+    url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/atf";
+    rev = "jetson_${l4tVersion}";
+    sha256 = "sha256-feG/GtT2CRTxCiEdSMSjCM5yDxO5kYFTClqT3YGgdVs=";
+  };
+
+  nvopteeSrc = fetchgit {
+    url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
+    rev = "jetson_${l4tVersion}";
+    sha256 = "sha256-vNyzvYzMyZgqS3n42DaIT5mIrRX3BOrTsL2SkQSskiY=";
+  };
+
+  opteeClient = stdenv.mkDerivation {
+    pname = "optee_client";
+    version = nvopteeSrc.rev;
+    src = nvopteeSrc;
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ libuuid ];
+    makeFlags = [ "-C optee/optee_client" "DESTDIR=$(out)" "SBINDIR=/bin" "LIBDIR=/lib" "INCLUDEDIR=/include" ];
+    meta.platforms = [ "aarch64-linux" ];
+  };
+
+  buildOptee = lib.makeOverridable ({ pname ? "optee-os"
+                                    , platform
+                                    , earlyTaPaths ? [ ]
+                                    , extraMakeFlags ? [ ]
+                                    }:
+    let
+      stmmPath = {
+        t194 = "${bspSrc}/bootloader/standalonemm_optee_t194.bin";
+        t234 = "${bspSrc}/bootloader/standalonemm_optee_t234.bin";
+      }.${platform};
+
+      nvCccPrebuilt = {
+        t194 = "";
+        t234 = "${nvopteeSrc}/optee/optee_os/prebuilt/t234/libcommon_crypto.a";
+      }.${platform};
+
+      makeFlags = [
+        "-C optee/optee_os"
+        "CROSS_COMPILE64=${stdenv.cc.targetPrefix}"
+        "PLATFORM=tegra"
+        "PLATFORM_FLAVOR=${platform}"
+        "CFG_WITH_STMM_SP=y"
+        "CFG_STMM_PATH=${stmmPath}"
+        "NV_CCC_PREBUILT=${nvCccPrebuilt}"
+        "O=$(out)"
+      ]
+      ++ extraMakeFlags;
+    in
+    stdenv.mkDerivation {
+      inherit pname;
+      version = nvopteeSrc.rev;
+      src = nvopteeSrc;
+      postPatch = ''
+        patchShebangs $(find optee/optee_os -type d -name scripts -printf '%p ')
+      '';
+      nativeBuildInputs = [
+        dtc
+        (buildPackages.python3.withPackages (p: with p; [ pyelftools cryptography ]))
+      ];
+      inherit makeFlags;
+      # NOTE: EARLY_TA_PATHS needs to be added outside of `makeFlags` since it is a
+      # space separated list of paths. See
+      # https://nixos.org/manual/nixpkgs/stable/#build-phase for more details.
+      preBuild = lib.optionalString (earlyTaPaths != [ ]) ''
+        makeFlagsArray+=(EARLY_TA_PATHS="${toString earlyTaPaths}")
+      '';
+      dontInstall = true;
+      meta.platforms = [ "aarch64-linux" ];
+    });
+
+  buildOpteeTaDevKit = args: buildOptee ({
+    pname = "optee-ta-dev-kit";
+    extraMakeFlags = [ "ta_dev_kit" ];
+  } // args);
+
+  buildNvLuksSrv = args: stdenv.mkDerivation {
+    pname = "nvluks-srv";
+    version = nvopteeSrc.rev;
+    src = nvopteeSrc;
+    patches = [ ./0001-nvoptee-no-install-makefile.patch ];
+    nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+    makeFlags = [
+      "-C optee/samples/luks-srv"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      "TA_DEV_KIT_DIR=${buildOpteeTaDevKit args}/export-ta_arm64"
+      "OPTEE_CLIENT_EXPORT=${opteeClient}"
+      "O=$(PWD)/out"
+    ];
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 -t $out/bin out/ca/luks-srv/nvluks-srv-app
+      install -Dm755 -t $out out/early_ta/luks-srv/*.stripped.elf
+
+      runHook postInstall
+    '';
+    meta.platforms = [ "aarch64-linux" ];
+  };
+
+  buildHwKeyAgent = args: stdenv.mkDerivation {
+    pname = "hwkey-agent";
+    version = nvopteeSrc.rev;
+    src = nvopteeSrc;
+    patches = [ ./0001-nvoptee-no-install-makefile.patch ];
+    nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+    makeFlags = [
+      "-C optee/samples/hwkey-agent"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      "TA_DEV_KIT_DIR=${buildOpteeTaDevKit args}/export-ta_arm64"
+      "OPTEE_CLIENT_EXPORT=${opteeClient}"
+      "O=$(PWD)/out"
+    ];
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 -t $out/bin out/ca/hwkey-agent/nvhwkey-app
+      install -Dm755 -t $out out/ta/hwkey-agent/*.stripped.elf
+
+      runHook postInstall
+    '';
+  };
+
+  buildOpteeDTB = lib.makeOverridable ({ platform }:
+    let
+      flavor = lib.replaceStrings [ "t" ] [ "" ] platform;
+    in
+    buildPackages.runCommand "tegra-${flavor}-optee.dtb"
+      {
+        nativeBuildInputs = [ dtc ];
+      } ''
+      mkdir -p $out
+      dtc -I dts -O dtb -o $out/tegra${flavor}-optee.dtb ${nvopteeSrc}/optee/tegra${flavor}-optee.dts
+    '');
+
+  buildArmTrustedFirmware = lib.makeOverridable ({ platform }:
+    stdenv.mkDerivation {
+      pname = "arm-trusted-firmware";
+      version = atfSrc.rev;
+      src = atfSrc;
+      makeFlags = [
+        "-C arm-trusted-firmware"
+        "BUILD_BASE=$(PWD)/build"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "DEBUG=0"
+        "LOG_LEVEL=20"
+        "PLAT=tegra"
+        "SPD=opteed"
+        "TARGET_SOC=${platform}"
+        "V=0"
+        # binutils 2.39 regression
+        # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`
+        # See also: https://developer.trustedfirmware.org/T996
+        "LDFLAGS=-no-warn-rwx-segments"
+      ];
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp ./build/tegra/${platform}/release/bl31.bin $out/bl31.bin
+
+        runHook postInstall
+      '';
+
+      meta.platforms = [ "aarch64-linux" ];
+    });
+
+  buildTOS = { platform }@args:
+    let
+      armTrustedFirmware = buildArmTrustedFirmware args;
+
+      opteeDTB = buildOpteeDTB args;
+
+      nvLuksSrv = buildNvLuksSrv args;
+      hwKeyAgent = buildHwKeyAgent args;
+
+      opteeOS = buildOptee ({
+        earlyTaPaths = [
+          "${nvLuksSrv}/b83d14a8-7128-49df-9624-35f14f65ca6c.stripped.elf"
+          "${hwKeyAgent}/82154947-c1bc-4bdf-b89d-04f93c0ea97c.stripped.elf"
+        ];
+      } // args);
+
+      image = buildPackages.runCommand "tos.img"
+        {
+          passthru = { inherit platform nvLuksSrv hwKeyAgent; };
+        } ''
+        mkdir -p $out
+        ${buildPackages.python3}/bin/python3 ${bspSrc}/nv_tegra/tos-scripts/gen_tos_part_img.py \
+          --monitor ${armTrustedFirmware}/bl31.bin \
+          --os ${opteeOS}/core/tee-raw.bin \
+          --dtb ${opteeDTB}/*.dtb \
+          --tostype optee \
+          $out/tos.img
+      '';
+    in
+    image;
+in
+{
+  inherit
+    opteeClient
+    buildTOS
+    ;
+}


### PR DESCRIPTION
###### Description of changes

OPTEE and ATF are built according to the SOC platform (t194 or t234), so it requires having hardware.nvidia-jetpack.som defined.

Changes include:
- Adding an ATF image with OPTEE and builtin nvluks-srv and hwkey-agent trusted applications that are flashed in the same per-device flash script.
- Adding the tee-supplicant service to each board running a TOS. This is used to broker communication between the REE and TEE (regular execution environment and trusted execution environment).


###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
Tested on an Orin AGX devkit. Functionality between the nix-built TOS and stock TOS appears to be the same.