### PR TITLE
Add UEFI capsule update scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Anduril Industries
+Copyright 2022-2023 Anduril Industries
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,5 +1,6 @@
-{ lib, runCommand, writeScript, writeShellScriptBin, makeInitrd, makeModulesClosure,
-  flashFromDevice, jetson-firmware, flash-tools,
+{ lib, callPackage, runCommand, writeScript, writeShellScriptBin, makeInitrd, makeModulesClosure,
+  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools,
+  python3, bspSrc, openssl,
   l4tVersion,
   pkgsAarch64,
 }:
@@ -17,20 +18,16 @@ let
     ];
     xavier-nx = [ # Dev variant
       { boardid="3668"; boardsku="0000"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0000"; fab="200"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0000"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
+      { boardid="3668"; boardsku="0000"; fab="301"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
     ];
     xavier-nx-emmc = [ # Prod variant
       { boardid="3668"; boardsku="0001"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0001"; fab="200"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0001"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0001"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
       { boardid="3668"; boardsku="0003"; fab="301"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
     ];
 
     orin-agx = [
-      { boardid="3701"; boardsku="0000"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; }
-      { boardid="3701"; boardsku="0004"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 32GB
+      { boardid="3701"; boardsku="0000"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; }
+      { boardid="3701"; boardsku="0004"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 32GB
       { boardid="3701"; boardsku="0005"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 64GB
     ];
 
@@ -57,7 +54,7 @@ let
       postPatch = postPatch + cfg.flashScriptOverrides.postPatch;
     });
 
-    jetson-firmware = jetson-firmware.override {
+    uefi-firmware = uefi-firmware.override {
       bootLogo = cfg.bootloader.logo;
       debugMode = cfg.bootloader.debugMode;
       errorLevelInfo = cfg.bootloader.errorLevelInfo;
@@ -155,6 +152,7 @@ let
 
   # Bootloader Update Package (BUP)
   # TODO: Try to make this run on aarch64-linux?
+  # TODO: Maybe generate this ourselves from signedFirmware so we dont have multiple scripts using the same keys to sign the same artifacts
   bup = runCommand "bup-${hostName}-${l4tVersion}" {} ((mkFlashScript {
     flashCommands = let
     in lib.concatMapStringsSep "\n" (v: with v;
@@ -164,6 +162,15 @@ let
     mkdir -p $out
     cp -r bootloader/payloads_*/* $out/
   '');
+
+  # TODO: This step could probably also be done on aarch64-linux too.  That would be valuable to allow Jetsons to be able to update themselves.
+  # See l4t_generate_soc_bup.sh
+  # python ${edk2-jetson}/BaseTools/BinWrappers/PosixLike/GenerateCapsule -v --encode --monotonic-count 1
+  # ${bspSrc}
+  # TODO: improve soc arch (t234) condition
+  uefiCapsuleUpdate = runCommand "uefi-${hostName}-${l4tVersion}.Cap" { nativeBuildInputs = [ python3 openssl ]; } ''
+    bash ${bspSrc}/generate_capsule/l4t_generate_soc_capsule.sh -i ${bup}/bl_only_payload -o $out ${if (lib.hasPrefix "orin-" cfg.som) then "t234" else "t194"}
+  '';
 in {
-  inherit flashScript initrdFlashScript signedFirmware bup;
+  inherit flashScript initrdFlashScript signedFirmware bup uefiCapsuleUpdate;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,8 @@
       }
       # Flashing and board automation scripts _only_ work on x86_64-linux
       // x86_packages.flashScripts
-      // x86_packages.initrdFlashScripts;
+      // x86_packages.initrdFlashScripts
+      // x86_packages.uefiCapsuleUpdates;
 
       aarch64-linux = {
         iso_minimal = self.nixosConfigurations.installer_minimal.config.system.build.isoImage;

--- a/flash-from-device.nix
+++ b/flash-from-device.nix
@@ -9,7 +9,15 @@ let
     cp ${tegra-eeprom-tool-static}/bin/tegra-boardspec $out/bin
   '';
 in
-writeScriptBin "flash-from-device" (''
+runCommand "flash-from-device" {} ''
+  mkdir -p $out/bin
+
+  cat > $out/bin/flash-from-device <<EOF
   #!${pkgsAarch64.pkgsStatic.busybox}/bin/sh
   export PATH="${lib.makeBinPath [ pkgsAarch64.pkgsStatic.busybox staticDeps ]}:$PATH"
-'' + (builtins.readFile ./flash-from-device.sh))
+  EOF
+  cat ${./flash-from-device.sh} >> $out/bin/flash-from-device
+  substituteInPlace $out/bin/flash-from-device \
+    --replace "ota_helpers_func" "${./ota_helpers.func}"
+  chmod +x $out/bin/flash-from-device
+''

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -7,7 +7,7 @@
   dtbsDir ? null,
 
   # Optional package containing uefi_jetson.efi to replace prebuilt version
-  jetson-firmware ? null,
+  uefi-firmware ? null,
 }:
 ''
   set -euo pipefail
@@ -33,15 +33,15 @@
 
   ${lib.optionalString (partitionTemplate != null) "cp ${partitionTemplate} flash.xml"}
   ${lib.optionalString (dtbsDir != null) "cp -r ${dtbsDir}/. kernel/dtb/"}
-  ${lib.optionalString (jetson-firmware != null) ''
-  cp ${jetson-firmware}/uefi_jetson.bin bootloader/uefi_jetson.bin
+  ${lib.optionalString (uefi-firmware != null) ''
+  cp ${uefi-firmware}/uefi_jetson.bin bootloader/uefi_jetson.bin
 
   # For normal NixOS usage, we'd probably use systemd-boot or GRUB instead,
   # but lets replace the upstream L4TLauncher EFI payload anyway
-  cp ${jetson-firmware}/L4TLauncher.efi bootloader/BOOTAA64.efi
+  cp ${uefi-firmware}/L4TLauncher.efi bootloader/BOOTAA64.efi
 
   # Replace additional dtbos
-  cp ${jetson-firmware}/dtbs/*.dtbo kernel/dtb/
+  cp ${uefi-firmware}/dtbs/*.dtbo kernel/dtb/
   ''}
 
   ${preFlashCommands}

--- a/flash-tools.nix
+++ b/flash-tools.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, makeWrapper, bzip2_1_1, fetchurl, python3, python2, perl, xxd,
   libxml2, coreutils, gnugrep, gnused, gnutar, gawk, which, gzip, cpio,
   bintools-unwrapped, findutils, util-linux, dosfstools, lz4, gcc, dtc,
+  runtimeShell,
 
   bspSrc, l4tVersion,
 }:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -156,7 +156,10 @@ in
       wantedBy = [ "multi-user.target" ];
     };
 
-    environment.systemPackages = with pkgs.nvidia-jetpack; [ l4t-tools ];
+    environment.systemPackages = with pkgs.nvidia-jetpack; [
+      l4t-tools
+      otaUtils # Tools for UEFI capsule updates
+    ];
 
     # Used by libEGL_nvidia.so.0
     environment.etc."egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";

--- a/ota-utils/default.nix
+++ b/ota-utils/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenvNoCC, util-linux, e2fsprogs, tegra-eeprom-tool, l4tVersion }:
+
+stdenvNoCC.mkDerivation {
+  name = "ota-utils";
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    cp ${./ota-setup-efivars.sh} $out/bin/ota-setup-efivars
+    cp ${./ota-apply-capsule-update.sh} $out/bin/ota-apply-capsule-update
+    cp ${./ota-check-firmware.sh} $out/bin/ota-check-firmware
+    cp ${./ota_helpers.func} $out/share/ota_helpers.func
+    chmod +x $out/bin/ota-setup-efivars $out/bin/ota-apply-capsule-update $out/bin/ota-check-firmware
+
+    for fname in ota-setup-efivars ota-apply-capsule-update; do
+      substituteInPlace $out/bin/$fname \
+        --replace "@ota_helpers@" "$out/share/ota_helpers.func"
+      sed -i '2a export PATH=${lib.makeBinPath [ util-linux e2fsprogs tegra-eeprom-tool ]}:$PATH' $out/bin/$fname
+    done
+
+    substituteInPlace $out/bin/ota-check-firmware \
+      --replace "@l4tVersion@" "${l4tVersion}"
+  '';
+}

--- a/ota-utils/ota-apply-capsule-update.sh
+++ b/ota-utils/ota-apply-capsule-update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "@ota_helpers@"
+
+capsuleFile=$1
+
+boardspec=$(tegra-boardspec)
+detect_can_write_runtime_uefi_vars "$boardspec"
+
+# Check for /boot being an ESP. On Xavier AGX, even though the efi vars need to
+# be written to an ESP on the emmc, capsule updates can still be written to an
+# ESP partition at /boot on other devices (e.g. nvme)
+if ! mountpoint -q /boot; then
+    echo "/boot is not mounted"
+    exit 1
+fi
+
+mkdir -p /boot/EFI/UpdateCapsule
+cp "$capsuleFile" /boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+sync /boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+
+set_efi_var OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c "\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00"
+
+echo "UEFI will now attempt an update during the next reboot"

--- a/ota-utils/ota-check-firmware.sh
+++ b/ota-utils/ota-check-firmware.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+FW_VER=$(cat /sys/devices/virtual/dmi/id/bios_version)
+SW_VER=@l4tVersion@
+
+echo "Current firmware version is: ${FW_VER}"
+echo "Current software version is: ${SW_VER}"
+
+if [[ "$FW_VER" != "$SW_VER" ]]; then
+    exit 1
+fi

--- a/ota-utils/ota-setup-efivars.sh
+++ b/ota-utils/ota-setup-efivars.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "@ota_helpers@"
+
+targetBoard=$1
+
+boardspec=$(tegra-boardspec)
+compatspec=$(generate_compat_spec "$boardspec")
+
+detect_can_write_runtime_uefi_vars "$boardspec"
+
+if [[ ! -e /sys/firmware/efi/efivars/TegraPlatformSpec-781e084c-a330-417c-b678-38e696380cb9 ]]; then
+  set_efi_var TegraPlatformSpec-781e084c-a330-417c-b678-38e696380cb9 "\x07\x00\x00\x00${boardspec}-${targetBoard}-"
+fi
+
+if [[ ! -e /sys/firmware/efi/efivars/TegraPlatformCompatSpec-781e084c-a330-417c-b678-38e696380cb9 ]]; then
+    # TODO: We should also replace this value if ours is different
+    set_efi_var TegraPlatformCompatSpec-781e084c-a330-417c-b678-38e696380cb9 "\x07\x00\x00\x00${compatspec}-${targetBoard}-"
+fi

--- a/ota-utils/ota_helpers.func
+++ b/ota-utils/ota_helpers.func
@@ -1,0 +1,120 @@
+# See also: nvidia-l4t-init/opt/nvidia/nv-l4t-bootloader-config.sh
+# and meta-tegra recipes-bsp/tools/setup-nv-boot-control
+
+generate_compat_spec() {
+    local boardspec=$1
+    local boardid=$(echo "$boardspec" | cut -d- -f1)
+    local fab=$(echo "$boardspec" | cut -d- -f2)
+    local boardsku=$(echo "$boardspec" | cut -d- -f3)
+    local boardrev=$(echo "$boardspec" | cut -d- -f4)
+    local fuselevel=$(echo "$boardspec" | cut -d- -f5)
+    local chiprev=$(echo "$boardspec" | cut -d- -f6)
+
+    case "${boardid}" in
+        # Xavier AGX
+        2888)
+            if [[ "${fab}" == "400" ]]; then
+                if [[ "${boardsku}" == "0004" ]]; then
+                    boardrev=""
+                else
+                    if [[ "${boardrev}" == "D.0" ]] || [[ "${boardrev}" < "D.0" ]] ; then
+                        boardrev="D.0"
+                    else
+                        boardrev="E.0"
+                    fi
+                    boardsku="0001"
+                fi
+            elif [[ "${fab}" == "600" ]] && [[ "${boardsku}" == "0008" ]]; then
+                boardrev=""
+            fi
+        ;;
+
+        # Xavier NX
+        3668)
+            if [[ "${fab}" != "301" ]]; then
+                fab="100"
+            fi
+            boardsku=""
+            boardrev=""
+            chiprev=""
+        ;;
+
+        # Orin AGX
+        3701)
+            if [[ "${boardsku}" == "0000" ]] || [[ "${boardsku}" == "0004" ]]; then
+                if [[ "${fab}" == "000" ]] || [[ "${fab}" == "TS"* ]] || [[ "${fab}" == "EB"* ]] || [[ ($((fab)) -gt 0 && $((fab)) -lt 300) ]]; then
+                    fab="000"
+                else
+                    fab="300"
+                fi
+            fi
+            if [[ "${boardsku}" == "0005" ]]; then
+                fab=""
+            fi
+            boardrev=""
+            chiprev=""
+        ;;
+
+        # Orin NX/Nano
+        3767)
+            if [[ "${boardsku}" == "0000" ]] || [[ "${boardsku}" == "0002" ]]; then
+                if [[ "${fab}" != "TS"* ]] && [[ "${fab}" != "EB"* ]]; then
+                    fab="000"
+                fi
+            else
+                fab=""
+            fi
+            boardrev=""
+            chiprev=""
+        ;;
+
+        *)
+            echo "Unknown boardid: ${boardid}"
+            exit 1
+    esac
+
+    echo "$boardid-$fab-$boardsku-$boardrev-$fuselevel-$chiprev"
+}
+
+noRuntimeUefiWrites=
+espDir=
+detect_can_write_runtime_uefi_vars() {
+    local boardspec=$1
+
+    # All AGX Xaviers except industrial variants have firmware on emmc instead of qspi
+    boardid=$(echo "$boardspec" | cut -d- -f1)
+    boardsku=$(echo "$boardspec" | cut -d- -f3)
+    noRuntimeUefiWrites=
+    if [[ "$boardid" == "2888" ]] && [[ "$boardsku" != "0008" ]]; then
+        noRuntimeUefiWrites=true
+        espDir=/opt/nvidia/esp
+    else
+        espDir=/boot
+    fi
+}
+
+# Call detect_can_write_runtime_uefi_vars before running this
+set_efi_var() {
+    local name=$1
+    local value=$2
+
+    local filepath
+
+    if [[ -n "$noRuntimeUefiWrites" ]]; then
+        if ! mountpoint -q "$espDir"; then
+            echo "$espDir is not mounted"
+            exit 1
+        fi
+
+        mkdir -p "$espDir"/EFI/NVDA/Variables
+        filepath="$espDir"/EFI/NVDA/Variables/"$name"
+    else
+        filepath=/sys/firmware/efi/efivars/"$name"
+
+        if [[ -e "$filepath" ]]; then
+            chattr -i "$filepath"
+        fi
+    fi
+
+    printf "$value" > $filepath
+}


### PR DESCRIPTION
###### Description of changes

To determine if the currently running firmware matches the software, run, `ota-check-firmware`:
```
$ ota-check-firmware
Current firmware version is: 35.2.1
Current software version is: 35.2.1
```

If these versions do not match, you can update your firmware using the UEFI Capsule update mechanism. The procedure to do so is below:

To build a capsule update file, build the
`config.system.build.devicePkgs.uefiCapsuleUpdate` attribute from your NixOS build. For the standard devkit configurations supported in this repository, one could also run (for example),
`nix build .#uefi-capsule-update-xavier-nx-emmc-devkit`. Unfortunately, due to some limitations from nvidia's scripts, this build needs to happen on an `x86_64-linux` machine. This will produce a file that you can scp (no need for `nix copy`) to the device to update.

Once the file is on the device, run:
```
$ sudo ota-apply-capsule-update example.Cap
$ sudo reboot
```
(Assuming `example.Cap` is the file you copied to the device.) While the device is rebooting, do not disconnect power.  You should be able to see a progress bar while the update is being applied. The capsule update works by updating the non-current slot A/B firmware partitions, and then rebooting into the new slot. So, if the new firmware does not boot up to UEFI, it should theoretically rollback to the original firmware.

###### Testing

UEFI capsule updates have been tested working on:
- [ ] orin-agx-devkit
- [x] orin-nx-devkit
- [x] xavier-agx-devkit
- [x] xavier-nx-emmc-devkit

For an unknown reason, this currently does _not_ work on the xavier-nx-devkit (the non-production module with an SD card instead of eMMC).

Closes #36 