### PR TITLE
Add configFileName option. Default to targetBoard

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -48,6 +48,12 @@ in
           description = "Target board to use when flashing (should match .conf in BSP package)";
         };
 
+        configFileName = mkOption {
+          type = types.str;
+          default = cfg.flashScriptOverrides.targetBoard;
+          description = "Name of configuration file to use when flashing (excluding .conf suffix).  Defaults to targetBoard";
+        };
+
         flashArgs = mkOption {
           type = types.listOf types.str;
           description = "Arguments to apply to flashing script";
@@ -91,7 +97,7 @@ in
     hardware.nvidia-jetpack.devicePkgs = devicePkgs; # Left for backwards-compatibility
     system.build.jetsonDevicePkgs = devicePkgs;
 
-    hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = lib.mkAfter [ cfg.flashScriptOverrides.targetBoard "mmcblk0p1" ];
+    hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = lib.mkAfter [ cfg.flashScriptOverrides.configFileName "mmcblk0p1" ];
 
     hardware.nvidia-jetpack.bootloader.edk2NvidiaPatches = [
       # Have UEFI use the device tree compiled into the firmware, instead of


### PR DESCRIPTION
###### Description of changes

On some BSPs, the config filename does not match the target_board string that should ultimately make it into the boardspec string. So, we'll add a new option that defaults to targetBoard which can be overridden on for those BSPs.


###### Testing

Tested on a vendor's carrier board that requires this.