### PR TITLE
Add fix to EDK2 TnSpec handling

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -105,9 +105,12 @@ in
       # See: https://github.com/anduril/jetpack-nixos/pull/18
       ../edk2-uefi-dtb.patch
 
-      # TODO: Add TnSpec null-terminated string fix
-#      (pkgs.fetchpatch {
-#        url = "
+      # Ensure termination of TnSpec variables
+      # https://github.com/NVIDIA/edk2-nvidia/pull/37
+      (pkgs.fetchpatch {
+        url = "https://github.com/NVIDIA/edk2-nvidia/commit/df0ff1aff5ecd9f343ce5409234c9ef071124d44.patch";
+        sha256 = "sha256-8J+Ip1n7np+VWtdeA0RoKHT3fdo8rsDxKXGkVSROnvA=";
+      })
     ];
 
     systemd.services = lib.mkIf (cfg.flashScriptOverrides.targetBoard != null) {


### PR DESCRIPTION
###### Description of changes

Add patch to fix the way edk2 handles TnSpec strings, which need to be zero-terminated

###### Testing

Just building edk2
