### PR TITLE
Use write shell applications for flashing scripts

### DIFF
--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, runCommand, writeScript, writeShellScriptBin, makeInitrd, makeModulesClosure,
+{ lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
   flashFromDevice, edk2-jetson, uefi-firmware, flash-tools,
   python3, bspSrc, openssl,
   l4tVersion,
@@ -65,7 +65,10 @@ let
   } // args);
 
   # Generate a flash script using the built configuration options set in a NixOS configuration
-  flashScript = writeShellScriptBin "flash-${hostName}" (mkFlashScript {});
+  flashScript = writeShellApplication {
+    name = "flash-${hostName}";
+    text = (mkFlashScript {});
+  };
 
   # TODO: The flash script should not have the kernel output in its runtime closure
   initrdFlashScript = let
@@ -106,21 +109,24 @@ let
         { object = "${modulesClosure}/lib/firmware"; symlink = "/lib/firmware"; }
       ];
     };
-  in writeShellScriptBin "initrd-flash-${hostName}" (mkFlashScript {
-    preFlashCommands = ''
-      cp ${config.boot.kernelPackages.kernel}/Image kernel/Image
-      cp ${initrd}/initrd bootloader/l4t_initrd.img
+  in writeShellApplication {
+    name = "initrd-flash-${hostName}";
+    text = mkFlashScript {
+      preFlashCommands = ''
+        cp ${config.boot.kernelPackages.kernel}/Image kernel/Image
+        cp ${initrd}/initrd bootloader/l4t_initrd.img
 
-      export CMDLINE="initrd=initrd console=ttyTCU0,115200"
-      export INITRD_IN_BOOTIMG="yes"
-    '';
-    flashArgs = [ "--rcm-boot" ] ++ cfg.flashScriptOverrides.flashArgs;
-    postFlashCommands = ''
-      echo
-      echo "Jetson device should now be flashing and will reboot when complete."
-      echo "You may watch the progress of this on the device's serial port"
-    '';
-  });
+        export CMDLINE="initrd=initrd console=ttyTCU0,115200"
+        export INITRD_IN_BOOTIMG="yes"
+      '';
+      flashArgs = [ "--rcm-boot" ] ++ cfg.flashScriptOverrides.flashArgs;
+      postFlashCommands = ''
+        echo
+        echo "Jetson device should now be flashing and will reboot when complete."
+        echo "You may watch the progress of this on the device's serial port"
+      '';
+    };
+  };
 
   # This must be built on x86_64-linux
   signedFirmware = runCommand "signed-${hostName}-${l4tVersion}" {} (mkFlashScript {

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -51,7 +51,7 @@
 '' + (if (flashCommands != "") then ''
   ${flashCommands}
 '' else ''
-  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} $@ ${builtins.toString flashArgs}
+  ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} "$@" ${builtins.toString flashArgs}
 '') + ''
   ${postFlashCommands}
 ''


### PR DESCRIPTION
###### Description of changes
Use `writeShellApplications` instead of `writeShellScriptBin` to get shellcheck automatically and also to make it work nicely with `nix run`

###### Testing
Nix build works fine and flash script for an Orin NX runs without errors.
