### PR TITLE
Add mountFirmwareEsp setting

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -61,6 +61,13 @@ in
         type = types.bool;
         description = "Enable PREEMPT_RT patches";
       };
+
+      mountFirmwareEsp = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Whether to mount the ESP partition on eMMC under /opt/nvidia/esp on Xavier AGX platforms. Needed for capsule updates";
+        internal = true;
+      };
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Allows the user of this module to disable this functionality. Why do we need this instead of just using option priority? If the user sets fileSystems.* at a mkDefault level, then setting
fileSystems."/opt/nvidia/esp" at any level would override all other fileSystems, including "/".

###### Testing

Eval only