### PR TITLE
Re-enable VPI2 test

### DIFF
--- a/samples.nix
+++ b/samples.nix
@@ -366,12 +366,12 @@ let
       echo "Running Multimedia test"
       echo "====="
       ${multimedia-test}/bin/multimedia-test
+
+      echo "====="
+      echo "Running VPI2 test"
+      echo "====="
+      ${vpi2-test}/bin/vpi2-test
     '';
-    # Disabling VPI2 test until its working on JP5.1 again....
-      #echo "====="
-      #echo "Running VPI2 test"
-      #echo "====="
-      #${vpi2-test}/bin/vpi2-test
   };
 in {
   inherit


### PR DESCRIPTION

###### Description of changes

This now appears to be working on Jetpack 5.1.1. Release notes for Jetpack 5.1.1 say it includes VPI2 fixes.

Closes #44

###### Testing

Tested on a Xavier AGX
