### PR TITLE
Automatic Firmware updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Current software version is: 35.2.1
 If these versions do not match, you can update your firmware using the UEFI Capsule update mechanism. The procedure to do so is below:
 
 To build a capsule update file, build the
-`config.system.build.devicePkgs.uefiCapsuleUpdate` attribute from your NixOS build. For the standard devkit configurations supported in this repository, one could also run (for example),
-`nix build .#uefi-capsule-update-xavier-nx-emmc-devkit`. Unfortunately, due to some limitations from nvidia's scripts, this build needs to happen on an `x86_64-linux` machine. This will produce a file that you can scp (no need for `nix copy`) to the device to update.
+`config.system.build.jetsonDevicePkgs.uefiCapsuleUpdate` attribute from your NixOS build. For the standard devkit configurations supported in this repository, one could also run (for example),
+`nix build .#uefi-capsule-update-xavier-nx-emmc-devkit`. This will produce a file that you can scp (no need for `nix copy`) to the device to update.
 
 Once the file is on the device, run:
 ```

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ You may need to enter the firmware menu and reorder it manually so NixOS will bo
 
 ### Updating firmware from device
 
-Recent versions of Jetpack (>=5.1) support updating the device firmware from
-the device using the UEFI Capsule update mechanism.
+Recent versions of Jetpack (>=5.1) support updating the device firmware from the device using the UEFI Capsule update mechanism.
 This can be done as a more convenient alternative to physically attaching to the device and re-running the flash script.
+These updates can be performed automatically after a `nixos-rebuild boot` if the `hardware.nvidia-jetpack.bootloader.autoUpdate` setting is set to true and systemd-boot is used.
+Otherwise, the instructions to apply the update manually are below.
 
 To determine if the currently running firmware matches the software, run, `ota-check-firmware`:
 ```

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -88,10 +88,7 @@ in
   };
 
   config = let
-    # Totally ugly reimport of nixpkgs so we can get a native x86 version. This
-    # is probably not the right way to do it, since overlays wouldn't get
-    # applied in the new import of nixpkgs.
-    devicePkgs = ((import pkgs.path { system = "x86_64-linux"; }).callPackage ../default.nix {}).devicePkgsFromNixosConfig config;
+    devicePkgs = pkgs.nvidia-jetpack.devicePkgsFromNixosConfig config;
   in {
     hardware.nvidia-jetpack.flashScript = devicePkgs.flashScript; # Left for backwards-compatibility
     hardware.nvidia-jetpack.devicePkgs = devicePkgs; # Left for backwards-compatibility

--- a/ota-utils/ota-apply-capsule-update.sh
+++ b/ota-utils/ota-apply-capsule-update.sh
@@ -22,4 +22,6 @@ sync /boot/EFI/UpdateCapsule/TEGRA_BL.Cap
 
 set_efi_var OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c "\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00"
 
-echo "UEFI will now attempt an update during the next reboot"
+echo "New Jetson firmware will be applied during the next reboot."
+echo "The next reboot may take an extra 5 minutes or so."
+echo "Do not disconnect power during the reboot, or the firmware upgrade will not be applied"


### PR DESCRIPTION
###### Description of changes

Add option to enable automatically applying firmware updates after `nixos-rebuild boot/switch` using the UEFI Capsule update mechanism.
To enable, set  `hardware.nvidia-jetpack.bootloader.autoUpdate = true;` and use systemd-boot as your bootloader.   (This could potentially work with other bootloaders, but systemd-boot provides `extraInstallCommands` we use)

###### Testing

Tested working on Xavier AGX devkit