### PR TITLE
Add Orin Nano

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -90,6 +90,7 @@ let
   }) [
     { som = "orin-agx"; carrierBoard = "devkit"; }
     { som = "orin-nx"; carrierBoard = "devkit"; }
+    { som = "orin-nano"; carrierBoard = "devkit"; }
     { som = "xavier-agx"; carrierBoard = "devkit"; }
     { som = "xavier-nx"; carrierBoard = "devkit"; }
     { som = "xavier-nx-emmc"; carrierBoard = "devkit"; }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -46,7 +46,7 @@ in
         # You can add your own som or carrierBoard by merging the enum type
         # with additional possibilies in an external NixOS module. See:
         # "Extensible option types" in the NixOS manual
-        type = types.nullOr (types.enum [ "orin-agx" "orin-nx" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ]);
+        type = types.nullOr (types.enum [ "orin-agx" "orin-nx" "orin-nano" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ]);
         description = "Jetson SoM (System-on-Module) to target. Can be null to target a generic jetson device, but some things may not work.";
       };
 

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -10,19 +10,21 @@ let
   cfg = config.hardware.nvidia-jetpack;
 
   nvpModelConf = {
-    "orin-agx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3701_0000.conf";
-    "orin-nx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3767_0000.conf";
-    "xavier-agx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194.conf";
-    "xavier-nx" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
-    "xavier-nx-emmc" = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
+    orin-agx = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3701_0000.conf";
+    orin-nx = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3767_0000.conf";
+    orin-nano = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_p3767_0000.conf";
+    xavier-agx = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194.conf";
+    xavier-nx = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
+    xavier-nx-emmc = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
   };
 
-  nvfancontrolConf = {
-    "orin-agx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3701_0000.conf";
-    "orin-nx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
-    "xavier-agx" = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p2888.conf";
-    "xavier-nx" ="${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
-    "xavier-nx-emmc" ="${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
+  nvfancontrolConf = rec {
+    orin-agx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3701_0000.conf";
+    orin-nx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
+    orin-nano = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
+    xavier-agx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p2888.conf";
+    xavier-nx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
+    xavier-nx-emmc ="${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3668.conf";
   };
 in lib.mkMerge [{
   # Turn on nvpmodel if we have a config for it.
@@ -60,16 +62,14 @@ in lib.mkMerge [{
       targetBoard = mkDefault "jetson-agx-orin-devkit";
       # We don't flash the sdmmc with kernel/initrd/etc at all. Just let it be a
       # regular NixOS machine instead of having some weird partition structure.
-      partitionTemplate = mkDefault (pkgs.runCommand "flash.xml" { nativeBuildInputs = [ pkgs.buildPackages.xmlstarlet ]; } ''
-        xmlstarlet ed -d '//device[@type="sdmmc_user"]' \
-          ${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi_sdmmc.xml \
-          >$out
-      '');
+      partitionTemplate = mkDefault "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi.xml";
     })
 
-    (mkIf (cfg.som == "orin-nx") {
-      targetBoard = mkDefault "p3509-a02+p3767-0000";
-      partitionTemplate = mkDefault (filterPartitions defaultPartitionsToRemove "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi.xml");
+    (mkIf (cfg.som == "orin-nx" || cfg.som == "orin-nano") {
+      targetBoard = mkDefault "jetson-orin-nano-devkit";
+      # Use this instead if you want to use the original Xavier NX Devkit module (p3509-a02)
+      #targetBoard = mkDefault "p3509-a02+p3767-0000";
+      partitionTemplate = mkDefault "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi.xml";
     })
 
     (mkIf (cfg.som == "xavier-agx") {


### PR DESCRIPTION
###### Description of changes

This adds support for the "Orin Nano".  At least from the flashing scripts perspective, it is basically the same as an Orin NX.  (Or rather, an Orin NX is the same as an Orin Nano).

Closes #76 

###### Testing

Tested by booting on an Orin Nano + devkit
