### PR TITLE
Add fixes for firmware signing

### DIFF
--- a/flash-tools-secureboot.patch
+++ b/flash-tools-secureboot.patch
@@ -1,0 +1,110 @@
+diff -u a/bootloader/tegrasign_v3_internal.py b/bootloader/tegrasign_v3_internal.py
+--- a/bootloader/tegrasign_v3_internal.py	1969-12-31 16:00:01.000000000 -0800
++++ b/bootloader/tegrasign_v3_internal.py	2023-03-29 12:24:24.000000000 -0700
+@@ -1115,7 +1115,6 @@
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     # Derive the key relationship: dk -> kdk -> *_dec_kdk
+     dk_params = params['DK'][dk]
+@@ -1166,21 +1165,12 @@
+         bl_dec_kdk_ctx['Msg'] = None
+         fw_dec_kdk_ctx['Msg'] = None
+ 
+-    dec_kdk_params = params['DEC_KDK'][kdk_to_use]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        'Label' : dec_kdk_params['Label'],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+ 
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.FLAG):
+         kdf_list.pop()
+ 
+-    return ([dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], dec_kdk_ctx["Msg"],
++    return ([None, None,
+             bl_dec_kdk_ctx["Msg"], kdk_ctx["Msg"], dk_ctx["Msg"]])
+ 
+ def do_kdf(params_slist, kdf_list):
+@@ -1260,7 +1250,6 @@
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     dk_params = params['DK'][dk]
+     dk_ctx = {
+@@ -1355,20 +1344,8 @@
+         count = count - 1
+ 
+     aes_params = params['AES'][kdk_to_use]
+-    aes_iv = manifest_xor_offset(basic_params[aes_params['IV']], aes_params["Offset"])
+-    aes_aad = aes_params['Manifest'] + AAD_0_96
+     aes_tag = bytes(16)
+ 
+-    dec_kdk_params = params['DEC_KDK'][aes_params['KDK']]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        "Label" : dec_kdk_params["Label"],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+-
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.DKSTR):
+         kdf_list.pop()
+@@ -1381,7 +1358,7 @@
+             if extract_AES_key(key_buf, p_key):
+                 sbk_keystr = hex_to_str(p_key.key.aeskey)
+ 
+-    return [dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], aes_iv,  aes_aad, sbk_keystr, dec_kdk_ctx['Msg'],
++    return [None, None, None, sbk_keystr, None,
+             bl_kdk_ctx['Msg'], tz_kdk_ctx['Msg'], gp_kdk_ctx['Msg'], gpto_kdk_ctx['Msg'],  kdk_ctx['Msg'], dk_ctx['Msg']]
+ 
+ def do_kdf_params_oem(dk, params, kdf_list, p_key):
+@@ -1389,7 +1366,6 @@
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     dk_params = params['DK'][dk]
+     dk_ctx = {
+@@ -1488,20 +1464,8 @@
+         count = count - 1
+ 
+     aes_params = params['AES'][kdk_to_use]
+-    aes_iv = manifest_xor_offset(basic_params[aes_params['IV']], aes_params["Offset"])
+-    aes_aad = aes_params['Manifest'] + AAD_0_96
+     aes_tag = bytes(16)
+ 
+-    dec_kdk_params = params['DEC_KDK'][aes_params['KDK']]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        "Label" : dec_kdk_params["Label"],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+-
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.DKSTR):
+         kdf_list.pop()
+@@ -1514,7 +1478,7 @@
+             if extract_AES_key(key_buf, p_key):
+                 sbk_keystr = hex_to_str(p_key.key.aeskey)
+ 
+-    return [dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], aes_iv,  aes_aad, sbk_keystr, dec_kdk_ctx['Msg'],
++    return [None, None, None, sbk_keystr, None,
+             bl_kdk_ctx['Msg'], tz_kdk_ctx['Msg'], gp_kdk_ctx['Msg'], gpto_kdk_ctx['Msg'],  kdk_ctx['Msg'], dk_ctx['Msg']]
+ 
+ # calls for offset, then enc, then do sha and returns

--- a/flash-tools.patch
+++ b/flash-tools.patch
@@ -9,6 +9,18 @@ diff -Naur bsp-5.1.1/bootloader/l4t_bup_gen.func bsp-5.1.1-new/bootloader/l4t_bu
  
  PART_NAME=""
  IMAGE_SIGNED=0
+diff -Naur bsp-5.1.1/bootloader/tegraflash_impl_t234.py bsp-5.1.1-new/bootloader/tegraflash_impl_t234.py
+--- bsp-5.1.1/bootloader/tegraflash_impl_t234.py	1969-12-31 16:00:01.000000000 -0800
++++ bsp-5.1.1-new/bootloader/tegraflash_impl_t234.py	2023-05-08 10:58:50.257272841 -0700
+@@ -1853,7 +1853,7 @@
+             xml_tree = ElementTree.parse(file)
+             mode = xml_tree.getroot().get('mode')
+ 
+-            for file_nodes in xml_tree.getiterator('file'):
++            for file_nodes in xml_tree.iter('file'):
+                 filename = file_nodes.get('name')
+                 if 'dce' in filename:
+                     continue
 diff -Naur bsp-5.1.1/flash.sh bsp-5.1.1-new/flash.sh
 --- bsp-5.1.1/flash.sh	1969-12-31 16:00:01.000000000 -0800
 +++ bsp-5.1.1-new/flash.sh	2023-04-27 15:36:47.766684941 -0700


### PR DESCRIPTION
###### Description of changes

These fixes appear to be necessary to use the flashing script with firmware signing keys.

###### Testing

Tested by flashing an Orin Nano with `-u <pkc.pem>` cmdline option.