### PR TITLE
Patch efitools to write to eMMC FAT partition

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -118,5 +118,15 @@ in lib.mkMerge [{
     autoFormat = true;
     formatOptions = "-F 32 -n ESP";
   };
+
+  systemd.tmpfiles.rules = [ "d /opt/nvidia/esp/EFI/NVDA/Variables 0755 root root -" ];
+
+  nixpkgs.overlays = [
+    (final: prev: {
+      efitools = prev.efitools.overrideAttrs (old: {
+        patches = (old.patches or []) ++ [ ./efitools-nvidia-ro-efivars.patch ];
+      });
+    })
+  ];
 })
 ]

--- a/modules/efitools-nvidia-ro-efivars.patch
+++ b/modules/efitools-nvidia-ro-efivars.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/kernel_efivars.c b/lib/kernel_efivars.c
+index 630088b..b19a9bf 100644
+--- a/lib/kernel_efivars.c
++++ b/lib/kernel_efivars.c
+@@ -165,7 +165,7 @@ set_variable(const char *var, EFI_GUID *guid, uint32_t attributes,
+ 		*newbuf = malloc(size + sizeof(attributes));
+ 	int fd;
+ 
+-	snprintf(varfs, varfs_len, "%s/%s-%s", kernel_efi_path,
++	snprintf(varfs, varfs_len, "/opt/nvidia/esp/EFI/NVDA/Variables/%s-%s",
+ 		 var, guid_to_str(guid));
+ 	fd = open(varfs, O_RDWR|O_CREAT|O_TRUNC, 0644);
+ 	free(varfs);

--- a/uefi-firmware.nix
+++ b/uefi-firmware.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPackages, fetchFromGitHub, runCommand, edk2, acpica-tools,
-  dtc, python3, bc, imagemagick, applyPatches, nukeReferences,
+  dtc, python3, bc, util-linux, imagemagick, applyPatches, nukeReferences,
   l4tVersion,
 
   # Optional path to a boot logo that will be converted and cropped into the format required
@@ -105,7 +105,7 @@ let
       src = edk2-src;
 
       depsBuildBuild = [ buildPackages.stdenv.cc ];
-      nativeBuildInputs = [ bc pythonEnv acpica-tools dtc ];
+      nativeBuildInputs = [ bc pythonEnv acpica-tools dtc util-linux ];
       strictDeps = true;
 
       NIX_CFLAGS_COMPILE = [ "-Wno-error=format-security" ];


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

For the xavier agx where efivars is mounted read-only and EFI variable
modifications must happen through an eMMC FAT partition, use a patched
efitools so that writes from the `efi-updatevar` utility are written to
the correct location.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
Manually tested `efi-updatevar` with the patch applied on an xavier-agx devkit