### PR TITLE
Run ota-setup-efivars as part of bootloader.autoUpdate

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -116,7 +116,7 @@ in
       };
     };
 
-    boot.loader.systemd-boot.extraInstallCommands = lib.mkIf (cfg.bootloader.autoUpdate && cfg.som != null) ''
+    boot.loader.systemd-boot.extraInstallCommands = lib.mkIf (cfg.bootloader.autoUpdate && cfg.som != null && cfg.flashScriptOverrides.targetBoard != null) ''
       # Jetpack 5.0 didn't expose this DMI variable,
       if [[ ! -f /sys/devices/virtual/dmi/id/bios_version ]]; then
         echo "Unable to determine current Jetson firmware version."
@@ -129,6 +129,13 @@ in
           echo "Current Jetson firmware version is: $CUR_VER"
           echo "New Jetson firmware version is: $NEW_VER"
           echo
+
+          # Set efi vars here as well as in systemd service, in case we're
+          # upgrading from an older nixos generation that doesn't have the
+          # systemd service. Plus, this ota-setup-efivars will be from the
+          # generation we're switching to, which can contain additional
+          # fixes/improvements.
+          ${pkgs.nvidia-jetpack.otaUtils}/bin/ota-setup-efivars ${cfg.flashScriptOverrides.targetBoard}
 
           ${pkgs.nvidia-jetpack.otaUtils}/bin/ota-apply-capsule-update ${config.system.build.jetsonDevicePkgs.uefiCapsuleUpdate}
         fi

--- a/ota-utils/ota_helpers.func
+++ b/ota-utils/ota_helpers.func
@@ -102,7 +102,7 @@ set_efi_var() {
 
     if [[ -n "$noRuntimeUefiWrites" ]]; then
         if ! mountpoint -q "$espDir"; then
-            echo "$espDir is not mounted"
+            echo "$espDir is not mounted. Unable to set EFI variable."
             exit 1
         fi
 


### PR DESCRIPTION
###### Description of changes

Set OTA relavent EFI variagbles if doing bootloader autoUpdate, so previous generations that don't yet have the systemd service can update.

###### Testing

Tested on a Xavier AGX