### PR TITLE
Initial work on secureboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository packages components from NVIDIA's [Jetpack SDK](https://developer.nvidia.com/embedded/jetpack) for use with NixOS, including:
  * Platform firmware flashing scripts
- * A 5.10 Linux kernel from NVIDIA, which includes some open-source drivers like nvgpu (built from source)
- * An [EDK2-based UEFI firmware](https://github.com/NVIDIA/edk2-nvidia) (built from source)
- * ARM Trusted Firmware / OP-TEE (could be built from source, but not yet implemented)
+ * A 5.10 Linux kernel from NVIDIA, which includes some open-source drivers like nvgpu
+ * An [EDK2-based UEFI firmware](https://github.com/NVIDIA/edk2-nvidia)
+ * ARM Trusted Firmware / OP-TEE
  * Additional packages for:
    - GPU computing: CUDA, CuDNN, TensorRT
    - Multimedia: hardware accelerated encoding/decoding with V4L2 and gstreamer plugins

--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
     edk2-jetson uefi-firmware;
 
   inherit (pkgsAarch64.callPackages ./optee.nix {
-    inherit l4tVersion bspSrc;
+    inherit bspSrc l4tVersion;
   }) buildTOS opteeClient;
 
   flash-tools = callPackage ./flash-tools.nix {

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { callPackage, callPackages, stdenv, stdenvNoCC, lib, runCommand, fetchurl,
-  bzip2_1_1, dpkg,  pkgs, dtc, python3, runtimeShell,
+  bzip2_1_1, dpkg,  pkgs, dtc, python3, runtimeShell, writeShellApplication
 }:
 
 let
@@ -147,17 +147,20 @@ in rec {
 
   devicePkgs = lib.mapAttrs (n: c: devicePkgsFromNixosConfig (pkgs.nixos c).config) supportedNixOSConfigurations;
 
-  flash-generic = callPackage ./flash-script.nix {
-    inherit flash-tools uefi-firmware;
-    flashCommands = ''
-      ${runtimeShell}
-    '';
-    # Use cross-compiled machine here so we don't have to depend on aarch64 builders
-    # TODO: Do a smaller cross-compiled version from old jetpack dir
-    dtbsDir = (pkgsAarch64.nixos {
-      imports = [ ./modules/default.nix ];
-      hardware.nvidia-jetpack.enable = true;
-    }).config.hardware.deviceTree.package;
+  flash-generic = writeShellApplication {
+    name = "flash-generic";
+    text = callPackage ./flash-script.nix {
+      inherit flash-tools uefi-firmware;
+      flashCommands = ''
+        ${runtimeShell}
+      '';
+      # Use cross-compiled machine here so we don't have to depend on aarch64 builders
+      # TODO: Do a smaller cross-compiled version from old jetpack dir
+      dtbsDir = (pkgsAarch64.nixos {
+        imports = [ ./modules/default.nix ];
+        hardware.nvidia-jetpack.enable = true;
+      }).config.hardware.deviceTree.package;
+    };
   };
 
   flashScripts = lib.mapAttrs' (n: c: lib.nameValuePair "flash-${n}" c.flashScript) devicePkgs;

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -44,8 +44,8 @@ let
   cfg = config.hardware.nvidia-jetpack;
   hostName = config.networking.hostName;
 
-  socType =
-    if lib.hasPrefix "orin-" cfg.som then "t234"
+  socType = if cfg.som == null then null
+    else if lib.hasPrefix "orin-" cfg.som then "t234"
     else if lib.hasPrefix "xavier-" cfg.som then "t194"
     else throw "Unknown SoC type";
 
@@ -70,6 +70,8 @@ let
       errorLevelInfo = cfg.firmware.uefi.errorLevelInfo;
       edk2NvidiaPatches = cfg.firmware.uefi.edk2NvidiaPatches;
     };
+
+    inherit socType;
 
     inherit tosImage;
 

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -8,39 +8,6 @@
 config:
 
 let
-  # These are from l4t_generate_soc_bup.sh, plus some additional ones found in the wild.
-  variants = rec {
-    xavier-agx = [
-      { boardid="2888"; boardsku="0001"; fab="400"; boardrev="D.0"; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="2888"; boardsku="0001"; fab="400"; boardrev="E.0"; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="2888"; boardsku="0004"; fab="400"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="2888"; boardsku="0005"; fab="402"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-    ];
-    xavier-nx = [ # Dev variant
-      { boardid="3668"; boardsku="0000"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0000"; fab="301"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-    ];
-    xavier-nx-emmc = [ # Prod variant
-      { boardid="3668"; boardsku="0001"; fab="100"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-      { boardid="3668"; boardsku="0003"; fab="301"; boardrev=""; fuselevel="fuselevel_production"; chiprev="2"; }
-    ];
-
-    orin-agx = [
-      { boardid="3701"; boardsku="0000"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; }
-      { boardid="3701"; boardsku="0004"; fab="300"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 32GB
-      { boardid="3701"; boardsku="0005"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # 64GB
-    ];
-
-    orin-nano = [
-      { boardid = "3767"; boardsku = "0000"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin NX 16GB
-      { boardid = "3767"; boardsku = "0001"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin NX 8GB
-      { boardid = "3767"; boardsku = "0003"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin Nano 8GB
-      { boardid = "3767"; boardsku = "0005"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } #
-      { boardid = "3767"; boardsku = "0004"; fab="000"; boardrev=""; fuselevel="fuselevel_production"; chiprev=""; } # Orin Nano 4GB
-    ];
-    orin-nx = orin-nano;
-  };
-
   cfg = config.hardware.nvidia-jetpack;
   hostName = config.networking.hostName;
 
@@ -170,7 +137,7 @@ let
       done < bootloader/signed/flash.idx
 
       rm -rf bootloader/signed
-    '') variants.${cfg.som};
+    '') cfg.firmware.variants;
   });
 
   # Bootloader Update Package (BUP)
@@ -181,7 +148,7 @@ let
     flashCommands = let
     in lib.concatMapStringsSep "\n" (v: with v;
       "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString flashArgs}"
-    ) variants.${cfg.som};
+    ) cfg.firmware.variants;
   }) + ''
     mkdir -p $out
     cp -r bootloader/payloads_*/* $out/

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -55,6 +55,7 @@ let
   tosImage = buildTOS {
     inherit socType;
     opteePatches = cfg.firmware.optee.patches;
+    extraMakeFlags = cfg.firmware.optee.extraMakeFlags;
   };
 
   mkFlashScript = args: import ./flash-script.nix ({

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -52,7 +52,10 @@ let
   inherit (cfg.flashScriptOverrides)
     flashArgs partitionTemplate;
 
-  tosImage = buildTOS { inherit socType; };
+  tosImage = buildTOS {
+    inherit socType;
+    opteePatches = cfg.firmware.optee.patches;
+  };
 
   mkFlashScript = args: import ./flash-script.nix ({
     inherit lib flashArgs partitionTemplate;

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -62,10 +62,10 @@ let
     });
 
     uefi-firmware = uefi-firmware.override {
-      bootLogo = cfg.bootloader.logo;
-      debugMode = cfg.bootloader.debugMode;
-      errorLevelInfo = cfg.bootloader.errorLevelInfo;
-      edk2NvidiaPatches = cfg.bootloader.edk2NvidiaPatches;
+      bootLogo = cfg.firmware.uefi.logo;
+      debugMode = cfg.firmware.uefi.debugMode;
+      errorLevelInfo = cfg.firmware.uefi.errorLevelInfo;
+      edk2NvidiaPatches = cfg.firmware.uefi.edk2NvidiaPatches;
     };
 
     inherit tosImage;

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -75,6 +75,7 @@ let
     inherit socType;
 
     inherit tosImage;
+    eksFile = cfg.firmware.eksFile;
 
     dtbsDir = config.hardware.deviceTree.package;
   } // args);

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -13,6 +13,9 @@
 
   # Optional package containing tos.img to replace prebuilt version
   tosImage ? null,
+
+  # Optional EKS file containing encrypted keyblob
+  eksFile ? null,
 }:
 ''
   set -euo pipefail
@@ -50,6 +53,9 @@
   ''}
   ${lib.optionalString (tosImage != null) ''
   cp ${tosImage}/tos.img bootloader/tos-optee_${socType}.img
+  ''}
+  ${lib.optionalString (eksFile != null) ''
+  cp ${eksFile} bootloader/eks_${socType}.img
   ''}
 
   ${preFlashCommands}

--- a/flash-script.nix
+++ b/flash-script.nix
@@ -2,6 +2,8 @@
 
   preFlashCommands ? "", flashCommands ? "", postFlashCommands ? "", flashArgs ? [], partitionTemplate ? null,
 
+  socType ? null,
+
   # Optional directory containing DTBs to be used by flashing script, which can
   # be used by the bootloader(s) and passed to the kernel.
   dtbsDir ? null,
@@ -47,7 +49,7 @@
   cp ${uefi-firmware}/dtbs/*.dtbo kernel/dtb/
   ''}
   ${lib.optionalString (tosImage != null) ''
-  cp ${tosImage}/tos.img bootloader/tos-optee_${tosImage.socType}.img
+  cp ${tosImage}/tos.img bootloader/tos-optee_${socType}.img
   ''}
 
   ${preFlashCommands}

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -57,6 +57,11 @@ in
             type = types.listOf types.path;
             default = [];
           };
+
+          extraMakeFlags = mkOption {
+            type = types.listOf types.str;
+            default = [];
+          };
         };
       };
 

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -63,6 +63,11 @@ in
             default = [];
           };
         };
+
+        eksFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+        };
       };
 
       flashScriptOverrides = {

--- a/optee.nix
+++ b/optee.nix
@@ -197,7 +197,7 @@ let
       image = buildPackages.runCommand "tos.img"
         {
           nativeBuildInputs = [ nukeReferences ];
-          passthru = { inherit socType nvLuksSrv hwKeyAgent; };
+          passthru = { inherit nvLuksSrv hwKeyAgent; };
         } ''
         mkdir -p $out
         ${buildPackages.python3}/bin/python3 ${bspSrc}/nv_tegra/tos-scripts/gen_tos_part_img.py \

--- a/optee.nix
+++ b/optee.nix
@@ -81,10 +81,10 @@ let
       meta.platforms = [ "aarch64-linux" ];
     });
 
-  buildOpteeTaDevKit = args: buildOptee ({
+  buildOpteeTaDevKit = args: buildOptee (args // {
     pname = "optee-ta-dev-kit";
-    extraMakeFlags = [ "ta_dev_kit" ];
-  } // args);
+    extraMakeFlags = (args.extraMakeFlags or []) ++ [ "ta_dev_kit" ];
+  });
 
   buildNvLuksSrv = args: stdenv.mkDerivation {
     pname = "nvluks-srv";

--- a/optee.nix
+++ b/optee.nix
@@ -25,7 +25,7 @@ let
 
   opteeClient = stdenv.mkDerivation {
     pname = "optee_client";
-    version = nvopteeSrc.rev;
+    version = l4tVersion;
     src = nvopteeSrc;
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libuuid ];
@@ -60,7 +60,7 @@ let
     in
     stdenv.mkDerivation {
       inherit pname;
-      version = nvopteeSrc.rev;
+      version = l4tVersion;
       src = nvopteeSrc;
       patches = opteePatches;
       postPatch = ''
@@ -88,7 +88,7 @@ let
 
   buildNvLuksSrv = args: stdenv.mkDerivation {
     pname = "nvluks-srv";
-    version = nvopteeSrc.rev;
+    version = l4tVersion;
     src = nvopteeSrc;
     patches = [ ./0001-nvoptee-no-install-makefile.patch ];
     nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
@@ -112,7 +112,7 @@ let
 
   buildHwKeyAgent = args: stdenv.mkDerivation {
     pname = "hwkey-agent";
-    version = nvopteeSrc.rev;
+    version = l4tVersion;
     src = nvopteeSrc;
     patches = [ ./0001-nvoptee-no-install-makefile.patch ];
     nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
@@ -148,7 +148,7 @@ let
   buildArmTrustedFirmware = lib.makeOverridable ({ socType, ... }:
     stdenv.mkDerivation {
       pname = "arm-trusted-firmware";
-      version = atfSrc.rev;
+      version = l4tVersion;
       src = atfSrc;
       makeFlags = [
         "-C arm-trusted-firmware"

--- a/optee.nix
+++ b/optee.nix
@@ -37,6 +37,8 @@ let
                                     , socType
                                     , earlyTaPaths ? [ ]
                                     , extraMakeFlags ? [ ]
+                                    , opteePatches ? [ ]
+                                    , ...
                                     }:
     let
       nvCccPrebuilt = {
@@ -60,6 +62,7 @@ let
       inherit pname;
       version = nvopteeSrc.rev;
       src = nvopteeSrc;
+      patches = opteePatches;
       postPatch = ''
         patchShebangs $(find optee/optee_os -type d -name scripts -printf '%p ')
       '';
@@ -130,7 +133,7 @@ let
     '';
   };
 
-  buildOpteeDTB = lib.makeOverridable ({ socType }:
+  buildOpteeDTB = lib.makeOverridable ({ socType, ... }:
     let
       flavor = lib.replaceStrings [ "t" ] [ "" ] socType;
     in
@@ -142,7 +145,7 @@ let
       dtc -I dts -O dtb -o $out/tegra${flavor}-optee.dtb ${nvopteeSrc}/optee/tegra${flavor}-optee.dts
     '');
 
-  buildArmTrustedFirmware = lib.makeOverridable ({ socType }:
+  buildArmTrustedFirmware = lib.makeOverridable ({ socType, ... }:
     stdenv.mkDerivation {
       pname = "arm-trusted-firmware";
       version = atfSrc.rev;
@@ -175,7 +178,7 @@ let
       meta.platforms = [ "aarch64-linux" ];
     });
 
-  buildTOS = { socType }@args:
+  buildTOS = { socType, ... }@args:
     let
       armTrustedFirmware = buildArmTrustedFirmware args;
 


### PR DESCRIPTION
###### Description of changes

A number of cleanups and initial work on supporting NVIDIA's firmware secureboot implementation, described here:
https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/SD/Security/SecureBoot.html

###### Testing

Just tested that some existing NixOS closures still build
