### PR TITLE
Bump edk2-nvidia

### DIFF
--- a/uefi-firmware.nix
+++ b/uefi-firmware.nix
@@ -58,8 +58,8 @@ let
     src = fetchFromGitHub {
       owner = "NVIDIA";
       repo = "edk2-nvidia";
-      rev = "ad78b07af65d41bb96839f0bbe67bb445e04272f"; # Latest on r35.3.1-updates as of 2023-05-01
-      sha256 = "sha256-PdrisHYkmBXGvfkNboVvKJnBqORiM8sUsGySj7n5Y5c=";
+      rev = "2c81e0fc74f703012dd3b2f18da5be256e142fe3"; # Latest on r35.3.1-updates as of 2023-05-17
+      sha256 = "sha256-Qh1g+8a7ZcFG4VmwH+xDix6dpZ881HaNRE/FJoaRljw=";
     };
     patches = edk2NvidiaPatches ++ [ ./capsule-authentication.patch ];
     postPatch = lib.optionalString errorLevelInfo ''


### PR DESCRIPTION

###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->
This brings in https://github.com/NVIDIA/edk2-nvidia/commit/2c81e0fc74f703012dd3b2f18da5be256e142fe3, which allows for the Xavier AGX to have similar behavior to other boards in regards to the secure boot UEFI menu.

###### Testing

Manually tested on an Xavier AGX
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
