### PR TITLE
Add NixOS options for enrolling default secureboot keys

### DIFF
--- a/flash-script.nix
+++ b/flash-script.nix
@@ -16,6 +16,9 @@
 
   # Optional EKS file containing encrypted keyblob
   eksFile ? null,
+
+  # Additional DTB overlays to use during device flashing
+  additionalDtbOverlays ? [],
 }:
 ''
   set -euo pipefail
@@ -38,6 +41,8 @@
   export NO_ROOTFS=1
   export NO_RECOVERY_IMG=1
   export NO_ESP_IMG=1
+
+  export ADDITIONAL_DTB_OVERLAY=''${ADDITIONAL_DTB_OVERLAY:+$ADDITIONAL_DTB_OVERLAY,}${lib.concatStringsSep "," additionalDtbOverlays}
 
   ${lib.optionalString (partitionTemplate != null) "cp ${partitionTemplate} flash.xml"}
   ${lib.optionalString (dtbsDir != null) "cp -r ${dtbsDir}/. kernel/dtb/"}

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -50,6 +50,28 @@ in
             default = [];
           };
 
+          secureBoot = {
+            enrollDefaultKeys = lib.mkEnableOption "enroll default UEFI keys";
+            defaultPkEslFile = mkOption {
+              type = lib.types.path;
+              description = lib.mdDoc ''
+                The path to the UEFI PK EFI Signature List (ESL).
+              '';
+            };
+            defaultKekEslFile = mkOption {
+              type = lib.types.path;
+              description = lib.mdDoc ''
+                The path to the UEFI KEK Signature List (ESL).
+              '';
+            };
+            defaultDbEslFile = mkOption {
+              type = lib.types.path;
+              description = lib.mdDoc ''
+                The path to the UEFI DB Signature List (ESL).
+              '';
+            };
+          };
+
           capsuleAuthentication = {
             enable = mkEnableOption "capsule update authentication";
 

--- a/uefi-default-keys.dts
+++ b/uefi-default-keys.dts
@@ -1,0 +1,40 @@
+/dts-v1/;
+/plugin/;
+/ {
+    overlay-name = "UEFI default Keys";
+    fragment@0 {
+        target-path = "/";
+        board_config {
+            sw-modules = "uefi";
+        };
+        __overlay__ {
+            firmware {
+                uefi {
+                    variables {
+                        gNVIDIAPublicVariableGuid {
+                            EnrollDefaultSecurityKeys {
+                                data = [01];
+                                non-volatile;
+                            };
+                        };
+
+                        gEfiGlobalVariableGuid {
+                            dbDefault {
+                                data = [@dbDefault@];
+                                non-volatile;
+                            };
+                            KEKDefault {
+                                data = [@kekDefault@];
+                                non-volatile;
+                            };
+                            PKDefault {
+                                data = [@pkDefault@];
+                                non-volatile;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+};


### PR DESCRIPTION
###### Description of changes

Nvidia's flash script allows for enrolling the following UEFI protected variables:
- `dbDefault`
- `kekDefault`
- `pkDefault`

These changes take their BSP script `tools/gen_uefi_default_keys_dts.sh` to create a DTBO for use during the flashing procedure.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an Xavier AGX. After flashing with these changes, Nvidia's EnrollFromDefaultKeysApp UEFI application picks up the default keys and enrolls them as PK, KEK, db, etc. on first boot.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
