### PR TITLE
Pin optee toolchain to GCC 9

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,9 @@ let
     edk2-jetson uefi-firmware;
 
   inherit (pkgsAarch64.callPackages ./optee.nix {
+    # Nvidia's recommended toolchain is gcc9:
+    # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
+    stdenv = pkgsAarch64.gcc9Stdenv;
     inherit bspSrc l4tVersion;
   }) buildTOS opteeClient;
 


### PR DESCRIPTION


###### Description of changes

Nvidia's documentation provides instructions for downloading a GCC 9 toolchain, so we can do the same here.

Fixes #96 

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an orin-agx-devkit.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
