### PR TITLE
Remove publicCertificateDerFile and just use trustedPublicCertPemFile

### DIFF
--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -172,7 +172,7 @@ let
   # NOTE: providing null public certs here will use the test certs in the EDK2 repo
   uefiCapsuleUpdate = runCommand "uefi-${hostName}-${l4tVersion}.Cap" {
     nativeBuildInputs = [ python3 openssl ];
-    inherit (cfg.firmware.secureBoot) requiredSystemFeatures;
+    inherit (cfg.firmware.uefi.capsuleAuthentication) requiredSystemFeatures;
   } (''
     bash ${bspSrc}/generate_capsule/l4t_generate_soc_capsule.sh \
   '' + (lib.optionalString cfg.firmware.uefi.capsuleAuthentication.enable ''

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -75,21 +75,13 @@ in
           capsuleAuthentication = {
             enable = mkEnableOption "capsule update authentication";
 
-            publicCertificateDerFile = mkOption {
+            trustedPublicCertPemFile = mkOption {
               type = lib.types.path;
               description = lib.mdDoc ''
                 The path to the public certificate (in DER format) that will be
                 used for validating capsule updates. Capsule files must be signed
                 with a private key in the same certificate chain. This file will
                 be included in the EDK2 build.
-              '';
-            };
-
-            trustedPublicCertPemFile = mkOption {
-              type = lib.types.path;
-              description = lib.mdDoc ''
-                The path to the public certificate (in PEM format) that will be
-                used when signing capsule payloads.
               '';
             };
 


### PR DESCRIPTION
###### Description of changes

The DER format of the public certificate can just be created at build-time based on the PEM-formatted trustedPublicCertPemFile. Since these are supposed to be the same certificate, it's less confusing if there's just one option for it.

Also, don't set default null 

###### Testing

Tested by performing a UEFI capsule update on the Orin nano devkit.
