### PR TITLE
Expose mkFlashScript from device-pkgs

### DIFF
--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -203,5 +203,6 @@ let
   };
 in {
   inherit (tosImage) nvLuksSrv hwKeyAgent;
+  inherit mkFlashScript;
   inherit flashScript initrdFlashScript tosImage signedFirmware bup fuseScript uefiCapsuleUpdate;
 }


### PR DESCRIPTION
###### Description of changes

Expose mkFlashScript from device-pkgs.nix. Thus one can now call devicePkgsFromNixosConfig from another package/flake, and get an attribute set where mkFlashScript is available. This makes it easier to create custom flash scripts, because not all the arguments need to be specified, but user of jetpack-nixos could just override the desired arguments, and use the defaults for others.

###### Testing

Tested from other project, using AGX Orin Devkit. This change does not really change any behavior in this project, but merely exposes one part of the API