### PR TITLE
Add patch for nvluks-srv-app

### DIFF
--- a/0002-Exit-with-non-zero-status-code-on-TEEC_InvokeCommand.patch
+++ b/0002-Exit-with-non-zero-status-code-on-TEEC_InvokeCommand.patch
@@ -1,0 +1,29 @@
+From 68c3bd1bfdbe2683db7c9b7aad0dc6990b8a7225 Mon Sep 17 00:00:00 2001
+From: Jared Baur <jbaur@anduril.com>
+Date: Fri, 2 Jun 2023 10:47:13 -0700
+Subject: [PATCH] Exit with non-zero status code on TEEC_InvokeCommand
+
+This makes the status of TEEC_InvokeCommand consistent with other
+failure modes of the program.
+---
+ optee/samples/luks-srv/host/luks_srv_ca.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/optee/samples/luks-srv/host/luks_srv_ca.c b/optee/samples/luks-srv/host/luks_srv_ca.c
+index 49bc029..2a19749 100644
+--- a/optee/samples/luks-srv/host/luks_srv_ca.c
++++ b/optee/samples/luks-srv/host/luks_srv_ca.c
+@@ -140,9 +140,8 @@ static void luks_srv_app_handler(struct arguments *argus, luks_ca_ctx_t *ctx)
+ 	/* Send command to TA. */
+ 	rc = TEEC_InvokeCommand(&ctx->sess, cmd_id, &op, &origin);
+ 	if (rc != TEEC_SUCCESS) {
+-		printf("TEEC_InvokeCommand failed 0x%x origin 0x%x\n", rc,
++		errx(1, "TEEC_InvokeCommand failed 0x%x origin 0x%x\n", rc,
+ 		       origin);
+-		return;
+ 	}
+ 
+ 	if ((LUKS_SRV_TA_CMD_GET_UNIQUE_PASS == cmd_id) ||
+-- 
+2.40.1
+

--- a/optee.nix
+++ b/optee.nix
@@ -83,14 +83,14 @@ let
 
   buildOpteeTaDevKit = args: buildOptee (args // {
     pname = "optee-ta-dev-kit";
-    extraMakeFlags = (args.extraMakeFlags or []) ++ [ "ta_dev_kit" ];
+    extraMakeFlags = (args.extraMakeFlags or [ ]) ++ [ "ta_dev_kit" ];
   });
 
   buildNvLuksSrv = args: stdenv.mkDerivation {
     pname = "nvluks-srv";
     version = l4tVersion;
     src = nvopteeSrc;
-    patches = [ ./0001-nvoptee-no-install-makefile.patch ];
+    patches = [ ./0001-nvoptee-no-install-makefile.patch ./0002-Exit-with-non-zero-status-code-on-TEEC_InvokeCommand.patch ];
     nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
     makeFlags = [
       "-C optee/samples/luks-srv"


### PR DESCRIPTION

###### Description of changes

The patch makes sure that nvluks-srv-app exits with a non-zero exit code when it encounters a TEE invoke error. This makes nvluks-srv-app more consistent with the rest of the failure modes of the program.


<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an xavier-agx-devkit.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
