### PR TITLE
Build tee-supplicant with a customizable TEE_CLIENT_LOAD_PATH

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -111,10 +111,8 @@ let
 
   # Packages whose contents are paramterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs.nix {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS bspSrc;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS opteeClient bspSrc;
   };
-
-  devicePkgs = lib.mapAttrs (n: c: devicePkgsFromNixosConfig (pkgs.nixos c).config) supportedConfigurations;
 
   otaUtils = callPackage ./ota-utils {
     inherit tegra-eeprom-tool l4tVersion;
@@ -133,8 +131,6 @@ in rec {
 
   inherit kernel kernelPackages;
   inherit rtkernel rtkernelPackages;
-
-  inherit opteeClient;
 
   inherit nxJetsonBenchmarks xavierAgxJetsonBenchmarks orinAgxJetsonBenchmarks;
 

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,5 +1,5 @@
 { lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
-  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS,
+  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, opteeClient,
   python3, bspSrc, openssl, dtc,
   l4tVersion,
   pkgsAarch64,
@@ -24,6 +24,15 @@ let
     opteePatches = cfg.firmware.optee.patches;
     extraMakeFlags = cfg.firmware.optee.extraMakeFlags;
   };
+
+  teeSupplicant = opteeClient.overrideAttrs (old: {
+    pname = "tee-supplicant";
+    buildFlags = (old.buildFlags or []) ++ [ "CFG_TEE_CLIENT_LOAD_PATH=${cfg.firmware.optee.clientLoadPath}" ];
+    # remove unneeded headers
+    postInstall = ''
+      rm -rf $out/include
+    '';
+  });
 
   uefiDefaultKeysDtbo = runCommand "UefiDefaultSecurityKeys.dtbo" { nativeBuildInputs = [ dtc ]; } ''
     export pkDefault=$(od -t x1 -An "${cfg.firmware.uefi.secureBoot.defaultPkEslFile}")
@@ -204,5 +213,5 @@ let
 in {
   inherit (tosImage) nvLuksSrv hwKeyAgent;
   inherit mkFlashScript;
-  inherit flashScript initrdFlashScript tosImage signedFirmware bup fuseScript uefiCapsuleUpdate;
+  inherit flashScript initrdFlashScript tosImage teeSupplicant signedFirmware bup fuseScript uefiCapsuleUpdate;
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -166,7 +166,7 @@ in
     systemd.services.tee-supplicant = {
       description = "Userspace supplicant for OPTEE-OS";
       serviceConfig = {
-        ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant";
+        ExecStart = "${config.hardware.nvidia-jetpack.devicePkgs.teeSupplicant}/bin/tee-supplicant ${lib.escapeShellArgs cfg.firmware.optee.supplicantExtraArgs}";
         Restart = "always";
       };
       wantedBy = [ "multi-user.target" ];

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -115,6 +115,25 @@ in
         };
 
         optee = {
+          supplicantExtraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = lib.mdDoc ''
+              Extra arguments to pass to tee-supplicant.
+            '';
+          };
+
+          clientLoadPath = mkOption {
+            type = types.path;
+            default = "/var/lib/optee";
+            description = lib.mdDoc ''
+              The path tee-supplicant will use to search for trusted
+              applications. Note that trusted applications must be placed in
+              the TA directory (specified with tee-supplicant's --ta-dir flag),
+              under this load path.
+            '';
+          };
+
           patches = mkOption {
             type = types.listOf types.path;
             default = [];

--- a/optee.nix
+++ b/optee.nix
@@ -214,8 +214,5 @@ let
     image;
 in
 {
-  inherit
-    opteeClient
-    buildTOS
-    ;
+  inherit buildTOS opteeClient;
 }


### PR DESCRIPTION
###### Description of changes

These changes add a NixOS option for customizing the TEE_CLIENT_LOAD_PATH for tee-supplicant. Also added is a NixOS option for adding command-line arguments to tee-supplicant, helpful in this case for changing tee-supplicant's `--ta-dir`, the subdirectory under the load path where tee-supplicant will look for TAs. The default load path is set to "/var/lib/optee", but can trivially be changed to some static path built with nix. For example:

```nix
{ pkgs, ... }: {
  hardware.nvidia-jetpack.firmare.optee.clientLoadPath = pkgs.linkFarm "optee-load-path" [{
    name = "optee_armtz/my.ta";
    path = taDerivation;
  }];
}
``` 

where `taDerivation` is the path to the trusted application.

Fixes #100 

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an orin-agx-devkit.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
