### PR TITLE
Added additionalDtbOverlays option

### DIFF
--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -17,7 +17,7 @@ let
     else throw "Unknown SoC type";
 
   inherit (cfg.flashScriptOverrides)
-    flashArgs fuseArgs partitionTemplate;
+    flashArgs fuseArgs partitionTemplate additionalDtbOverlays;
 
   tosImage = buildTOS {
     inherit socType;
@@ -38,6 +38,8 @@ let
   mkFlashScript = args: import ./flash-script.nix ({
     inherit lib flashArgs partitionTemplate;
 
+    inherit (cfg.flashScriptOverrides) additionalDtbOverlays;
+
     flash-tools = flash-tools.overrideAttrs ({ postPatch ? "", ... }: {
       postPatch = postPatch + cfg.flashScriptOverrides.postPatch;
     });
@@ -55,8 +57,6 @@ let
 
     inherit tosImage;
     eksFile = cfg.firmware.eksFile;
-
-    additionalDtbOverlays = lib.optional (cfg.firmware.uefi.secureBoot.enrollDefaultKeys) uefiDefaultKeysDtbo;
 
     dtbsDir = config.hardware.deviceTree.package;
   } // args);


### PR DESCRIPTION
###### Description of changes

Add `additionalDtbOverlays` option, which is list of paths to compiled .dtbo files to include with the UEFI image while flashing. These overlays are applied by UEFI at runtime.  This is a NixOS module option that can be set as an alternative to setting the ADDITIONAL_DTB_OVERLAYS environment variable when running the flash script.

###### Testing

Tested that I can apply a device tree overlay to UEFI at runtime