### PR TITLE
Fix kernel issues preventing inclusion of BTF info

### DIFF
--- a/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
+++ b/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
@@ -1,0 +1,52 @@
+From 7c9c4b52c818ed3ac6761b41e8a6c00ee63e8f9c Mon Sep 17 00:00:00 2001
+From: Ilya Leoshkevich <iii@linux.ibm.com>
+Date: Wed, 19 Oct 2022 10:56:00 +0200
+Subject: [PATCH 1/5] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
+
+commit db16c1fe92d7ba7d39061faef897842baee2c887  upstream.
+
+[backported for dependency only extra_paholeopt variable setup and
+usage, we don't want floats generated in 5.10]
+
+pahole v1.21 supports the --btf_gen_floats flag, which makes it
+generate the information about the floating-point types [1].
+
+Adjust link-vmlinux.sh to pass this flag to pahole in case it's
+supported, which is determined using a simple version check.
+
+[1] https://lore.kernel.org/dwarves/YHRiXNX1JUF2Az0A@kernel.org/
+
+Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/20210413190043.21918-1-iii@linux.ibm.com
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 6eded325c837..779fde480a99 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -140,6 +140,7 @@ vmlinux_link()
+ gen_btf()
+ {
+ 	local pahole_ver
++	local extra_paholeopt=
+ 
+ 	if ! [ -x "$(command -v ${PAHOLE})" ]; then
+ 		echo >&2 "BTF: ${1}: pahole (${PAHOLE}) is not available"
+@@ -155,7 +156,7 @@ gen_btf()
+ 	vmlinux_link ${1}
+ 
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${1}
++	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+-- 
+2.39.1
+

--- a/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
+++ b/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
@@ -1,0 +1,70 @@
+From 688d9cbc5932cce17ed2f97b62eac880b4dab5f0 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Wed, 19 Oct 2022 10:56:01 +0200
+Subject: [PATCH 2/5] kbuild: Quote OBJCOPY var to avoid a pahole call break
+ the build
+
+commit ff2e6efda0d5c51b33e2bcc0b0b981ac0a0ef214 upstream.
+
+[backported for dependency, skipped Makefile.modfinal change,
+because module BTF is not supported in 5.10]
+
+The ccache tool can be used to speed up cross-compilation, by calling the
+compiler and binutils through ccache. For example, following should work:
+
+    $ export ARCH=arm64 CROSS_COMPILE="ccache aarch64-linux-gnu-"
+
+    $ make M=drivers/gpu/drm/rockchip/
+
+but pahole fails to extract the BTF info from DWARF, breaking the build:
+
+      CC [M]  drivers/gpu/drm/rockchip//rockchipdrm.mod.o
+      LD [M]  drivers/gpu/drm/rockchip//rockchipdrm.ko
+      BTF [M] drivers/gpu/drm/rockchip//rockchipdrm.ko
+    aarch64-linux-gnu-objcopy: invalid option -- 'J'
+    Usage: aarch64-linux-gnu-objcopy [option(s)] in-file [out-file]
+     Copies a binary file, possibly transforming it in the process
+    ...
+    make[1]: *** [scripts/Makefile.modpost:156: __modpost] Error 2
+    make: *** [Makefile:1866: modules] Error 2
+
+this fails because OBJCOPY is set to "ccache aarch64-linux-gnu-copy" and
+later pahole is executed with the following command line:
+
+    LLVM_OBJCOPY=$(OBJCOPY) $(PAHOLE) -J --btf_base vmlinux $@
+
+which gets expanded to:
+
+    LLVM_OBJCOPY=ccache aarch64-linux-gnu-objcopy pahole -J ...
+
+instead of:
+
+    LLVM_OBJCOPY="ccache aarch64-linux-gnu-objcopy" pahole -J ...
+
+Fixes: 5f9ae91f7c0d ("kbuild: Build kernel module BTFs if BTF is enabled and pahole supports it")
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Link: https://lore.kernel.org/bpf/20210526215228.3729875-1-javierm@redhat.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 779fde480a99..94c548b11db9 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -156,7 +156,7 @@ gen_btf()
+ 	vmlinux_link ${1}
+ 
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${extra_paholeopt} ${1}
++	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+-- 
+2.39.1
+

--- a/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
+++ b/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
@@ -1,0 +1,57 @@
+From a85beb65ff300d9a118d71d187e0a451ee4e1d6e Mon Sep 17 00:00:00 2001
+From: Andrii Nakryiko <andrii@kernel.org>
+Date: Wed, 19 Oct 2022 10:56:02 +0200
+Subject: [PATCH 3/5] kbuild: skip per-CPU BTF generation for pahole
+ v1.18-v1.21
+
+commit a0b8200d06ad6450c179407baa5f0f52f8cfcc97 upstream.
+
+[small context changes due to missing floats support in 5.10]
+
+Commit "mm/page_alloc: convert per-cpu list protection to local_lock" will
+introduce a zero-sized per-CPU variable, which causes pahole to generate
+invalid BTF.  Only pahole versions 1.18 through 1.21 are impacted, as
+before 1.18 pahole doesn't know anything about per-CPU variables, and 1.22
+contains the proper fix for the issue.
+
+Luckily, pahole 1.18 got --skip_encoding_btf_vars option disabling BTF
+generation for per-CPU variables in anticipation of some unanticipated
+problems.  So use this escape hatch to disable per-CPU var BTF info on
+those problematic pahole versions.  Users relying on availability of
+per-CPU var BTFs would need to upgrade to pahole 1.22+, but everyone won't
+notice any regressions.
+
+Link: https://lkml.kernel.org/r/20210530002536.3193829-1-andrii@kernel.org
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Mel Gorman <mgorman@techsingularity.net>
+Cc: Arnaldo Carvalho de Melo <acme@redhat.com>
+Cc: Hao Luo <haoluo@google.com>
+Cc: Michal Suchanek <msuchanek@suse.de>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 94c548b11db9..55bcfa85873c 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -155,6 +155,11 @@ gen_btf()
+ 
+ 	vmlinux_link ${1}
+ 
++	if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
++		# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
++		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
++	fi
++
+ 	info "BTF" ${2}
+ 	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+-- 
+2.39.1
+

--- a/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
+++ b/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
@@ -1,0 +1,106 @@
+From f3fd824d409bc429b661572e2ef01dfeb64ce326 Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@redhat.com>
+Date: Wed, 19 Oct 2022 10:56:03 +0200
+Subject: [PATCH 4/5] kbuild: Unify options for BTF generation for vmlinux and
+ modules
+
+commit 9741e07ece7c247dd65e1aa01e16b683f01c05a8 upstream.
+
+[skipped --btf_gen_floats option in pahole-flags.sh, skipped
+Makefile.modfinal change, because there's no BTF kmod support,
+squashing in 'exit 0' change from merge commit fc02cb2b37fe]
+
+Using new PAHOLE_FLAGS variable to pass extra arguments to
+pahole for both vmlinux and modules BTF data generation.
+
+Adding new scripts/pahole-flags.sh script that detect and
+prints pahole options.
+
+[ fixed issues found by kernel test robot ]
+
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/20211029125729.70002-1-jolsa@kernel.org
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ Makefile                |  3 +++
+ scripts/link-vmlinux.sh |  8 +-------
+ scripts/pahole-flags.sh | 17 +++++++++++++++++
+ 3 files changed, 21 insertions(+), 7 deletions(-)
+ create mode 100755 scripts/pahole-flags.sh
+
+diff --git a/Makefile b/Makefile
+index 8873e748b667..541ec88ff7c8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -484,6 +484,8 @@ LZ4		= lz4c
+ XZ		= xz
+ ZSTD		= zstd
+ 
++PAHOLE_FLAGS	= $(shell PAHOLE=$(PAHOLE) $(srctree)/scripts/pahole-flags.sh)
++
+ CHECKFLAGS     := -D__linux__ -Dlinux -D__STDC__ -Dunix -D__unix__ \
+ 		  -Wbitwise -Wno-return-void -Wno-unknown-attribute $(CF)
+ NOSTDINC_FLAGS :=
+@@ -537,6 +539,7 @@ export KBUILD_CFLAGS CFLAGS_KERNEL CFLAGS_MODULE
+ export KBUILD_AFLAGS AFLAGS_KERNEL AFLAGS_MODULE
+ export KBUILD_AFLAGS_MODULE KBUILD_CFLAGS_MODULE KBUILD_LDFLAGS_MODULE
+ export KBUILD_AFLAGS_KERNEL KBUILD_CFLAGS_KERNEL
++export PAHOLE_FLAGS
+ 
+ # Files to ignore in find ... statements
+ 
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 55bcfa85873c..cff7ef9a5773 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -140,7 +140,6 @@ vmlinux_link()
+ gen_btf()
+ {
+ 	local pahole_ver
+-	local extra_paholeopt=
+ 
+ 	if ! [ -x "$(command -v ${PAHOLE})" ]; then
+ 		echo >&2 "BTF: ${1}: pahole (${PAHOLE}) is not available"
+@@ -155,13 +154,8 @@ gen_btf()
+ 
+ 	vmlinux_link ${1}
+ 
+-	if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
+-		# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
+-		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
+-	fi
+-
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
++	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${PAHOLE_FLAGS} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+diff --git a/scripts/pahole-flags.sh b/scripts/pahole-flags.sh
+new file mode 100755
+index 000000000000..27445cb72974
+--- /dev/null
++++ b/scripts/pahole-flags.sh
+@@ -0,0 +1,17 @@
++#!/bin/sh
++# SPDX-License-Identifier: GPL-2.0
++
++extra_paholeopt=
++
++if ! [ -x "$(command -v ${PAHOLE})" ]; then
++	exit 0
++fi
++
++pahole_ver=$(${PAHOLE} --version | sed -E 's/v([0-9]+)\.([0-9]+)/\1\2/')
++
++if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
++	# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
++	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
++fi
++
++echo ${extra_paholeopt}
+-- 
+2.39.1
+

--- a/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
+++ b/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
@@ -1,0 +1,45 @@
+From 776ce6f0aa1ddc6d207b6c2a87bcdb8adf675a06 Mon Sep 17 00:00:00 2001
+From: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
+Date: Wed, 19 Oct 2022 10:56:04 +0200
+Subject: [PATCH 5/5] kbuild: Add skip_encoding_btf_enum64 option to pahole
+
+New pahole (version 1.24) generates by default new BTF_KIND_ENUM64 BTF tag,
+which is not supported by stable kernel.
+
+As a result the kernel with CONFIG_DEBUG_INFO_BTF option will fail to
+compile with following error:
+
+  BTFIDS  vmlinux
+FAILED: load BTF from vmlinux: Invalid argument
+
+New pahole provides --skip_encoding_btf_enum64 option to skip BTF_KIND_ENUM64
+generation and produce BTF supported by stable kernel.
+
+Adding this option to scripts/pahole-flags.sh.
+
+This change does not have equivalent commit in linus tree, because linus tree
+has support for BTF_KIND_ENUM64 tag, so it does not need to be disabled.
+
+Signed-off-by: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/pahole-flags.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scripts/pahole-flags.sh b/scripts/pahole-flags.sh
+index 27445cb72974..8c82173e42e5 100755
+--- a/scripts/pahole-flags.sh
++++ b/scripts/pahole-flags.sh
+@@ -14,4 +14,8 @@ if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
+ 	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
+ fi
+ 
++if [ "${pahole_ver}" -ge "124" ]; then
++	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_enum64"
++fi
++
+ echo ${extra_paholeopt}
+-- 
+2.39.1
+

--- a/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
+++ b/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
@@ -1,0 +1,93 @@
+From 507f96036e6af6bcec7f4e0435ed11ba0f65619a Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@kernel.org>
+Date: Wed, 6 Jan 2021 00:42:19 +0100
+Subject: [PATCH 6/6] tools/resolve_btfids: Warn when having multiple IDs for
+ single type
+
+The kernel image can contain multiple types (structs/unions)
+with the same name. This causes distinct type hierarchies in
+BTF data and makes resolve_btfids fail with error like:
+
+  BTFIDS  vmlinux
+FAILED unresolved symbol udp6_sock
+
+as reported by Qais Yousef [1].
+
+This change adds warning when multiple types of the same name
+are detected:
+
+  BTFIDS  vmlinux
+WARN: multiple IDs found for 'file': 526, 113351 - using 526
+WARN: multiple IDs found for 'sk_buff': 2744, 113958 - using 2744
+
+We keep the lower ID for the given type instance and let the
+build continue.
+
+Also changing the 'nr' variable name to 'nr_types' to avoid confusion.
+
+[1] https://lore.kernel.org/lkml/20201229151352.6hzmjvu3qh6p2qgg@e107158-lin/
+
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/20210105234219.970039-1-jolsa@kernel.org
+---
+ tools/bpf/resolve_btfids/main.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/tools/bpf/resolve_btfids/main.c b/tools/bpf/resolve_btfids/main.c
+index f32c059fbfb4..c3f808a393d1 100644
+--- a/tools/bpf/resolve_btfids/main.c
++++ b/tools/bpf/resolve_btfids/main.c
+@@ -139,6 +139,8 @@ int eprintf(int level, int var, const char *fmt, ...)
+ #define pr_debug2(fmt, ...) pr_debugN(2, pr_fmt(fmt), ##__VA_ARGS__)
+ #define pr_err(fmt, ...) \
+ 	eprintf(0, verbose, pr_fmt(fmt), ##__VA_ARGS__)
++#define pr_info(fmt, ...) \
++	eprintf(0, verbose, pr_fmt(fmt), ##__VA_ARGS__)
+ 
+ static bool is_btf_id(const char *name)
+ {
+@@ -477,7 +479,7 @@ static int symbols_resolve(struct object *obj)
+ 	int nr_funcs    = obj->nr_funcs;
+ 	int err, type_id;
+ 	struct btf *btf;
+-	__u32 nr;
++	__u32 nr_types;
+ 
+ 	btf = btf__parse(obj->btf ?: obj->path, NULL);
+ 	err = libbpf_get_error(btf);
+@@ -488,12 +490,12 @@ static int symbols_resolve(struct object *obj)
+ 	}
+ 
+ 	err = -1;
+-	nr  = btf__get_nr_types(btf);
++	nr_types = btf__get_nr_types(btf);
+ 
+ 	/*
+ 	 * Iterate all the BTF types and search for collected symbol IDs.
+ 	 */
+-	for (type_id = 1; type_id <= nr; type_id++) {
++	for (type_id = 1; type_id <= nr_types; type_id++) {
+ 		const struct btf_type *type;
+ 		struct rb_root *root;
+ 		struct btf_id *id;
+@@ -531,8 +533,13 @@ static int symbols_resolve(struct object *obj)
+ 
+ 		id = btf_id__find(root, str);
+ 		if (id) {
+-			id->id = type_id;
+-			(*nr)--;
++			if (id->id) {
++				pr_info("WARN: multiple IDs found for '%s': %d, %d - using %d\n",
++					str, id->id, type_id, id->id);
++			} else {
++				id->id = type_id;
++				(*nr)--;
++			}
+ 		}
+ 	}
+ 
+-- 
+2.39.1
+

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -20,8 +20,8 @@ in pkgsAarch64.buildLinux (args // {
     src = fetchFromGitHub {
       owner = "OE4T";
       repo = "linux-tegra-5.10";
-      rev = "26cfd067b9113af207849146b86607a10fedd5c6"; # latest on oe4t-patches-l4t-r35.3.ga as of 2023-03-29
-      sha256 = "sha256-3HGnrfBJY+38zXA3YISK/DCh3w/7dZtH3If9GaBr4a8=";
+      rev = "7191dccf8670635906182cc2da862d9c0fdcb93a"; # latest on oe4t-patches-l4t-r35.3.ga as of 2023-07-27
+      sha256 = "sha256-s71v4Bzc2jF9l65FY7OlrB/zi8Vkty+dBxZry8MyBno=";
     };
     # Remove device tree overlays with some incorrect "remote-endpoint" nodes.
     # They are strings, but should be phandles. Otherwise, it fails to compile
@@ -83,7 +83,7 @@ in pkgsAarch64.buildLinux (args // {
     # https://lkml.iu.edu/hypermail/linux/kernel/2012.3/03853.html
     # https://lore.kernel.org/lkml/CAE1WUT75gu9G62Q9uAALGN6vLX=o7vZ9uhqtVWnbUV81DgmFPw@mail.gmail.com/
     # Could probably also be fixed by updating the GCC version used by default on ARM
-    DEBUG_INFO_BTF = lib.mkForce no;
+    #DEBUG_INFO_BTF = lib.mkForce no;
 
     # Override the default CMA_SIZE_MBYTES=32M setting in common-config.nix with the default from tegra_defconfig
     # Otherwise, nvidia's driver craps out

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -57,6 +57,26 @@ in pkgsAarch64.buildLinux (args // {
         USB_XHCI_TEGRA y
       '';
     }
+
+    # Fix "FAILED: load BTF from vmlinux: Unknown error -22" by including a
+    # number of patches from the 5.10 LTS branch. Unclear exactly which one is needed.
+    # See also: https://github.com/NixOS/nixpkgs/pull/194551
+    { patch = ./0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch; }
+    { patch = ./0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch; }
+    { patch = ./0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch; }
+    { patch = ./0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch; }
+    { patch = ./0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch; }
+
+    # Fix "FAILED: resolved symbol udp_sock"
+    # This is caused by having multiple structs of the same name in the BTF output.
+    # For example, `bpftool btf dump file vmlinux | grep "STRUCT 'udp_sock'"`
+    #   [507] STRUCT 'file' size=256 vlen=22
+    #   [121957] STRUCT 'file' size=256 vlen=22
+    # Without this patch, resolve_btfids doesn't handle this case and
+    # miscounts, leading to the failure. The underlying cause of why we have
+    # multiple structs of the same name is still unresolved as of 2023-07-29
+    { patch = ./0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch; }
+
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {
@@ -76,14 +96,6 @@ in pkgsAarch64.buildLinux (args // {
     # the kernel will have already tried loading!
     EXTRA_FIRMWARE_DIR = freeform "${l4t-xusb-firmware}/lib/firmware";
     EXTRA_FIRMWARE = freeform "nvidia/tegra194/xusb.bin";
-
-    # Fix issue resulting in this error message:
-    # FAILED unresolved symbol udp_sock
-    #
-    # https://lkml.iu.edu/hypermail/linux/kernel/2012.3/03853.html
-    # https://lore.kernel.org/lkml/CAE1WUT75gu9G62Q9uAALGN6vLX=o7vZ9uhqtVWnbUV81DgmFPw@mail.gmail.com/
-    # Could probably also be fixed by updating the GCC version used by default on ARM
-    #DEBUG_INFO_BTF = lib.mkForce no;
 
     # Override the default CMA_SIZE_MBYTES=32M setting in common-config.nix with the default from tegra_defconfig
     # Otherwise, nvidia's driver craps out


### PR DESCRIPTION
###### Description of changes

Removed build workaround where I disabled  `CONFIG_DEBUG_INFO_BTF`.

###### Testing

Booted kernel on Orin AGX devkit. Noted that `/sys/kernel/btf/vmlinux` exists.