### PR TITLE
Support for l4t Docker containers

### DIFF
--- a/avoid-static-libtirpc-build.patch
+++ b/avoid-static-libtirpc-build.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index 709102b..2c50cc6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -201,7 +201,7 @@ $(LIB_STATIC_OBJ): $(LIB_OBJS)
+ 
+ all: CPPFLAGS += -DNDEBUG
+ all: STRIP  := @echo skipping: strip
+-all: shared static
++all: shared
+ 
+ # Run with ASAN_OPTIONS="protect_shadow_gap=0" to avoid CUDA OOM errors
+ debug: CFLAGS += -pedantic -fsanitize=undefined -fno-omit-frame-pointer -fno-common -fsanitize=address
+@@ -228,7 +228,6 @@ install: all
+ 	# Install header files
+ 	$(INSTALL) -m 644 $(LIB_INCS) $(DESTDIR)$(includedir)
+ 	# Install library files
+-	$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 $(LIB_SHARED) $(DESTDIR)$(libdir)
+ 	$(LN) -sf $(LIB_SONAME) $(DESTDIR)$(libdir)/$(LIB_SYMLINK)
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir)
+-- 
+2.38.5
+

--- a/containers.nix
+++ b/containers.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  dpkg,
+  debs,
+  fetchFromGitHub,
+  libelf,
+  libcap,
+  libtirpc,
+  libseccomp,
+  substituteAll,
+  bspSrc,
+  pkgs,
+  pkg-config,
+  rpcsvc-proto,
+}:
+
+
+let
+  # First, extract the l4t.xml from the root image to know what packages are expected to be present.
+  l4tCsv = pkgs.runCommand "l4t.csv" {} ''
+    tar -xf "${bspSrc}/nv_tegra/config.tbz2"
+    mkdir -p "$out"
+    mv etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv "$out"
+  '';
+
+  # make a single sources root of all the debs.
+  # given this is WAY more stuff than we need, we should be able to dramatically reduce this by intersecting at extract time with l4t.csv.
+  # However, this was beyond my bash skills at time of writing and I can't spare more time on this.
+  # In theory, we could also filter the list of debs that have been extracted - however this will be less efficient.
+  unpackedDebs = pkgs.runCommand "depsForContainer" { nativeBuildInputs = [ dpkg ]; } ''
+    mkdir -p $out
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: p: "echo Unpacking ${n}; dpkg -x ${p.src} $out") debs.common)}
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: p: "echo Unpacking ${n}; dpkg -x ${p.src} $out") debs.t234)}
+  '';
+
+  modprobeVersion = "396.51";
+  nvidia-modprobe = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "nvidia-modprobe";
+    rev = modprobeVersion;
+    sha256 = "sha256-c2G0qatv0LMZ0RAbluB9TyHkZAVbdGf4U8RMghjHgrs=";
+  };
+  modprobePatch = substituteAll {
+    src = ./modprobe.patch;
+    inherit modprobeVersion;
+  };
+
+  libnvidia_container0 = stdenv.mkDerivation rec {
+    pname = "libnvidia-container";
+    version = "0.11.0+jetpack";
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = "libnvidia-container";
+      rev = "v${version}";
+      sha256 = "sha256-dRK0mmewNL2jIvnlk0YgCfTHuIc3BuZhIlXG5VqBQ5Q=";
+    };
+    patches = [
+      ./nvc-ldcache.patch
+      ./avoid-static-libtirpc-build.patch
+      ./libcontainer-nixos-base.patch
+    ];
+    postPatch = ''
+      sed -i \
+        -e 's/^REVISION :=.*/REVISION = ${src.rev}/' \
+        -e 's/^COMPILER :=.*/COMPILER = $(CC)/' \
+        mk/common.mk
+
+      sed -i 's#/etc/nvidia-container-runtime/host-files-for-container.d#${l4tCsv}#' src/nvc_info.c
+      sed -i 's#NIXOS_ROOT#${unpackedDebs}#' src/common.h
+
+      mkdir -p deps/src/nvidia-modprobe-${modprobeVersion}
+      cp -r ${nvidia-modprobe}/* deps/src/nvidia-modprobe-${modprobeVersion}
+      chmod -R u+w deps/src
+      pushd deps/src
+
+      # patch -p0 < ${modprobePatch}
+      touch nvidia-modprobe-${modprobeVersion}/.download_stamp
+      popd
+
+      # 1. replace DESTDIR=$(DEPS_DIR) with empty strings to prevent copying
+      #    things into deps/src/nix/store
+      # 2. similarly, remove any paths prefixed with DEPS_DIR
+      # 3. prevent building static libraries because we don't build static
+      #    libtirpc (for now)
+      # 4. prevent installation of static libraries because of step 3
+      # 5. prevent installation of libnvidia-container-go.so twice
+      sed -i Makefile \
+        -e 's#DESTDIR=\$(DEPS_DIR)#DESTDIR=""#g' \
+        -e 's#\$(DEPS_DIR)\$#\$#g' \
+        -e 's#all: shared static tools#all: shared tools#g' \
+        -e '/$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)/d' \
+        -e '/$(INSTALL) -m 755 $(libdir)\/$(LIBGO_SHARED) $(DESTDIR)$(libdir)/d'
+    '';
+
+    enableParallelBuilding = true;
+
+    preBuild = ''
+      HOME="$(mktemp -d)"
+    '';
+
+    NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
+    NIX_LDFLAGS = [ "-L${libtirpc}/lib" "-ltirpc" ];
+
+    nativeBuildInputs = [ pkg-config rpcsvc-proto ];
+
+    buildInputs = [ libelf libcap libseccomp libtirpc ];
+
+    makeFlags = [
+      "WITH_LIBELF=yes"
+      "prefix=$(out)"
+      # we can't use the WITH_TIRPC=yes flag that exists in the Makefile for the
+      # same reason we patch out the static library use of libtirpc so we set the
+      # define in CFLAGS
+      "CFLAGS=-DWITH_TIRPC"
+    ];
+  };
+in {
+    inherit libnvidia_container0;
+}

--- a/cuda-packages.nix
+++ b/cuda-packages.nix
@@ -216,6 +216,7 @@ let
     libcusparse = buildFromSourcePackage { name = "libcusparse"; };
     libnpp = buildFromSourcePackage { name = "libnpp"; };
     libcudla = buildFromSourcePackage { name = "libcudla"; buildInputs = [ l4t.l4t-cuda ]; };
+
     nsight_compute_target = buildFromDebs {
       name = "nsight-compute-target";
       version = nsight_compute_version;

--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,8 @@ let
 
   cudaPackages = callPackages ./cuda-packages.nix { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t; };
 
+  containers = callPackages ./containers.nix { inherit debs bspSrc; };
+
   samples = callPackages ./samples.nix { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t cudaPackages; };
 
   kernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; kernelPatches = []; };
@@ -125,7 +127,7 @@ in rec {
   # Just for convenience
   inherit bspSrc debs unpackedDebs;
 
-  inherit cudaPackages samples;
+  inherit cudaPackages containers samples;
   inherit flash-tools;
   inherit board-automation; # Allows automation of Orin AGX devkit
   inherit python-jetson; # Allows automation of Xavier AGX devkit

--- a/libcontainer-nixos-base.patch
+++ b/libcontainer-nixos-base.patch
@@ -1,0 +1,114 @@
+diff --git a/src/common.h b/src/common.h
+index 015452f..4790e2c 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -24,6 +24,8 @@
+ #define LDCONFIG_PATH             "/sbin/ldconfig"
+ #define LDCONFIG_ALT_PATH         "/sbin/ldconfig.real"
+ 
++#define JETSON_FROM_ROOT          "NIXOS_ROOT"
++
+ #define LIB_DIR                   "/lib64"
+ #define USR_BIN_DIR               "/usr/bin"
+ #define USR_LIB_DIR               "/usr/lib64"
+diff --git a/src/jetson_mount.c b/src/jetson_mount.c
+index 1c5d9de..9100f0b 100644
+--- a/src/jetson_mount.c
++++ b/src/jetson_mount.c
+@@ -50,7 +50,7 @@ mount_jetson_files(struct error *err, const char *root, const struct nvc_contain
+                     !match_jetson_directory_flags(paths[i], cnt->flags))
+                         continue;
+ 
+-                if (path_new(err, src, root) < 0)
++                if (path_new(err, src, JETSON_FROM_ROOT) < 0)
+                         goto fail;
+                 if (path_new(err, dst, cnt->cfg.rootfs) < 0)
+                         goto fail;
+@@ -94,7 +94,7 @@ create_jetson_symlinks(struct error *err, const char *root, const struct nvc_con
+                 if (!match_jetson_symlink_flags(paths[i], cnt->flags))
+                         continue;
+ 
+-                if (path_new(err, src, root) < 0)
++                if (path_new(err, src, JETSON_FROM_ROOT) < 0)
+                         return (-1);
+                 if (path_new(err, dst, cnt->cfg.rootfs) < 0)
+                         return (-1);
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index fd0e60f..4d4d3e7 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -42,7 +42,7 @@ static int lookup_binaries(struct error *, struct nvc_driver_info *, const char
+ static int lookup_ipcs(struct error *, struct nvc_driver_info *, const char *, int32_t);
+ 
+ static int lookup_jetson(struct error *, struct nvc_driver_info *, const char *);
+-static int parse_file(struct error *, const char *, const char *, struct nvc_jetson_info *);
++static int parse_file(struct error *, const char *, const char *, const char *, struct nvc_jetson_info *);
+ static int lookup_jetson_devices(struct error *, struct nvc_jetson_info *, const char *);
+ static int lookup_jetson_dirs(struct error *, struct nvc_jetson_info *, const char *);
+ static int lookup_jetson_libs(struct error *, struct nvc_jetson_info *, const char *);
+@@ -404,13 +404,13 @@ lookup_jetson_libs(struct error *err, struct nvc_jetson_info *info, const char *
+         char path[PATH_MAX];
+ 
+         for (size_t i = 0; i < info->nlibs; ++i) {
+-                if (path_resolve(err, path, root, info->libs[i]) < 0)
++                if (path_resolve(err, path, JETSON_FROM_ROOT, info->libs[i]) < 0)
+                         return (-1);
+ 
+                 free(info->libs[i]);
+                 info->libs[i] = NULL;
+ 
+-                if (select_libraries(err, info, root, NULL, path) < 0) {
++                if (select_libraries(err, info, JETSON_FROM_ROOT, NULL, path) < 0) {
+                         log_infof("missing library %s", path);
+                         continue;
+                 }
+@@ -432,7 +432,7 @@ lookup_jetson_dirs(struct error *err, struct nvc_jetson_info *info, const char *
+         struct stat s;
+ 
+         for (size_t i = 0; i < info->ndirs; ++i) {
+-                if (path_resolve(err, path, root, info->dirs[i]) < 0)
++                if (path_resolve(err, path, JETSON_FROM_ROOT, info->dirs[i]) < 0)
+                         return (-1);
+ 
+                 free(info->dirs[i]);
+@@ -510,7 +510,7 @@ lookup_jetson_devices(struct error *err, struct nvc_jetson_info *info, const cha
+ }
+ 
+ static int
+-parse_file(struct error *err, const char *path, const char *root, struct nvc_jetson_info *jetson)
++parse_file(struct error *err, const char *path, const char *root, const char *nixos_root, struct nvc_jetson_info *jetson)
+ {
+         struct csv ctx;
+         int rv = -1;
+@@ -525,16 +525,16 @@ parse_file(struct error *err, const char *path, const char *root, struct nvc_jet
+         if (csv_parse(&ctx, jetson) < 0)
+                 goto fail;
+ 
+-        if (lookup_jetson_libs(err, jetson, root) < 0)
++        if (lookup_jetson_libs(err, jetson, nixos_root) < 0)
+                 goto fail;
+ 
+-        if (lookup_jetson_dirs(err, jetson, root) < 0)
++        if (lookup_jetson_dirs(err, jetson, nixos_root) < 0)
+                 goto fail;
+ 
+         if (lookup_jetson_devices(err, jetson, root) < 0)
+                 goto fail;
+ 
+-        if (lookup_jetson_symlinks(err, jetson, root) < 0)
++        if (lookup_jetson_symlinks(err, jetson, nixos_root) < 0)
+                 goto fail;
+ 
+         rv = 0;
+@@ -572,7 +572,7 @@ lookup_jetson(struct error *err, struct nvc_driver_info *info, const char *root)
+                 if ((file_info->path = xstrdup(err, files[i])) == NULL)
+                         goto fail;
+ 
+-                if (parse_file(err, files[i], root, &file_info->info) < 0)
++                if (parse_file(err, files[i], root, JETSON_FROM_ROOT, &file_info->info) < 0)
+                         goto fail;
+ 
+                 if ((tmp = jetson_info_append(err, &file_info->info, dst)) == NULL)
+-- 
+2.38.5
+

--- a/modprobe.patch
+++ b/modprobe.patch
@@ -1,0 +1,29 @@
+diff -ruN nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c
+--- nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.c	2020-08-18 12:43:03.223871514 +0000
+@@ -840,10 +840,10 @@
+     return mknod_helper(major, minor_num, vgpu_dev_name, NV_PROC_REGISTRY_PATH);
+ }
+
+-static int nvidia_cap_get_device_file_attrs(const char* cap_file_path,
+-                                            int *major,
+-                                            int *minor,
+-                                            char *name)
++int nvidia_cap_get_device_file_attrs(const char* cap_file_path,
++                                     int *major,
++                                     int *minor,
++                                     char *name)
+ {
+     char field[32];
+     FILE *fp;
+diff -ruN nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h
+--- nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-@modprobeVersion@/modprobe-utils/nvidia-modprobe-utils.h	2020-08-18 12:43:44.227745050 +0000
+@@ -81,6 +81,7 @@
+ int nvidia_nvswitch_get_file_state(int minor);
+ int nvidia_cap_mknod(const char* cap_file_path, int *minor);
+ int nvidia_cap_get_file_state(const char* cap_file_path);
++int nvidia_cap_get_device_file_attrs(const char* cap_file_path, int *major, int *minor, char *name);
+ int nvidia_get_chardev_major(const char *name);
+
+ #endif /* NV_LINUX */

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -173,11 +173,16 @@ in
     };
 
     environment.systemPackages = with pkgs.nvidia-jetpack; [
+      
       l4t-tools
       otaUtils # Tools for UEFI capsule updates
     ];
 
     # Used by libEGL_nvidia.so.0
     environment.etc."egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
+
+    systemd.services.docker.environment = lib.optionalAttrs (config.virtualisation.docker.enableNvidia) {
+      LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.nvidia-jetpack.containers.libnvidia_container0 ];
+    };
   };
 }

--- a/nvc-ldcache.patch
+++ b/nvc-ldcache.patch
@@ -1,0 +1,29 @@
+diff --git a/src/common.h b/src/common.h
+index 015452f..92da1c8 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -20,7 +20,7 @@
+ #define PROC_OVERFLOW_UID         "/proc/sys/kernel/overflowuid"
+ #define PROC_OVERFLOW_GID         "/proc/sys/kernel/overflowgid"
+ 
+-#define LDCACHE_PATH              "/etc/ld.so.cache"
++#define LDCACHE_PATH              "/tmp/ld.so.cache"
+ #define LDCONFIG_PATH             "/sbin/ldconfig"
+ #define LDCONFIG_ALT_PATH         "/sbin/ldconfig.real"
+ 
+diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
+index f2507f8..a4e2dc5 100644
+--- a/src/nvc_ldcache.c
++++ b/src/nvc_ldcache.c
+@@ -331,7 +331,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+         if (validate_args(ctx, cnt != NULL) < 0)
+                 return (-1);
+ 
+-        argv = (char * []){cnt->cfg.ldconfig, cnt->cfg.libs_dir, cnt->cfg.libs32_dir, NULL};
++        argv = (char * []){cnt->cfg.ldconfig, "-C", "/tmp/ld.so.cache", cnt->cfg.libs_dir, cnt->cfg.libs32_dir, NULL};
+         if (*argv[0] == '@') {
+                 /*
+                  * We treat this path specially to be relative to the host filesystem.
+-- 
+2.38.5
+


### PR DESCRIPTION
Fixes #5. I'm very new to Nix and so would appreciate a code style review if that's possible. This is a little closer to 'prototype' than 'good to go' but I figured it'd be worth pushing up regardless as others will likely benefit!

###### Description of changes

After this MR, setting `virtualisation.docker.enableNvidia = true` will work on Jetsons. Unfortunately there are two other flags which need handling:

1. At time of writing the unified cgroup hierarchy is not supported by libnvidia-container, with the standard flags set. Therefore one must add `systemd.enableUnifiedCgroupHierarchy = false` or receive errors. I assume that with nixpkgs changes this will eventually fade.
2. One must also disable the assertion `assertion = cfg.enableNvidia -> config.hardware.opengl.driSupport32Bit or false` which with a big stick could be done by `assertions = lib.mkForce []`. I have a PR for this here: https://github.com/NixOS/nixpkgs/pull/246179 but obviously it will be quite some time before it shows up in stable channels.

###### Testing

Tested on orin-nano. Tested by starting l4t-base, apt installing cuda, compiling samples, and running them (with success results).
