### PR TITLE
otaUtils: patchShebangs

### DIFF
--- a/ota-utils/default.nix
+++ b/ota-utils/default.nix
@@ -23,5 +23,7 @@ stdenvNoCC.mkDerivation {
 
     substituteInPlace $out/bin/ota-check-firmware \
       --replace "@l4tVersion@" "${l4tVersion}"
+
+    patchShebangs $out/bin/*
   '';
 }


### PR DESCRIPTION
###### Description of changes

On my system I’m having the setup-efi-vars unit fail because `bash` is not in the ambient environment (for whatever reason, but that seems like it ought to be otherwise supported anyway.)

Running `patchShebangs` will adjust these with specific references to the interpreter (which has an additonal bonus of maintaining a proper gc reference on the interpreter in question as well)


###### Testing

I built the `.#otaUtils` and inspected the binaries within to ensure that the outputs now have exact `/nix/store` references for the interpreter.