### PR TITLE
kernel: disable tegra-se since it broke LUKS

### DIFF
--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -130,6 +130,10 @@ in pkgsAarch64.buildLinux (args // {
     MD_RAID1 = module;
     MD_RAID10 = module;
     MD_RAID456 = module;
+
+    # TODO: Disable Tegra SE use for now because it causes kernel errors when used
+    # See https://github.com/anduril/jetpack-nixos/issues/114
+    DEV_TEGRA_SE_USE_HOST1X_INTERFACE = no;
   } // (lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix
     # These are the options enabled/disabled by scripts/rt-patch.sh


### PR DESCRIPTION
###### Description of changes

Workaround issue https://github.com/anduril/jetpack-nixos/issues/118 by disabling tegra-se for now. This shifts encryption/decryption for LUKS onto the CPU instead of the security engine (SE), so we lose the performance benefits of offloading this computation onto the SE.

###### Testing

Tested that `luksOpen` with `--perf-no_read_workqueue` and  `--perf-no_write_workqueue` would cause kernel panics on an Orin AGX before this PR--and that those kernel panics do not occur after this PR.
