### PR TITLE
Add additional BSP overlays for L4T35.3.1

### DIFF
--- a/flash-tools.nix
+++ b/flash-tools.nix
@@ -9,9 +9,18 @@
 let
   # This "overlay" can be found here: https://developer.nvidia.com/embedded/jetson-linux-r3521
   # It includes the tegra_v3_oemkey.yaml file which was missing in Jetpack 5.1, and still isn't in Jetpack 5.1.1 :(
-  secureboot_overlay =  fetchzip {
+  secureboot_overlay = fetchzip {
     url = "https://developer.download.nvidia.com/embedded/L4T/r35_Release_v2.1/secureboot_overlay_35.2.1.tbz2";
     sha256 = "sha256-mgtgI/MNTHRbmiJdfg6Nl1ZnEw6Swniaej2/5z/bpoI=";
+  };
+
+  mb1_overlay = fetchzip {
+    url = "https://developer.download.nvidia.com/embedded/L4T/r35_Release_v3.1/mb1_35.3.1_overlay.tbz2";
+    sha256 = "sha256-Ytp3vESEyPPwEXVSVjhCWEglgmK82To605vRbMhjv50=";
+  };
+  usb_overlay = fetchzip {
+    url = "https://developer.download.nvidia.com/embedded/L4T/r35_Release_v3.1/overlay_xusb_35.3.1.tbz2";
+    sha256 = "sha256-3ZH2gPKilZfexg2YdnppDBRSBO0oQVDBkjBl1Iw+iOw=";
   };
 
   flash-tools = stdenv.mkDerivation {
@@ -48,6 +57,11 @@ let
 
       # This file was missing from Jetpack 5.1, and still isn't in Jetpack 5.1.1 :(
       cp ${secureboot_overlay}/bootloader/tegrasign_v3_oemkey.yaml bootloader/
+
+      # Apply additional overlays added after 35.3.1 was released
+      cp ${mb1_overlay}/bootloader/* bootloader/
+      cp ${usb_overlay}/bootloader/* bootloader/
+      chmod u+w -R bootloader
     '' + (lib.optionalString (!stdenv.hostPlatform.isx86) ''
       # Wrap x86 binaries in qemu
       pushd bootloader/ >/dev/null


### PR DESCRIPTION
###### Description of changes

NVIDIA has released these overlays fixing a couple of issues. From their release notes:

- Overlay which fixes a bug related to UART receiving data in the L4T 35.3.1 release.
- This patch fixes an issue with booting Jetson module in an environment with temperature below -20 degree centigrade.


###### Testing

Tested flashing and booting works on Orin NX + devkit, and that the USB firmware is now running version 80.05 instead of 80.03