### PR TITLE
Remove python2 requirement for boardctl

### DIFF
--- a/board-automation.nix
+++ b/board-automation.nix
@@ -1,7 +1,6 @@
 { stdenv
 , bspSrc
 , l4tVersion
-, python2  # python2 is required for boardctl
 , python3  # python3 is required for nvtopo.py
 , makeWrapper
 }:
@@ -14,9 +13,10 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
-    python2
     python3
   ];
+
+  patches = [ ./board-automation.patch ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/board-automation.patch
+++ b/board-automation.patch
@@ -1,0 +1,34 @@
+diff --git a/tools/board_automation/boardctl b/tools/board_automation/boardctl
+index e69cd5b..5ac1f7c 100755
+--- a/tools/board_automation/boardctl
++++ b/tools/board_automation/boardctl
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python2
++#! /usr/bin/env python3
+ # Copyright (c) 2013-2016, NVIDIA CORPORATION.  All Rights Reserved.
+ #
+ # NVIDIA CORPORATION and its licensors retain all intellectual property
+@@ -40,7 +40,7 @@ if __name__ == "__main__":
+ 
+     if options.serial is None and "PMXXX_SERIAL" in os.environ:
+         options.serial = os.environ["PMXXX_SERIAL"]
+-        print >>sys.stderr, "NOTE: Using --serial=%s from environment." % options.serial
++        print(f"NOTE: Using --serial={options.serial} from environment.", file=sys.stderr)
+ 
+     if options.target in pm342_targets:
+         from pm342 import pm342
+@@ -60,7 +60,7 @@ if __name__ == "__main__":
+         exit(1)
+ 
+     if len(args) != 1:
+-        print >>sys.stderr, "Must give a board control command: reset | recovery | usb_{on,off} | recovery_{up,down} | onkey | onkey_{up,down} | power_{on,off} | status"
++        print("Must give a board control command: reset | recovery | usb_{on,off} | recovery_{up,down} | onkey | onkey_{up,down} | power_{on,off} | status", file=sys.stderr)
+         sys.exit(1)
+ 
+     if args[0] == "reset":
+@@ -91,4 +91,4 @@ if __name__ == "__main__":
+         for gpio in sorted([x for x in pmxxx.get_IO_names() if "GPIO" in x]):
+             print(gpio + " is %d" % pmxxx.get_IO(gpio))
+     else:
+-        print >>sys.stderr, "Must give a board control command: reset | recovery | usb_{on,off} | recovery_{up,down} | onkey | power_{on,off} | status"
++        print("Must give a board control command: reset | recovery | usb_{on,off} | recovery_{up,down} | onkey | power_{on,off} | status", file=sys.stderr)


### PR DESCRIPTION
###### Description of changes

- Added patch file to make `boardctl` compatible with Python 3
- Modified `board-automation` derivation to apply the patch and remove the `python2` dependency

###### Testing

```
nix shell github:evenfowler/jetpack-nixos/7ea7eb5a633dfe64f7f2947f91caf2a972d11590#board-automation
boardctl -t topo recovery
```
