### PR TITLE
Expose `taDevKit` in `config.system.build.jetsonDevicePkgs.taDevKit`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ let
     # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
     stdenv = pkgsAarch64.gcc9Stdenv;
     inherit bspSrc l4tVersion;
-  }) buildTOS opteeClient;
+  }) buildTOS buildOpteeTaDevKit opteeClient;
 
   flash-tools = callPackage ./flash-tools.nix {
     inherit bspSrc l4tVersion;
@@ -111,7 +111,7 @@ let
 
   # Packages whose contents are paramterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs.nix {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS opteeClient bspSrc;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient bspSrc;
   };
 
   otaUtils = callPackage ./ota-utils {

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -37,14 +37,6 @@ let
     '';
   });
 
-  uefiDefaultKeysDtbo = runCommand "UefiDefaultSecurityKeys.dtbo" { nativeBuildInputs = [ dtc ]; } ''
-    export pkDefault=$(od -t x1 -An "${cfg.firmware.uefi.secureBoot.defaultPkEslFile}")
-    export kekDefault=$(od -t x1 -An "${cfg.firmware.uefi.secureBoot.defaultKekEslFile}")
-    export dbDefault=$(od -t x1 -An "${cfg.firmware.uefi.secureBoot.defaultDbEslFile}")
-    substituteAll ${./uefi-default-keys.dts} keys.dts
-    dtc -I dts -O dtb keys.dts -o $out
-  '';
-
   # TODO: Unify with fuseScript below
   mkFlashScript = args: import ./flash-script.nix ({
     inherit lib flashArgs partitionTemplate;

--- a/device-pkgs.nix
+++ b/device-pkgs.nix
@@ -1,5 +1,5 @@
 { lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
-  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, opteeClient,
+  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit, opteeClient,
   python3, bspSrc, openssl, dtc,
   l4tVersion,
   pkgsAarch64,
@@ -19,12 +19,14 @@ let
   inherit (cfg.flashScriptOverrides)
     flashArgs fuseArgs partitionTemplate additionalDtbOverlays;
 
-  tosImage = buildTOS {
+  tosArgs = {
     inherit socType;
     inherit (cfg.firmware.optee) taPublicKeyFile;
     opteePatches = cfg.firmware.optee.patches;
     extraMakeFlags = cfg.firmware.optee.extraMakeFlags;
   };
+  tosImage = buildTOS tosArgs;
+  taDevKit = buildOpteeTaDevKit tosArgs;
 
   teeSupplicant = opteeClient.overrideAttrs (old: {
     pname = "tee-supplicant";
@@ -214,5 +216,5 @@ let
 in {
   inherit (tosImage) nvLuksSrv hwKeyAgent;
   inherit mkFlashScript;
-  inherit flashScript initrdFlashScript tosImage teeSupplicant signedFirmware bup fuseScript uefiCapsuleUpdate;
+  inherit flashScript initrdFlashScript tosImage taDevKit teeSupplicant signedFirmware bup fuseScript uefiCapsuleUpdate;
 }

--- a/optee.nix
+++ b/optee.nix
@@ -216,5 +216,5 @@ let
     image;
 in
 {
-  inherit buildTOS opteeClient;
+  inherit buildTOS buildOpteeTaDevKit opteeClient;
 }


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->
    
The TA dev kit is specific per-board and it is necessary for this to be
exposed in order for users to build trusted applications that don't get
built into the OPTEE image.
    
This can be used when building a TA by using the make flag
"TA_DEV_KIT_DIR=${config.system.build.jetsonDevicePkgs.taDevKit}/export-ta_arm64".


###### Testing

Ensured `taDevKit` builds on a nixos system closure for an orin-agx-devkit

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
