### PR TITLE
Build tee-supplicant with a customizable CFG_TEE_PLUGIN_LOAD_PATH

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -36,7 +36,9 @@ let
 
   teeSupplicant = opteeClient.overrideAttrs (old: {
     pname = "tee-supplicant";
-    buildFlags = (old.buildFlags or []) ++ [ "CFG_TEE_CLIENT_LOAD_PATH=${cfg.firmware.optee.clientLoadPath}" ];
+    buildFlags = (old.buildFlags or [])
+      ++ [ "CFG_TEE_CLIENT_LOAD_PATH=${cfg.firmware.optee.clientLoadPath}" ]
+      ++ cfg.firmware.optee.clientExtraMakeFlags;
     # remove unneeded headers
     postInstall = ''
       rm -rf $out/include

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -158,6 +158,14 @@ in
             '';
           };
 
+          clientExtraMakeFlags = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = lib.mdDoc ''
+              Extra make flags to pass OP-TEE's client build.
+           '';
+          };
+
           patches = mkOption {
             type = types.listOf types.path;
             default = [];
@@ -166,6 +174,9 @@ in
           extraMakeFlags = mkOption {
             type = types.listOf types.str;
             default = [];
+            description = lib.mdDoc ''
+              Extra make flags to pass OP-TEE's OS build.
+           '';
           };
 
           taPublicKeyFile = mkOption {


### PR DESCRIPTION
###### Description of changes
Adding a NixOS option for tee-supplicant to modify CFG_TEE_PLUGIN_LOAD_PATH by build time. As an example usage of setting CFG_TEE_PLUGIN_LOAD_PATH:

```
hardware.nvidia-jetpack.firmware.optee.suppPluginLoadPath = pkgs.linkFarm "optee-plugin-path" [
{
    name = "myTeeSupp.plugin";
    path = "myTeeSuppPluginDerivation";
}];
```

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing
Tested on orin-nx-devkit
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
