### PR TITLE
Don't apply formatOptions unless systemd-makefs is not being used

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -110,13 +110,19 @@ in lib.mkMerge [{
   # https://forums.developer.nvidia.com/t/setting-uefi-variables-using-the-defaultvariabledxe-only-works-if-esp-is-on-emmc-but-not-on-an-nvme-drive/250254
   # We don't mount this at /boot, because we still want to allow the user to have their ESP part on NVMe, or whatever else.
   fileSystems."/opt/nvidia/esp" = lib.mkDefault {
-    device = "/dev/disk/by-partlabel/esp";
-    fsType = "vfat";
-    options = [ "nofail" ];
-    # Since we have NO_ESP_IMG=1 while formatting, the script doesn't
-    # actually create an FS here, so we'll do it automatically
-    autoFormat = true;
-    formatOptions = "-F 32 -n ESP";
+    config = {
+      device = "/dev/disk/by-partlabel/esp";
+      fsType = "vfat";
+      options = [ "nofail" ];
+      # Since we have NO_ESP_IMG=1 while formatting, the script doesn't
+      # actually create an FS here, so we'll do it automatically
+      autoFormat = true;
+      formatOptions =
+        if (lib.versionAtLeast config.system.nixos.release "23.05") then
+          null
+        else
+          "-F 32 -n ESP";
+    };
   };
 })
 ]


### PR DESCRIPTION


###### Description of changes

With commit
https://github.com/nixos/nixpkgs/commit/5176a4f11356a338331d82e63563f8510b67317d, the option `fileSystems.<name>.options` will contain an "x-systemd.makefs". Since systemd-makefs does not take any parameters (but has sane defaults and actually uses fat32 for vfat fstype), the `formatOptions` option was made internal only and set to null. Let's set it null here unless systemd-makefs is not being used.

Fixes #105 

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested that the assertion https://github.com/NixOS/nixpkgs/blob/28562b6c75906da822189e6f93bf45768dc04ee6/nixos/modules/tasks/filesystems.nix#L323 does not fail when evaluating a nixos config (using nixpkgs/nixos-unstable) with som xavier-agx and mountFirmwareEsp set to true. Also tested with nixpkgs/nixos-23.05 that formatOptions is a string with the value "-F 32 -n ESP".
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->