### PR TITLE
Add option for changing boot order

### DIFF
--- a/modules/uefi-boot-order.dts
+++ b/modules/uefi-boot-order.dts
@@ -1,0 +1,28 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	overlay-name = "UEFI Boot order";
+
+	fragment@0 {
+		target-path = "/";
+		board_config {
+			sw-modules = "uefi";
+		};
+
+		__overlay__ {
+			firmware {
+				uefi {
+					variables {
+						gNVIDIATokenSpaceGuid {
+							DefaultBootPriority {
+								data = "@bootOrder@";
+								locked;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
###### Description of changes

This change adds a nixos option for changing the default boot order. The option defaults to using the same boot order from
https://github.com/NVIDIA/edk2-nvidia/blob/71fc2f6de48f3e9f01214b4e9464dd03620b876b/Silicon/NVIDIA/Tegra/DeviceTree/L4TConfiguration.dts, which gets applied in the flash script using `additionalDtbOverlays`.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an orin agx devkit

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
