### PR TITLE
Fix multimedia-test executing the wrong binary

### DIFF
--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -265,7 +265,7 @@ let
       ${multimedia-samples}/bin/jpeg_decode num_files 1 ${multimedia-samples}/data/Picture/nvidia-logo.jpg "$WORKDIR"/nvidia-logo.yuv
       echo
       echo " * Running video_decode"
-      ${multimedia-samples}/bin/video_convert H264 --disable-rendering ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264
+      ${multimedia-samples}/bin/video_decode H264 --disable-rendering ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264
       echo
       echo " * Running video_convert"
       ${multimedia-samples}/bin/video_convert "$WORKDIR"/nvidia-logo.yuv 1920 1080 YUV420 "$WORKDIR"/test.yuv 1920 1080 YUYV


### PR DESCRIPTION
###### Description of changes

The multimedia-test package was incorrectly trying to call the `video_convert` binary instead of the `video_decode` binary. 

###### Testing

Ran `multimedia-test` on a Xavier NX machine.