### PR TITLE
Switch flash scripts from openssl to openssl_1_1

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -1,6 +1,6 @@
 { lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
   flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit, opteeClient,
-  python3, bspSrc, openssl, dtc,
+  python3, bspSrc, openssl_1_1, dtc,
   l4tVersion,
   pkgsAarch64,
 }:
@@ -172,7 +172,7 @@ let
   # python ${edk2-jetson}/BaseTools/BinWrappers/PosixLike/GenerateCapsule -v --encode --monotonic-count 1
   # NOTE: providing null public certs here will use the test certs in the EDK2 repo
   uefiCapsuleUpdate = runCommand "uefi-${hostName}-${l4tVersion}.Cap" {
-    nativeBuildInputs = [ python3 openssl ];
+    nativeBuildInputs = [ python3 openssl_1_1 ];
     inherit (cfg.firmware.uefi.capsuleAuthentication) requiredSystemFeatures;
   } (''
     bash ${bspSrc}/generate_capsule/l4t_generate_soc_capsule.sh \

--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, makeWrapper, bzip2_1_1, fetchurl, python3, perl, xxd,
   libxml2, coreutils, gnugrep, gnused, gnutar, gawk, which, gzip, cpio,
   bintools-unwrapped, findutils, util-linux, dosfstools, lz4, gcc, dtc, qemu,
-  runtimeShell, fetchzip, bc, openssl,
+  runtimeShell, fetchzip, bc, openssl_1_1,
 
   bspSrc, l4tVersion,
 }:
@@ -94,7 +94,7 @@ let
     # running
     passthru.flashDeps = [
       coreutils gnugrep gnused gnutar gawk xxd which gzip cpio bintools-unwrapped
-      findutils python3 util-linux dosfstools lz4 bc openssl
+      findutils python3 util-linux dosfstools lz4 bc openssl_1_1
 
       # Needed by bootloader/tegraflash_impl_t234.py
       gcc dtc


### PR DESCRIPTION
###### Description of changes

The flash scripts are typically run on machines where openssl 1.1 is expected. While this doesn't apparently have any functional difference for the standard usage in the flashing scripts, it may affect certain aspects when making modifications to support alternative signing methods.

###### Testing

Built and flashed on a Xavier NX devkit.