### PR TITLE
Add single-variant flash script capability

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -111,7 +111,7 @@ let
 
   # Packages whose contents are parameterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient bspSrc;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient;
   };
 
   otaUtils = callPackage ./pkgs/ota-utils {

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -228,7 +228,8 @@ let
   bup = runCommand "bup-${hostName}-${l4tVersion}" {
     inherit (cfg.firmware.secureBoot) requiredSystemFeatures;
   } ((mkFlashScript {
-    flashCommands = lib.concatMapStringsSep "\n" (v: with v;
+    # TODO: Remove preSignCommands when we switch to using signedFirmware directly
+    flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n" (v: with v;
       "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString flashArgs}"
     ) cfg.firmware.variants;
   }) + ''

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -1,6 +1,6 @@
 { lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
   flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit, opteeClient,
-  python3, bspSrc, openssl_1_1, dtc,
+  python3, openssl_1_1, dtc,
 
   l4tVersion,
   pkgsAarch64,
@@ -245,7 +245,7 @@ let
     inherit (cfg.firmware.uefi.capsuleAuthentication) requiredSystemFeatures;
   } (''
     ${cfg.firmware.uefi.capsuleAuthentication.preSignCommands}
-    bash ${bspSrc}/generate_capsule/l4t_generate_soc_capsule.sh \
+    bash ${flash-tools-patched}/generate_capsule/l4t_generate_soc_capsule.sh \
   '' + (lib.optionalString cfg.firmware.uefi.capsuleAuthentication.enable ''
       --trusted-public-cert ${cfg.firmware.uefi.capsuleAuthentication.trustedPublicCertPemFile} \
       --other-public-cert ${cfg.firmware.uefi.capsuleAuthentication.otherPublicCertPemFile} \

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -243,6 +243,7 @@ let
     nativeBuildInputs = [ python3 openssl_1_1 ];
     inherit (cfg.firmware.uefi.capsuleAuthentication) requiredSystemFeatures;
   } (''
+    ${cfg.firmware.uefi.capsuleAuthentication.preSignCommands}
     bash ${bspSrc}/generate_capsule/l4t_generate_soc_capsule.sh \
   '' + (lib.optionalString cfg.firmware.uefi.capsuleAuthentication.enable ''
       --trusted-public-cert ${cfg.firmware.uefi.capsuleAuthentication.trustedPublicCertPemFile} \

--- a/device-pkgs/flashcmd-script.nix
+++ b/device-pkgs/flashcmd-script.nix
@@ -1,0 +1,19 @@
+{ lib, flash-tools }:
+''
+  set -euo pipefail
+
+  if [[ -z ''${WORKDIR-} ]]; then
+    WORKDIR=$(mktemp -d)
+    function on_exit() {
+      rm -rf "$WORKDIR"
+    }
+    trap on_exit EXIT
+  fi
+
+  cp -r ${flash-tools}/. "$WORKDIR"
+  chmod -R u+w "$WORKDIR"
+  cd "$WORKDIR"
+
+  cd bootloader
+  bash ./flashcmd.txt
+''

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -189,6 +189,12 @@ in
             default = [ ];
             description = "Additional requiredSystemFeatures to add to derivations which make use of secure boot keys";
           };
+
+          preSignCommands = lib.mkOption {
+            type = types.lines;
+            default = "";
+            description = "Additional commands to run before performing operation that involve signing. Can be used to set up environment to interact with an external HSM.";
+          };
         };
 
         # Firmware variants. For most normal usage, you shouldn't need to set this option
@@ -248,6 +254,12 @@ in
         partitionTemplate = mkOption {
           type = types.path;
           description = ".xml file describing partition template to use when flashing";
+        };
+
+        patches = mkOption {
+          type = types.listOf types.path;
+          default = [];
+          description = "Patches to apply to the flash-tools";
         };
 
         postPatch = mkOption {

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -118,6 +118,12 @@ in
                 make use of capsule authentication private keys.
               '';
             };
+
+            preSignCommands = lib.mkOption {
+              type = types.lines;
+              default = "";
+              description = "Additional commands to run before performing operation that involve signing. Can be used to set up environment to interact with an external HSM.";
+            };
           };
         };
 


### PR DESCRIPTION
###### Description of changes

If there is only a single jetson variant, we can produce a flash script
that doesn't need to detect the variant befor flashing. This can make it
so we don't need access to signing keys when performing the flashing
step. (They could, for instance, be available via `extra-sandbox-paths`
on the Nix builder machine.

Using this feature does, however, require specifying the variant
(boardsku, etc.) in the NixOS configuration, which is not always
immediately obvious.

Additionally, adds a new option `preSignCommands` which can be used to
set up the environment to enable the signature part to work.

###### Testing

Flashed a Xavier AGX devkit using a single-variant flash script