### PR TITLE
fix(initrdFlash): lib.getExe path to rcm-boot script (instead of dire…

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -183,11 +183,11 @@ let
   in writeShellApplication {
     name = "initrd-flash-${hostName}";
     text = ''
-      ${mkRcmBootScript {
+      ${lib.getExe (mkRcmBootScript {
         kernelPath = "${config.boot.kernelPackages.kernel}/Image";
         initrdPath = initrd;
         kernelCmdline = "initrd=initrd console=ttyTCU0,115200";
-      }}
+      })}
       echo
       echo "Jetson device should now be flashing and will reboot when complete."
       echo "You may watch the progress of this on the device's serial port"


### PR DESCRIPTION
###### Description of changes

`writteShellApplication` places the executable in something like `$NIX_STORE_ROOT/<hash>-<name>-<version>/bin/<name>` (cf. https://github.com/NixOS/nixpkgs/blob/90e85bc7c1a6fc0760a94ace129d3a1c61c3d035/pkgs/build-support/trivial-builders/default.nix#L348) . The `initrdFlashScript` was apparently written/intended/designed to call the shell application defined by `mkRcmBootScript {... }` but it only pointed to `$NIX_STORE_ROOT/<hash>-<name>-<version>` (the `$out` folder instead of the executable).

We have used `lib.getExe` in this PR to resolve the path to the executable instead of to the folder.

###### Testing

We have used this patch to build and flashing script that points to an executable path which exists in our `nix` store :smile:  .
