### PR TITLE
OP-TEE: PKCS#11 support and xtest

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ let
     # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
     stdenv = pkgsAarch64.gcc9Stdenv;
     inherit bspSrc l4tVersion;
-  }) buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta;
+  }) buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta opteeXtest;
 
   flash-tools = callPackage ./pkgs/flash-tools {
     inherit bspSrc l4tVersion;
@@ -111,7 +111,7 @@ let
 
   # Packages whose contents are parameterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta opteeXtest;
   };
 
   otaUtils = callPackage ./pkgs/ota-utils {

--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ let
     # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
     stdenv = pkgsAarch64.gcc9Stdenv;
     inherit bspSrc l4tVersion;
-  }) buildTOS buildOpteeTaDevKit opteeClient;
+  }) buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta;
 
   flash-tools = callPackage ./pkgs/flash-tools {
     inherit bspSrc l4tVersion;
@@ -111,7 +111,7 @@ let
 
   # Packages whose contents are parameterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient buildOpteePKCS11Ta;
   };
 
   otaUtils = callPackage ./pkgs/ota-utils {

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -2,6 +2,7 @@
   flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit, opteeClient,
   python3, openssl_1_1, dtc,
   buildOpteePKCS11Ta,
+  opteeXtest,
   l4tVersion,
   pkgsAarch64,
 }:
@@ -35,11 +36,14 @@ let
   tosImage = buildTOS tosArgs;
   taDevKit = buildOpteeTaDevKit tosArgs;
   opteePKCS11Ta = buildOpteePKCS11Ta tosArgs;
+  xtest = opteeXtest tosArgs;
 
   teeSupplicant = opteeClient.overrideAttrs (old:
     let
       taPaths = lib.strings.removeSuffix ":" (
         lib.optionalString cfg.firmware.optee.pkcs11support "${opteePKCS11Ta}:"
+        +
+        lib.optionalString cfg.firmware.optee.xtest "${xtest}:"
         +
         (lib.concatMapStrings (x: x + ":") cfg.firmware.optee.clientLoadPath));
     in {
@@ -282,5 +286,5 @@ in {
   inherit (tosImage) nvLuksSrv hwKeyAgent;
   inherit mkFlashScript mkFlashCmdScript mkFlashScriptAuto;
   inherit flashScript initrdFlashScript tosImage taDevKit teeSupplicant signedFirmware bup fuseScript uefiCapsuleUpdate;
-  inherit mkRcmBootScript rcmBoot opteePKCS11Ta;
+  inherit mkRcmBootScript rcmBoot opteePKCS11Ta xtest;
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -163,10 +163,17 @@ in
       wantedBy = [ "multi-user.target" ];
     };
 
-    systemd.services.tee-supplicant = {
+    systemd.services.tee-supplicant = let
+      supplicantArgs = lib.escapeShellArgs
+        (cfg.firmware.optee.supplicantArgs.extraArgs
+        ++
+        # "optee_armtz" is hardcode into optee client source code.
+        (if cfg.firmware.optee.supplicantArgs.taDir == "optee_armtz" then []
+         else [ "--ta-dir=${cfg.firmware.optee.supplicantArgs.taDir}" ]));
+    in {
       description = "Userspace supplicant for OPTEE-OS";
       serviceConfig = {
-        ExecStart = "${config.hardware.nvidia-jetpack.devicePkgs.teeSupplicant}/bin/tee-supplicant ${lib.escapeShellArgs cfg.firmware.optee.supplicantExtraArgs}";
+        ExecStart = "${config.hardware.nvidia-jetpack.devicePkgs.teeSupplicant}/bin/tee-supplicant ${supplicantArgs}";
         Restart = "always";
       };
       wantedBy = [ "multi-user.target" ];

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -182,7 +182,7 @@ in
     environment.systemPackages = with pkgs.nvidia-jetpack; [
       l4t-tools
       otaUtils # Tools for UEFI capsule updates
-    ];
+    ] ++ lib.optional cfg.firmware.optee.xtest config.hardware.nvidia-jetpack.devicePkgs.xtest;
 
     # Used by libEGL_nvidia.so.0
     environment.etc."egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -128,12 +128,27 @@ in
         };
 
         optee = {
-          supplicantExtraArgs = mkOption {
-            type = types.listOf types.str;
-            default = [];
-            description = lib.mdDoc ''
-              Extra arguments to pass to tee-supplicant.
-            '';
+          supplicantArgs = {
+
+            taDir = mkOption {
+              type = types.str;
+              default = "optee_armtz";
+              description = lib.mdDoc ''
+                Passes --ta-dir argument to tee-supplicant. Default
+                value is from optee's client source code. "optee_armtz"
+                is partially hardcoded. NOTE: If default changed, it
+                need to be changed also systemd.services.tee-supplicant!
+              '';
+            };
+
+            extraArgs = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = lib.mdDoc ''
+                Extra arguments to pass to tee-supplicant.
+                NOTE: use for --ta-dir optee.supplicantArgs.taDir
+              '';
+            };
           };
 
           clientLoadPath = mkOption {

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -171,6 +171,14 @@ in
             '';
           };
 
+          xtest = mkOption {
+            type = types.bool;
+            default = false;
+            description = lib.mdDoc ''
+              Adds OP-TEE's xtest and related TA/Plugins
+            '';
+          };
+
           patches = mkOption {
             type = types.listOf types.path;
             default = [];

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -163,6 +163,14 @@ in
             '';
           };
 
+          pkcs11support = mkOption {
+            type = types.bool;
+            default = false;
+            description = lib.mdDoc ''
+              Adds OP-TEE's PKCS#11 TA.
+            '';
+          };
+
           patches = mkOption {
             type = types.listOf types.path;
             default = [];

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -137,13 +137,14 @@ in
           };
 
           clientLoadPath = mkOption {
-            type = types.path;
-            default = "/var/lib/optee";
+            type = types.listOf types.path;
+            default = [];
             description = lib.mdDoc ''
-              The path tee-supplicant will use to search for trusted
+              The path(s) tee-supplicant will use to search for trusted
               applications. Note that trusted applications must be placed in
               the TA directory (specified with tee-supplicant's --ta-dir flag),
-              under this load path.
+              under this load path. Default TA directory is optee_armtz. For
+              clarification: <tee-supplicant search dir>/optee_armtz.
             '';
           };
 


### PR DESCRIPTION
###### Description of changes
OP-TEE has a support for PKCS#11, but currently OP-TEE's PKCS#11 support is not working within Jetpack-nixos project due it is missing required [PKCS#11 TA](https://github.com/OP-TEE/optee_os/tree/master/ta/pkcs11). This pull request adds PKCS#11 derivation and option for enabling it. 

Also OP-TEE project has a sanity testsuite (xtest). Pull request adds xtest derivation and option for enabling it.

###### Testing
Pull request tested on orin-nx-devkit. As a test result then two xtests are failing: 1033 and 4016_ed25519. 

- 1033: Tests optee's plugin framework. Test fail due default plugin load path points to "/usr/lib/tee-supplicant/plugins/". Possible fixes are disabling plugin framework, pass an extra argument to tee-supplicant (--plugin-path) or copy manually required files into required location.
- 4016_ed25519: Uses uninitialized variable. Fix Requires this [commit](https://github.com/OP-TEE/optee_os/commit/e4c24b7f9f1afbdd7a48766007cf0055b4b8df6b).


