### PR TITLE
Fixed crypto engine option typo

### DIFF
--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -137,7 +137,7 @@ in pkgsAarch64.buildLinux (args // {
 
     # TODO: Disable Tegra SE use for now because it causes kernel errors when used
     # See https://github.com/anduril/jetpack-nixos/issues/114
-    DEV_TEGRA_SE_USE_HOST1X_INTERFACE = no;
+    CRYPTO_DEV_TEGRA_SE_USE_HOST1X_INTERFACE = no;
   } // (lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix
     # These are the options enabled/disabled by scripts/rt-patch.sh


### PR DESCRIPTION
###### Description of changes

The `CRYPTO_DEV_TEGRA_SE_USE_HOST1X_INTERFACE` option has a typo so it ends up not working. This PR changes it to the correct name

###### Testing

After the fix, LUKS filesystem no longer exhibits the `free cmd buf` error