### PR TITLE
Use CLI flags for tee-supplicant load paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -111,7 +111,7 @@ let
 
   # Packages whose contents are parameterized by NixOS configuration
   devicePkgsFromNixosConfig = callPackage ./device-pkgs {
-    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit opteeClient;
+    inherit l4tVersion pkgsAarch64 flash-tools flashFromDevice edk2-jetson uefi-firmware buildTOS buildOpteeTaDevKit;
   };
 
   otaUtils = callPackage ./pkgs/ota-utils {
@@ -136,6 +136,8 @@ in rec {
 
   inherit edk2-jetson uefi-firmware;
   inherit otaUtils;
+
+  inherit opteeClient;
 
   # TODO: Source packages. source_sync.sh from bspSrc
   # GST plugins

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -1,5 +1,5 @@
 { lib, callPackage, runCommand, writeScript, writeShellApplication, makeInitrd, makeModulesClosure,
-  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit, opteeClient,
+  flashFromDevice, edk2-jetson, uefi-firmware, flash-tools, buildTOS, buildOpteeTaDevKit,
   python3, openssl, dtc,
 
   l4tVersion,
@@ -33,15 +33,6 @@ let
   };
   tosImage = buildTOS tosArgs;
   taDevKit = buildOpteeTaDevKit tosArgs;
-
-  teeSupplicant = opteeClient.overrideAttrs (old: {
-    pname = "tee-supplicant";
-    buildFlags = (old.buildFlags or []) ++ [ "CFG_TEE_CLIENT_LOAD_PATH=${cfg.firmware.optee.clientLoadPath}" ];
-    # remove unneeded headers
-    postInstall = ''
-      rm -rf $out/include
-    '';
-  });
 
   # TODO: Unify with fuseScript below
   mkFlashScript = args: import ./flash-script.nix ({
@@ -273,6 +264,6 @@ let
 in {
   inherit (tosImage) nvLuksSrv hwKeyAgent;
   inherit mkFlashScript mkFlashCmdScript mkFlashScriptAuto;
-  inherit flashScript initrdFlashScript tosImage taDevKit teeSupplicant signedFirmware bup fuseScript uefiCapsuleUpdate;
+  inherit flashScript initrdFlashScript tosImage taDevKit signedFirmware bup fuseScript uefiCapsuleUpdate;
   inherit mkRcmBootScript rcmBoot;
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -2,15 +2,22 @@
 
 let
   inherit (lib)
-    mkDefault
     mkEnableOption
-    mkForce
     mkIf
     mkOption
-    mkOptionDefault
     types;
 
   cfg = config.hardware.nvidia-jetpack;
+
+  teeApplications = pkgs.symlinkJoin {
+    name = "tee-applications";
+    paths = cfg.firmware.optee.trustedApplications;
+  };
+
+  supplicantPlugins = pkgs.symlinkJoin {
+    name = "tee-supplicant-plugins";
+    paths = cfg.firmware.optee.supplicantPlugins;
+  };
 in
 {
   imports = [
@@ -120,14 +127,15 @@ in
     hardware.opengl.extraPackages = with pkgs.nvidia-jetpack; [
       l4t-cuda
       l4t-nvsci # cuda may use nvsci
-      l4t-gbm l4t-wayland
+      l4t-gbm
+      l4t-wayland
     ];
 
     # libGLX_nvidia.so.0 complains without this
     hardware.opengl.setLdLibraryPath = true;
 
     services.udev.packages = [
-      (pkgs.runCommand "jetson-udev-rules" {} ''
+      (pkgs.runCommand "jetson-udev-rules" { } ''
         install -D -t $out/etc/udev/rules.d ${pkgs.nvidia-jetpack.l4t-init}/etc/udev/rules.d/99-tegra-devices.rules
         sed -i \
           -e '/camera_device_detect/d' \
@@ -163,14 +171,22 @@ in
       wantedBy = [ "multi-user.target" ];
     };
 
-    systemd.services.tee-supplicant = {
-      description = "Userspace supplicant for OPTEE-OS";
-      serviceConfig = {
-        ExecStart = "${config.hardware.nvidia-jetpack.devicePkgs.teeSupplicant}/bin/tee-supplicant ${lib.escapeShellArgs cfg.firmware.optee.supplicantExtraArgs}";
-        Restart = "always";
+    systemd.services.tee-supplicant =
+      let
+        args = lib.escapeShellArgs ([
+          "--ta-path=${teeApplications}"
+          "--plugin-path=${supplicantPlugins}"
+        ]
+        ++ cfg.firmware.optee.supplicantExtraArgs);
+      in
+      {
+        description = "Userspace supplicant for OPTEE-OS";
+        serviceConfig = {
+          ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
+          Restart = "always";
+        };
+        wantedBy = [ "multi-user.target" ];
       };
-      wantedBy = [ "multi-user.target" ];
-    };
 
     environment.systemPackages = with pkgs.nvidia-jetpack; [
       l4t-tools

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -141,31 +141,20 @@ in
         optee = {
           supplicantExtraArgs = mkOption {
             type = types.listOf types.str;
-            default = [];
+            default = [ ];
             description = lib.mdDoc ''
               Extra arguments to pass to tee-supplicant.
             '';
           };
 
-          clientLoadPath = mkOption {
-            type = types.path;
-            default = "/var/lib/optee";
-            description = lib.mdDoc ''
-              The path tee-supplicant will use to search for trusted
-              applications. Note that trusted applications must be placed in
-              the TA directory (specified with tee-supplicant's --ta-dir flag),
-              under this load path.
-            '';
-          };
-
           patches = mkOption {
             type = types.listOf types.path;
-            default = [];
+            default = [ ];
           };
 
           extraMakeFlags = mkOption {
             type = types.listOf types.str;
-            default = [];
+            default = [ ];
           };
 
           taPublicKeyFile = mkOption {
@@ -176,6 +165,25 @@ in
               verifying loaded runtime TAs. If not provided, TAs are verified
               with the public key derived from the private key in optee's
               source tree.
+            '';
+          };
+
+          trustedApplications = mkOption {
+            type = types.listOf types.package;
+            default = [ ];
+            description = lib.mdDoc ''
+              Trusted applications that will be loaded into the TEE on
+              supplicant startup.
+            '';
+          };
+
+          supplicantPlugins = mkOption {
+            type = types.listOf types.package;
+            default = [ ];
+            description = lib.mdDoc ''
+              A list of packages containing TEE supplicant plugins. TEE
+              supplicant will load each plugin file in the top level of each
+              package on startup.
             '';
           };
         };

--- a/pkgs/optee/default.nix
+++ b/pkgs/optee/default.nix
@@ -8,6 +8,7 @@
 , libuuid
 , dtc
 , nukeReferences
+, fetchpatch
 }:
 
 let
@@ -27,10 +28,25 @@ let
     pname = "optee_client";
     version = l4tVersion;
     src = nvopteeSrc;
-    patches = [ ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch ];
+    patches = [
+      ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch
+      (fetchpatch {
+        name = "tee-supplicant-Allow-for-TA-load-path-to-be-specified-at-runtime.patch";
+        url = "https://github.com/OP-TEE/optee_client/commit/f3845d8bee3645eedfcc494be4db034c3c69e9ab.patch";
+        stripLen = 1;
+        extraPrefix = "optee/optee_client/";
+        hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
+      })
+    ];
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libuuid ];
-    makeFlags = [ "-C optee/optee_client" "DESTDIR=$(out)" "SBINDIR=/bin" "LIBDIR=/lib" "INCLUDEDIR=/include" ];
+    makeFlags = [
+      "-C optee/optee_client"
+      "DESTDIR=$(out)"
+      "SBINDIR=/sbin"
+      "LIBDIR=/lib"
+      "INCLUDEDIR=/include"
+    ];
     meta.platforms = [ "aarch64-linux" ];
   };
 


### PR DESCRIPTION
###### Description of changes


Add a patch for specifying TA load path and plugin load path at the time of running tee-supplicant instead of being fixed at compile time. Also moves `opteeClient` out of `jetsonDevicePkgs` as it is not a board-specific package.

Based on changes from https://github.com/OP-TEE/optee_client/pull/365.


<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an orin-agx-devkit with the hello_world TA and syslog plugin from https://github.com/linaro-swg/optee_examples.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
