### PR TITLE
fix: update SRI hashes for fetchpatch2 FODs

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -65,13 +65,13 @@ let
     patches = edk2NvidiaPatches ++ [
       (fetchpatch2 {
         url = "https://github.com/NVIDIA/edk2-nvidia/commit/9604259b0d11c049f6a3eb5365a3ae10cfb9e6d9.patch";
-        hash = "sha256-IfnTrQnkxFXbeHDfmQd4Umpbp9MKZI1OKi7H1Ujg8K8=";
+        hash = "sha256-wUJJLc8ijrVVm5HQGA7gTRJl7VI5LXkH18+f7m82S6o=";
       })
       # Fix Eqos driver to use correct TX clock name
       # PR: https://github.com/NVIDIA/edk2-nvidia/pull/76
       (fetchpatch2 {
         url = "https://github.com/NVIDIA/edk2-nvidia/commit/26f50dc3f0f041d20352d1656851c77f43c7238e.patch";
-        hash = "sha256-nDqLJIfTii/O2KM1yLzvXIpmu5h35PEw7DTSu1CJuDA=";
+        hash = "sha256-L+aCiGXntapsNqSkLm4NrDgH5Hx4ZP/CqOu3R41PaB0=";
       })
 
       ./capsule-authentication.patch

--- a/pkgs/uefi-firmware/edk2-openssl-patches.nix
+++ b/pkgs/uefi-firmware/edk2-openssl-patches.nix
@@ -55,11 +55,10 @@
     url = "https://github.com/tianocore/edk2/commit/d79295b5c57fddfff207c5c97d70ba6de635e17a.patch";
     hash = "sha256-wJrQsvcwQbCptl58YMyi5dokFjoWKoqy08dYyszy9a0=";
   })
-
   # CryptoPkg/Library/OpensslLib: Add generated flag to Accel INF
   (fetchpatch2 {
     url = "https://github.com/tianocore/edk2/commit/0882d6a32d3db7c506823c317dc2f756d30f6a91.patch";
-    hash = "sha256-H59qcKYv72vMsROKImHPncEFBermt1Jchcxj0T6hDdI=";
+    hash = "sha256-H59qcKYv72vMsROKImHPncEFBermt1Jchcxj0T6hDdI";
   })
 
   # CryptoPkg/Library/OpensslLib: update auto-generated files


### PR DESCRIPTION
###### Description of changes

I failed to build `uefi-firmware` because some of these hashes were wrong. It's possible that GitHub changed the [patch content slightly](https://github.com/NixOS/nixpkgs/blob/e8e29778437cc426514b7f664a2535201c64a316/pkgs/build-support/fetchpatch/default.nix#L3C1-L4). `fetchpatch` (vs. `fetchpatch2`) [can avoid instability](https://github.com/NixOS/nixpkgs/blob/274793192aa6a0859ac99101b4f7408c351a3b80/pkgs/top-level/all-packages.nix#L1120) in certain `git` portions of the patch file (`index`, `diff --git`, etc.) but unfortunately `fetchpatch` [does not support file renames](https://github.com/NixOS/nixpkgs/issues/32084) so patches like https://github.com/tianocore/edk2/commit/ea6d859b50b692577c4ccbeac0fb8686fad83a6e.patch (in https://github.com/johnrichardrinehart/jetpack-nixos/blob/5acff7ab88f0fa7a511a107f55ebf219ab3e661e/pkgs/uefi-firmware/edk2-openssl-patches.nix#L31) will silently skip the rename (i.e. the source won't have the expected file that may later need to be patched which would cause subsequent patches to fail with a "file not found" kind of error). Since these patches _do_ contain renames which later patches expect were applied a switch to using `fetchpatch` for all patches would, unfortunately, not work. It would be possible to change only some patches to use `fetchpatch` to increase robustness. But, it's simpler to only fix those patches whose hash has changed.

Worth noting is that GitHub [supports a URL query parameter](https://github.com/orgs/community/discussions/46034#discussioncomment-4846112) called `full_index` which acts like `--full-index` for `git diff`. I'm not sure about other `git` interfaces (`cgit`, `GitLab`, `BitBucket`, etc.). If it would be preferable to change all URLs to take advantage of this undocumented feature of GitHub's API then I'm happy to make that change.