### PR TITLE
Lower priority of tegra-se crypto modules

### DIFF
--- a/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
+++ b/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
@@ -1,7 +1,7 @@
-From bd2377c95029b7086bd6037d59825dca7239aada Mon Sep 17 00:00:00 2001
+From f8b3221fd6c6b3e18c5bac8d2c75e13bfba65458 Mon Sep 17 00:00:00 2001
 From: Ilya Leoshkevich <iii@linux.ibm.com>
 Date: Wed, 19 Oct 2022 10:56:00 +0200
-Subject: [PATCH 1/7] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
+Subject: [PATCH 1/8] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
 
 commit db16c1fe92d7ba7d39061faef897842baee2c887  upstream.
 
@@ -48,5 +48,5 @@ index 6eded325c837..779fde480a99 100755
  	# Create ${2} which contains just .BTF section but no symbols. Add
  	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
+++ b/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
@@ -1,7 +1,7 @@
-From 43e4f3cb5539c9a49133c29aea08167c9237b2c0 Mon Sep 17 00:00:00 2001
+From b2e3bf9aa750b790af9b5c64b24298dfdcf91a52 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Wed, 19 Oct 2022 10:56:01 +0200
-Subject: [PATCH 2/7] kbuild: Quote OBJCOPY var to avoid a pahole call break
+Subject: [PATCH 2/8] kbuild: Quote OBJCOPY var to avoid a pahole call break
  the build
 
 commit ff2e6efda0d5c51b33e2bcc0b0b981ac0a0ef214 upstream.
@@ -66,5 +66,5 @@ index 779fde480a99..94c548b11db9 100755
  	# Create ${2} which contains just .BTF section but no symbols. Add
  	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
+++ b/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
@@ -1,7 +1,7 @@
-From 55c152e451446598f17206ab84b2e5263dd0417a Mon Sep 17 00:00:00 2001
+From 24dad852ed692e9d7d53075cc20ac6060fa0cf7b Mon Sep 17 00:00:00 2001
 From: Andrii Nakryiko <andrii@kernel.org>
 Date: Wed, 19 Oct 2022 10:56:02 +0200
-Subject: [PATCH 3/7] kbuild: skip per-CPU BTF generation for pahole
+Subject: [PATCH 3/8] kbuild: skip per-CPU BTF generation for pahole
  v1.18-v1.21
 
 commit a0b8200d06ad6450c179407baa5f0f52f8cfcc97 upstream.
@@ -53,5 +53,5 @@ index 94c548b11db9..55bcfa85873c 100755
  	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
  
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
+++ b/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
@@ -1,7 +1,7 @@
-From dbf548b1489179a23f6b969404037121ccf682a7 Mon Sep 17 00:00:00 2001
+From bd1fbfdcc5bb92ac3b1bcf2ff259e2085d3181a7 Mon Sep 17 00:00:00 2001
 From: Jiri Olsa <jolsa@redhat.com>
 Date: Wed, 19 Oct 2022 10:56:03 +0200
-Subject: [PATCH 4/7] kbuild: Unify options for BTF generation for vmlinux and
+Subject: [PATCH 4/8] kbuild: Unify options for BTF generation for vmlinux and
  modules
 
 commit 9741e07ece7c247dd65e1aa01e16b683f01c05a8 upstream.
@@ -102,5 +102,5 @@ index 000000000000..27445cb72974
 +
 +echo ${extra_paholeopt}
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
+++ b/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
@@ -1,7 +1,7 @@
-From 2a6b382808025b054b5449dd4f8cba649d628ac9 Mon Sep 17 00:00:00 2001
+From 55112f49a9d87ed1eaac070f5be1f6b633984176 Mon Sep 17 00:00:00 2001
 From: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
 Date: Wed, 19 Oct 2022 10:56:04 +0200
-Subject: [PATCH 5/7] kbuild: Add skip_encoding_btf_enum64 option to pahole
+Subject: [PATCH 5/8] kbuild: Add skip_encoding_btf_enum64 option to pahole
 
 New pahole (version 1.24) generates by default new BTF_KIND_ENUM64 BTF tag,
 which is not supported by stable kernel.
@@ -41,5 +41,5 @@ index 27445cb72974..8c82173e42e5 100755
 +
  echo ${extra_paholeopt}
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
+++ b/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
@@ -1,7 +1,7 @@
-From 538e7a31b33cfafbeddf2f8113001fce57861dea Mon Sep 17 00:00:00 2001
+From 87524d1ea292f599c33b1b9fd55dc1f45f8119bf Mon Sep 17 00:00:00 2001
 From: Jiri Olsa <jolsa@kernel.org>
 Date: Wed, 6 Jan 2021 00:42:19 +0100
-Subject: [PATCH 6/7] tools/resolve_btfids: Warn when having multiple IDs for
+Subject: [PATCH 6/8] tools/resolve_btfids: Warn when having multiple IDs for
  single type
 
 The kernel image can contain multiple types (structs/unions)
@@ -89,5 +89,5 @@ index f32c059fbfb4..c3f808a393d1 100644
  	}
  
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0007-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch
+++ b/kernel/0007-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch
@@ -1,7 +1,7 @@
-From 4da238a5d4227f31465d1d7e951bd51bb9610cc3 Mon Sep 17 00:00:00 2001
+From 4a5b247af99c2d5da5d0a6720f8a535947ce57ac Mon Sep 17 00:00:00 2001
 From: Antonio Borneo <antonio.borneo@st.com>
 Date: Wed, 25 Nov 2020 00:07:56 +0100
-Subject: [PATCH 7/7] net: phy: realtek: read actual speed on rtl8211f to
+Subject: [PATCH 7/8] net: phy: realtek: read actual speed on rtl8211f to
  detect downshift
 
 The rtl8211f supports downshift and before commit 5502b218e001
@@ -39,5 +39,5 @@ index 7c38f7fbb2e4..118c6028229b 100644
  		.config_intr	= &rtl8211f_config_intr,
  		.get_wol	= &rtl8211f_get_wol,
 -- 
-2.40.1
+2.39.1
 

--- a/kernel/0008-Lower-priority-of-tegra-se-crypto.patch
+++ b/kernel/0008-Lower-priority-of-tegra-se-crypto.patch
@@ -1,0 +1,267 @@
+From b826a540a67d9a097dfd0d3d546f6af98a3a4f2a Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <dfullmer@anduril.com>
+Date: Sat, 18 Nov 2023 21:33:53 -0800
+Subject: [PATCH 8/8] Lower priority of tegra-se crypto
+
+It is far too flaky and slow to be useful.  I get approximately 150MB/s
+when benchmarking encryption with AES-CBC using this module, while I get
+over 2000MB/s with just the ARMv8 AES extensions.
+
+Multiple crashes have been reported on the Jetson forums over the course
+of years and there is still no resolution.
+
+For example, when using dm-crypt, we see:
+> [ 1058.429722] BUG: scheduling while atomic: swapper/6/0/0x00000100
+which happens in tegra_se_aes_queue_req because it uses mutexes while
+being called from the kcryptd tasklet.
+
+Additionally, we see:
+> [  329.008351] tegra-se-nvhost 15820000.se: Couldn't get free cmdbuf
+
+We don't entirely disable this module because nvpmodel on certain
+devices expects this driver to be loaded so it can set the SE frequency.
+---
+ nvidia/drivers/crypto/tegra-se-nvhost.c | 52 ++++++++++++-------------
+ 1 file changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/nvidia/drivers/crypto/tegra-se-nvhost.c b/nvidia/drivers/crypto/tegra-se-nvhost.c
+index 62e005da3dab..9b7c360a7048 100644
+--- a/nvidia/drivers/crypto/tegra-se-nvhost.c
++++ b/nvidia/drivers/crypto/tegra-se-nvhost.c
+@@ -6392,7 +6392,7 @@ static struct aead_alg aead_algs[] = {
+ 		.base = {
+ 			.cra_name	= "ccm(aes)",
+ 			.cra_driver_name = "ccm-aes-tegra",
+-			.cra_priority	= 1000,
++			.cra_priority	= 1,
+ 			.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+ 			.cra_ctxsize	= sizeof(struct tegra_se_aes_ccm_ctx),
+ 			.cra_module	= THIS_MODULE,
+@@ -6410,7 +6410,7 @@ static struct aead_alg aead_algs[] = {
+ 		.base = {
+ 			.cra_name	= "gcm(aes)",
+ 			.cra_driver_name = "gcm-aes-tegra",
+-			.cra_priority	= 1000,
++			.cra_priority	= 1,
+ 			.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+ 			.cra_ctxsize	= sizeof(struct tegra_se_aes_gcm_ctx),
+ 			.cra_module	= THIS_MODULE,
+@@ -6428,7 +6428,7 @@ static struct kpp_alg dh_algs[] = {
+ 	.base = {
+ 		.cra_name = "dh",
+ 		.cra_driver_name = "tegra-se-dh",
+-		.cra_priority = 300,
++		.cra_priority = 1,
+ 		.cra_module = THIS_MODULE,
+ 		.cra_ctxsize = sizeof(struct tegra_se_dh_context),
+ 		}
+@@ -6443,7 +6443,7 @@ static struct rng_alg rng_algs[] = {
+ 		.base = {
+ 			.cra_name = "rng_drbg",
+ 			.cra_driver_name = "rng_drbg-aes-tegra",
+-			.cra_priority = 100,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_RNG,
+ 			.cra_ctxsize = sizeof(struct tegra_se_rng_context),
+ 			.cra_module = THIS_MODULE,
+@@ -6457,7 +6457,7 @@ static struct skcipher_alg aes_algs[] = {
+ 	{
+ 		.base.cra_name		= "xts(aes)",
+ 		.base.cra_driver_name	= "xts-aes-tegra",
+-		.base.cra_priority	= 500,
++		.base.cra_priority	= 1,
+ 		.base.cra_flags		= CRYPTO_ALG_TYPE_SKCIPHER |
+ 					  CRYPTO_ALG_ASYNC,
+ 		.base.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+@@ -6476,7 +6476,7 @@ static struct skcipher_alg aes_algs[] = {
+ 	{
+ 		.base.cra_name		= "cbc(aes)",
+ 		.base.cra_driver_name	= "cbc-aes-tegra",
+-		.base.cra_priority	= 500,
++		.base.cra_priority	= 1,
+ 		.base.cra_flags		= CRYPTO_ALG_TYPE_SKCIPHER |
+ 					  CRYPTO_ALG_ASYNC,
+ 		.base.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+@@ -6495,7 +6495,7 @@ static struct skcipher_alg aes_algs[] = {
+ 	{
+ 		.base.cra_name		= "ecb(aes)",
+ 		.base.cra_driver_name	= "ecb-aes-tegra",
+-		.base.cra_priority	= 500,
++		.base.cra_priority	= 1,
+ 		.base.cra_flags		= CRYPTO_ALG_TYPE_SKCIPHER |
+ 					  CRYPTO_ALG_ASYNC,
+ 		.base.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+@@ -6514,7 +6514,7 @@ static struct skcipher_alg aes_algs[] = {
+ 	{
+ 		.base.cra_name		= "ctr(aes)",
+ 		.base.cra_driver_name	= "ctr-aes-tegra",
+-		.base.cra_priority	= 500,
++		.base.cra_priority	= 1,
+ 		.base.cra_flags		= CRYPTO_ALG_TYPE_SKCIPHER |
+ 					  CRYPTO_ALG_ASYNC,
+ 		.base.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+@@ -6533,7 +6533,7 @@ static struct skcipher_alg aes_algs[] = {
+ 	{
+ 		.base.cra_name		= "ofb(aes)",
+ 		.base.cra_driver_name	= "ofb-aes-tegra",
+-		.base.cra_priority	= 500,
++		.base.cra_priority	= 1,
+ 		.base.cra_flags		= CRYPTO_ALG_TYPE_SKCIPHER |
+ 					  CRYPTO_ALG_ASYNC,
+ 		.base.cra_blocksize	= TEGRA_SE_AES_BLOCK_SIZE,
+@@ -6566,7 +6566,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "cmac(aes)",
+ 			.cra_driver_name = "tegra-se-cmac(aes)",
+-			.cra_priority = 500,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = TEGRA_SE_AES_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_aes_cmac_context),
+@@ -6588,7 +6588,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha1",
+ 			.cra_driver_name = "tegra-se-sha1",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA1_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6610,7 +6610,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha224",
+ 			.cra_driver_name = "tegra-se-sha224",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA224_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6632,7 +6632,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha256",
+ 			.cra_driver_name = "tegra-se-sha256",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA256_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6654,7 +6654,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha384",
+ 			.cra_driver_name = "tegra-se-sha384",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA384_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6676,7 +6676,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha512",
+ 			.cra_driver_name = "tegra-se-sha512",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA512_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6698,7 +6698,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha3-224",
+ 			.cra_driver_name = "tegra-se-sha3-224",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_224_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6720,7 +6720,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha3-256",
+ 			.cra_driver_name = "tegra-se-sha3-256",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_256_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6742,7 +6742,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha3-384",
+ 			.cra_driver_name = "tegra-se-sha3-384",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_384_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6764,7 +6764,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "sha3-512",
+ 			.cra_driver_name = "tegra-se-sha3-512",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_512_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6786,7 +6786,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "shake128",
+ 			.cra_driver_name = "tegra-se-shake128",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_512_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6808,7 +6808,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "shake256",
+ 			.cra_driver_name = "tegra-se-shake256",
+-			.cra_priority = 300,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA3_512_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6831,7 +6831,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "hmac(sha224)",
+ 			.cra_driver_name = "tegra-se-hmac-sha224",
+-			.cra_priority = 500,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA224_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6854,7 +6854,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "hmac(sha256)",
+ 			.cra_driver_name = "tegra-se-hmac-sha256",
+-			.cra_priority = 500,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA256_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6877,7 +6877,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "hmac(sha384)",
+ 			.cra_driver_name = "tegra-se-hmac-sha384",
+-			.cra_priority = 500,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA384_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6900,7 +6900,7 @@ static struct ahash_alg hash_algs[] = {
+ 		.halg.base = {
+ 			.cra_name = "hmac(sha512)",
+ 			.cra_driver_name = "tegra-se-hmac-sha512",
+-			.cra_priority = 500,
++			.cra_priority = 1,
+ 			.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 			.cra_blocksize = SHA512_BLOCK_SIZE,
+ 			.cra_ctxsize = sizeof(struct tegra_se_sha_context),
+@@ -6924,7 +6924,7 @@ static struct akcipher_alg rsa_alg = {
+ 	.base = {
+ 		.cra_name = "rsa-pka0",
+ 		.cra_driver_name = "tegra-se-pka0-rsa",
+-		.cra_priority = 300,
++		.cra_priority = 1,
+ 		.cra_ctxsize = sizeof(struct tegra_se_aes_rsa_context),
+ 		.cra_module = THIS_MODULE,
+ 	}
+-- 
+2.39.1
+

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -81,6 +81,8 @@ in pkgsAarch64.buildLinux (args // {
     # PHY used on Xavier NX
     { patch = ./0007-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch; }
 
+    # Lower priority of tegra-se crypto modules since they're slow and flaky
+    { patch = ./0008-Lower-priority-of-tegra-se-crypto.patch; }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {
@@ -134,10 +136,6 @@ in pkgsAarch64.buildLinux (args // {
     MD_RAID1 = module;
     MD_RAID10 = module;
     MD_RAID456 = module;
-
-    # TODO: Disable Tegra SE use for now because it causes kernel errors when used
-    # See https://github.com/anduril/jetpack-nixos/issues/114
-    CRYPTO_DEV_TEGRA_SE_USE_HOST1X_INTERFACE = no;
   } // (lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix
     # These are the options enabled/disabled by scripts/rt-patch.sh


### PR DESCRIPTION
###### Description of changes

Switched from disabling the tegra-se kernel module to lowering priority of the tegra-se crypto.  nvpmodel fails on certain devices if it cannot set the frequency of the se engine--which is exposed by the kernel module.

###### Testing

Tested LUKS encryption works on all device types.