### PR TITLE
Switch fetchpatch2 to "fetchgitpatch"

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, buildPackages, fetchFromGitHub, fetchpatch2, runCommand, edk2, acpica-tools,
-  dtc, python3, bc, imagemagick, unixtools, applyPatches, nukeReferences,
+{ lib, stdenv, buildPackages, fetchFromGitHub, fetchpatch, fetchpatch2,
+  runCommand, edk2, acpica-tools, dtc, python3, bc, imagemagick, unixtools,
+  applyPatches, nukeReferences,
   l4tVersion,
 
   # Optional path to a boot logo that will be converted and cropped into the format required
@@ -63,15 +64,15 @@ let
       sha256 = "sha256-Qh1g+8a7ZcFG4VmwH+xDix6dpZ881HaNRE/FJoaRljw=";
     };
     patches = edk2NvidiaPatches ++ [
-      (fetchpatch2 {
+      (fetchpatch {
         url = "https://github.com/NVIDIA/edk2-nvidia/commit/9604259b0d11c049f6a3eb5365a3ae10cfb9e6d9.patch";
-        hash = "sha256-IfnTrQnkxFXbeHDfmQd4Umpbp9MKZI1OKi7H1Ujg8K8=";
+        hash = "sha256-v/WEwcSNjBXeN0eXVzzl31dn6mq78wIm0u5lW1jGcdE=";
       })
       # Fix Eqos driver to use correct TX clock name
       # PR: https://github.com/NVIDIA/edk2-nvidia/pull/76
-      (fetchpatch2 {
+      (fetchpatch {
         url = "https://github.com/NVIDIA/edk2-nvidia/commit/26f50dc3f0f041d20352d1656851c77f43c7238e.patch";
-        hash = "sha256-nDqLJIfTii/O2KM1yLzvXIpmu5h35PEw7DTSu1CJuDA=";
+        hash = "sha256-cc+eGLFHZ6JQQix1VWe/UOkGunAzPb8jM9SXa9ScIn8=";
       })
 
       ./capsule-authentication.patch

--- a/pkgs/uefi-firmware/edk2-openssl-patches.nix
+++ b/pkgs/uefi-firmware/edk2-openssl-patches.nix
@@ -1,85 +1,101 @@
 # Patches from upstream tianocore/edk2 to enable build of OpenSSL 1.1.1t inside
 # edk2 tree
-{fetchpatch2}:
+{ fetchpatch2 }:
+let
+  # Needs to use fetchpatch2 to handle "git extended headers", which include
+  # lines with semantic content like "rename from" and "rename to".
+  # However, it also includes "index" lines which include the git revision(s) the patch was initially created from.
+  # These lines may include revisions of differing length, based on how Github generates them.
+  # fetchpatch2 does not filter out, but probably should
+  fetchgitpatch = args: fetchpatch2 (args // {
+    postFetch = (args.postFetch or "") + ''
+      sed -i \
+        -e '/^index /d' \
+        -e '/^similarity index /d' \
+        -e '/^dissimilarity index /d' \
+        $out
+    '';
+  });
+in
 [
   # CryptoPkg/OpensslLib: Add native instruction support for IA32
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/03f708090b9da25909935e556c351a4d9445fd3f.patch";
-    hash = "sha256-kWTzzQjGJdYzoaMckReUQHl5IkpHFApG9zRVQRavbAE=";
+    hash = "sha256-nSAhWxYWzTYJYtk0GhuwKSngSXp2R7NboZ3Qs7ETHos=";
   })
 
   # CryptoPkg/OpensslLib: Commit the auto-generated assembly files for IA32
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/4102950a21dc726239505b8f7b8e017b6e9175ec.patch";
     hash = "sha256-DaqMQJN9axlXVF3QM2MPhzRh0yq8WuWLDg3El+lIN+M=";
   })
 
   # CryptoPkg/OpensslLib: Update generated files for native X64
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/a8e8c43a0ef25af133dc5ef1021befd897f71b12.patch";
-    hash = "sha256-4tD8AR78fYXFCcHHAgEYiSjcYFxdoObykNNocIuq1ac=";
+    hash = "sha256-o7xXCRw3eT4LGpgvDeO6ZCBim4+XWJYaUyPwLIcTf4Q=";
   })
 
   # CryptoPkg: Add LOONGARCH64 architecture for EDK2 CI.
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/c5f4b4fd03c9d8e2ba9bfa0e13065f4dc2be474e.patch";
-    hash = "sha256-dXQdHDJzkWy0vOpXQHNPGQus3ATvKnsSq0yriidy5hY=";
+    hash = "sha256-2cTMGRX78z+HPTz2yl/RTiJK+Ze2lu0QkKvqtVZuTYU=";
   })
 
   # CryptoPkg/Library/OpensslLib: Combine all performance optimized INFs
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/ea6d859b50b692577c4ccbeac0fb8686fad83a6e.patch";
-    hash = "sha256-XyF1+wBxy1nQhaPDDjNj1voHRvHd+IbkRiq1TOJwn1g=";
+    hash = "sha256-7uiubCI51L6LrmYzesKF4p/xCC6dsVR3M2h1H337/zw=";
   })
 
   # CryptoPkg/Library/OpensslLib: Produce consistent set of APIs
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/e75951ca896ee2146f2133d2dc425e2d21861e6b.patch";
-    hash = "sha256-3RAXVbm/rjbGKpnaYqoqY33rl8nyy80lsBBdBt7yXKo=";
+    hash = "sha256-bxV1hZ1c+i+CgZE1LsJy82pLgcMDq3Kkv4peZZDHZXE=";
   })
 
   # CryptoPkg/Library/OpensslLib: Remove PrintLib from INF files
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/a57b4c11a51d9c313735b3af5c69cc371c74e11f.patch";
-    hash = "sha256-Q9NAWwSa7uqXnFVmtk5s9YEpe8FdXJM70PLwTweKaVk=";
+    hash = "sha256-jM8/Nngzw5qFsLJQzKSJHQC8vP1Vdk1kHotVfq/NzGc=";
   })
 
   # Revert "CryptoPkg: Update process_files.pl to auto add PCD config option"
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/3b46a1e24339b03f04be80ebf21d03fd98c490de.patch";
-    hash = "sha256-L26HBzuQQVLHLSo9tPF7qSdMRaUSDmmWlvSeZE2S4tU=";
+    hash = "sha256-CX4O1lmHrGnJi9AChKh5hFC4sJikdcLCwOdG9/drwUk=";
   })
 
   # CryptoPkg/Library/OpensslLib: Update process_files.pl INF generation
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/d79295b5c57fddfff207c5c97d70ba6de635e17a.patch";
-    hash = "sha256-wJrQsvcwQbCptl58YMyi5dokFjoWKoqy08dYyszy9a0=";
+    hash = "sha256-oHPFcny1eS1kLNwGUPhXaLpOsBIQxy76tkKgM7QJ7yU=";
   })
 
   # CryptoPkg/Library/OpensslLib: Add generated flag to Accel INF
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/0882d6a32d3db7c506823c317dc2f756d30f6a91.patch";
-    hash = "sha256-H59qcKYv72vMsROKImHPncEFBermt1Jchcxj0T6hDdI=";
+    hash = "sha256-XbH4N/sKs6aJ6IfFYdy2f2T8mX1/QIuukeSrRxAYL2w=";
   })
 
   # CryptoPkg/Library/OpensslLib: update auto-generated files
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/4fcd5d2620386c039aa607ae5ed092624ad9543d.patch";
-    hash = "sha256-Uhwyuu0q0oPvKF0zFW/D8dAYOJ/2YyEG3pfVQH9khkc=";
+    hash = "sha256-yI4nd3j+QqpIqENFg1qyi5KtKv8DEkh3XrvYw3oS2xo=";
   })
 
   # CryptoPkg/OpensslLib: Upgrade OpenSSL to 1.1.1t
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/4ca4041b0dbb310109d9cb047ed428a0082df395.patch";
-    hash = "sha256-XPCqfQQekvxF33Q/QEkj14Zpxf/s+caNyQlSfNzwuD0=";
+    hash = "sha256-w6+5xunP9PcShkLFXBldMq/U5bcs2VfTjvIYoedIyWg=";
     excludes = [
       "CryptoPkg/Library/OpensslLib/openssl"
     ];
   })
 
   # CryptoPkg/Library: add -Wno-unused-but-set-variable for openssl
-  (fetchpatch2 {
+  (fetchgitpatch {
     url = "https://github.com/tianocore/edk2/commit/410ca0ff94a42ee541dd6ceab70ea974eeb7e500.patch";
-    hash = "sha256-WMKSIgYEaNNVcXD3UCp38YQU8qy63uBHDexl4+3c9LM=";
+    hash = "sha256-hmWkWTj6J1uhXKXynBWda455buTmbnB4GMu2+2sPYxY=";
   })
 ]


### PR DESCRIPTION
###### Description of changes

Create and use `fetchgitpatch` instead of  `fetchpatch2`.  Like `fetchpatch2`, `fetchgitpatch` saves the "git extended headers", except it filters out  "index" lines that may change based on what Github outputs for us.

Done as an alternative to https://github.com/anduril/jetpack-nixos/pull/157.

###### Testing

Built `uefi-firmware`