### PR TITLE
Prepare for cuda_compat usage: make libnvrm* available in /run/opengl-driver

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -118,6 +118,11 @@ in
 
     hardware.opengl.package = pkgs.nvidia-jetpack.l4t-3d-core;
     hardware.opengl.extraPackages = with pkgs.nvidia-jetpack; [
+      # l4t-core provides the libnvrm_gpu.so and libnvrm_mem.so, which are
+      # otherwise missing when using cuda_compat for the time being. Ideally,
+      # they should probably be directly set in a DT_NEEDED entry, as is the
+      # case currently with the `libcuda.so` provided by l4t-cuda
+      l4t-core
       l4t-cuda
       l4t-nvsci # cuda may use nvsci
       l4t-gbm l4t-wayland


### PR DESCRIPTION
# Cuda compatibility drivers

## Motivation

This commit is a prerequisite to automatically use `cuda_compat` and get forward-compatible CUDA drivers on Jetson devices. Typically, it is currently not possible to run a CUDA 12 application with the vanilla setting of jetpack-nixos, since latest Jetpack only ships with CUDA 11.4 drivers. With this PR and the companion Nixpkgs one (https://github.com/NixOS/nixpkgs/pull/267247), I am able to run `cudaPackages_12_0.saxpy` (a hello world CUDA application) with CUDA 12:

```console
$ nix build .#cudaPackages_12_0.saxpy
[..]
$ ./result/bin/saxpy 
Start
Runtime version: 12000
Driver version: 12000
Host memory initialized, copying to the device
Scheduled a cudaMemcpy, calling the kernel
Scheduled a kernel call
Max error: 0.000000
```

## Context

The CUDA compatibility package simply ships a new `libcuda.so` (and variants) that must be used in place of the original driver. Nvidia's recommended way is to use `LD_LIBRARY_PATH`; while it works (although it needs some tweaks on jetpack-nixos), this is both manual work and not very Nixy. The point of this PR and the Nixpkgs PR is to make `cuda_compat`'s `libcuda.so` accessible to CUDA applications (and have precedence over the driver in `/run/opengl-driver`) _automatically and by default_, so that `cuda_compat` is always used when available. Indeed, using `cuda_compat` strictly increases the set of compatible CUDA versions, without known drawbacks.

## Issue

On jetpack-nixos, some libraries required by the `cuda_compat` driver aren't found. Those are libraries libnvrm_xxx. This PR aims at fixing this.

## Content

Further inspection shows that the standard jetson driver has them available `DT_RUNPATH` which points to `l4t-core`:

```console
$ ldd /run/opengl-driver/lib/libcuda.so | grep libnvrm
[..]
libnvrm_gpu.so => /nix/store/ycrfym7ckcbz6vghriijdfan84dc4iz3-nvidia-l4t-core-35.3.1-20230319081403/lib/libnvrm_gpu.so (0x0000ffff9aaa0000)
libnvrm_mem.so => /nix/store/ycrfym7ckcbz6vghriijdfan84dc4iz3-nvidia-l4t-core-35.3.1-20230319081403/lib/libnvrm_mem.so (0x0000ffff9aa70000)

$ readelf -d /run/opengl-driver/lib/libcuda.so
[..]
 0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/ycrfym7ckcbz6vghriijdfan84dc4iz3-nvidia-l4t-core-35.3.1-20230319081403/lib]
[..]
 0x0000000000000001 (NEEDED)             Shared library: [libnvrm_gpu.so]
 0x0000000000000001 (NEEDED)             Shared library: [libnvrm_mem.so]
[..]
```

In an ideal world, we would the same thing for the `cuda_compat` driver. A difficutly is that the `l4t-core` package is provided by jetpack-nixos (through processed `.deb` packages), while `cuda_compat` is provided by upstream Nixpkgs. Thus, cross-referencing the two would either need to make l4t packages provided by jetpack-nixos available in Nixpkgs, or wait for the companion Nixpkgs PR to be merged, to land in a NixOS release, and to update jetpack-nixos to be compatible with this release. The timeline for doing so isn't obvious.

In the meantime, this PR proposes a simple and working solution: make the missing libnvrm libs available in `/run/opengl-driver`, and thus to the cuda_compat's driver by adding `l4t-core` to the list `hardware.opengl.extraPackages`. Indeed, `/run/opengl-driver` is prepended to any core CUDA library or CUDA package that requires the CUDA driver in Nixpkgs already. This includes `cuda_compat`.

This solution shouldn't impact people who don't use `cuda_compat`: it just makes a bunch of additional CUDA driver-related libs available in `/run/opengl-driver`.

## Testing

As mentioned in the introduction, this PR was tested in conjunction with the companion Nixpkgs PR, and was able to build and run `cudaPackages_12_0.saxpy` successfully.
