### PR TITLE
Don't set LD_LIBRARY_PATH

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -131,9 +131,6 @@ in
       l4t-wayland
     ];
 
-    # libGLX_nvidia.so.0 complains without this
-    hardware.opengl.setLdLibraryPath = true;
-
     services.udev.packages = [
       (pkgs.runCommand "jetson-udev-rules" { } ''
         install -D -t $out/etc/udev/rules.d ${pkgs.nvidia-jetpack.l4t-init}/etc/udev/rules.d/99-tegra-devices.rules

--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -104,10 +104,17 @@ let
   l4t-cuda = buildFromDeb {
     name = "nvidia-l4t-cuda";
     buildInputs = [ l4t-core ];
+
     postPatch = ''
       # Additional libcuda symlinks
       ln -sf libcuda.so.1.1 lib/libcuda.so.1
       ln -sf libcuda.so.1.1 lib/libcuda.so
+    '';
+
+    # libcuda.so actually depends on libnvcucompat.so at runtime (probably
+    # through `dlopen`), so we need to tell Nix about this.
+    postFixup = ''
+        patchelf --add-needed libnvcucompat.so $out/lib/libcuda.so
     '';
   };
 


### PR DESCRIPTION
# Don't set LD_LIBRARY_PATH

## Motivation

The initial motivation is for future support of `cuda_compat`. `cuda_compat` needs to take precedence over the current driver. It is achieved in https://github.com/NixOS/nixpkgs/pull/267247 by prepending the right path to CUDA libraries' `DT_RUNPATH`, so that `libcuda.so` is searched in `cuda_compat` first.

However, jetpack-nixos currently sets `LD_LIBRARY_PATH` to `/run/opengl-driver`. This prevent the Nixpkgs `cuda_compat` PR to work, because `LD_LIBRARY_PATH` takes precedence over `DT_RUNPATH`. Beside `cuda_compat`, it's probably best to not set `LD_LIBRARY_PATH` if we can avoid it, as it short-circuits most of other dynamic libraries loading mechanisms.

## Context

A comment in jetpack-nixos mentions that setting `LD_LIBRARY_PATH` is required for `libGLX_nvidia.so.0` to work (or to not complain). By any chance, would any reviewer have more information on that?

On the jetson, unsetting `LD_LIBRARY_PATH` (or, equivalently, using this PR) doesn't seem to case any issue to `ldd` (and we can indeed see that it doesn't pick the dependencies from `/run/opengl-driver ` anymore, but can find them directly in the store):

```console
$ echo $LD_LIBRARY_PATH

$ ldd /nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0
ldd: warning: you do not have execution permission for `/nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0'
	linux-vdso.so.1 (0x0000ffff92ce6000)
	libnvidia-glsi.so.35.3.1 => /nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libnvidia-glsi.so.35.3.1 (0x0000ffff92aa0000)
	libnvidia-tls.so.35.3.1 => /nix/store/ycrfym7ckcbz6vghriijdfan84dc4iz3-nvidia-l4t-core-35.3.1-20230319081403/lib/libnvidia-tls.so.35.3.1 (0x0000ffff92a80000)
	[...etc: a first gauge to see if any library is not found, doesn't seem to be the case...]

$ ldd /nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0 | grep "not found"
ldd: warning: you do not have execution permission for `/nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0'
```

The follwoing checks that the transitive dependencies don't have missing libs either. The only lib that aren't picked by this command are `/nix/store/r0aclnvj3xz61pqvdbd4l57z714ybywa-glibc-2.35-224/lib/ld-linux-aarch64.so.1` and `linux-vdso.so.1` which aren't related to the matter at hand:

```console
$ ldd /nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0 | cut -f3 -d" " | xargs ldd | grep "not found"
ldd: warning: you do not have execution permission for `/nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libGLX_nvidia.so.0'
ldd: warning: you do not have execution permission for `/nix/store/vl7jvh572swjsll0hrarb2967jc44lhk-nvidia-l4t-3d-core-35.3.1-20230319081403/lib/libnvidia-glsi.so.35.3.1'
[...and many other such warnings, but no actual output...]

$
```

It seems that there is no consequence on the Jetson Orin to unsetting `LD_LIBRARY_PATH`. I've rebooted the Jetson with the new configuration, and checked that the `cuda_compat`-enabled `saxpy` still runs, and everything seems to work.

The elephant in the room: the Orin doesn't have a working X server, so I might just not trigger the issue in the first place. In that case, what platform could be considered to test this change? Even if it turns out `libGLX_nvidia.so.0` needs some libraries from `/run/opengl-driver` on other carrier boards, can't we just patch its `DT_RUNPATH` field via Nixpkgs `add-opengl-runtime-path` (as it is done with other CUDA packages), instead of resorting to `LD_LIBRARY_PATH`?

## Content

This PR simply removes the line setting `hardware.opengl.setLdLibraryPath` to `true`.

## Testing

Tested on the Jetson Orin AGX.