### PR TITLE
uefi-firmware: fix edk2 build against NixOS 23.11

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, buildPackages, fetchFromGitHub, fetchpatch, fetchpatch2,
   runCommand, edk2, acpica-tools, dtc, python3, bc, imagemagick, unixtools,
+  libuuid,
   applyPatches, nukeReferences,
   l4tVersion,
 
@@ -115,6 +116,8 @@ let
 
   edk2-jetson = edk2.overrideAttrs (prev: {
     src = edk2-src;
+
+    depsBuildBuild = prev.depsBuildBuild ++ [ libuuid ];
 
     patches =
       # Remove this one patch (CryptoPkg/OpensslLib: Upgrade OpenSSL to 1.1.1t)


### PR DESCRIPTION
###### Description of changes

uefi-firmware stopped building with NixOS 23.11, as util-linux (which includes libuuid) was removed from the depsBuildBuild of the edk2-package. Add libuuid to the depsBuildBuild, which then fixes the issue related to `-luuid`.

###### Testing

Tested by flashing on Orin AGX and Orin NX. Tested that the build works against NixOS 22.05, 23.05 and 23.11