### PR TITLE
Fix edk2 build for 23.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673957332,
-        "narHash": "sha256-njH7Szk1BLVWGMw7IRibgGejSlxXHj9saZHfH20gHdk=",
+        "lastModified": 1701952659,
+        "narHash": "sha256-TJv2srXt6fYPUjxgLAL0cy4nuf1OZD4KuA1TrCiQqg0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b83e7f5a04a3acc8e92228b0c4bae68933d504eb",
+        "rev": "b4372c4924d9182034066c823df76d6eaf1f4ec4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
   };
 
   outputs = { self, nixpkgs, ... }@inputs: let

--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -116,6 +116,10 @@ let
   edk2-jetson = edk2.overrideAttrs (prev: {
     src = edk2-src;
 
+    depsBuildBuild = (prev.depsBuildBuild or []) ++ [
+      buildPackages.libuuid
+    ];
+
     patches =
       # Remove this one patch (CryptoPkg/OpensslLib: Upgrade OpenSSL to 1.1.1t)
       # present on nixos-23.05, as it will be added in the opensslPatches below


### PR DESCRIPTION
###### Description of changes
This seems to be fine upstream: https://github.com/NixOS/nixpkgs/commit/ff3adab3708ec2f8ce2e4b7316e3c8f4456da638

However, we aren't using tianocore sources, and the this fails with our current sources.

###### Testing

```
nix build .#legacyPackages.x86_64-linux.edk2-jetson
```
