### PR TITLE
Allow for disabling tee-supplicant

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,12 +11,12 @@ let
 
   teeApplications = pkgs.symlinkJoin {
     name = "tee-applications";
-    paths = cfg.firmware.optee.trustedApplications;
+    paths = cfg.firmware.optee.supplicant.trustedApplications;
   };
 
   supplicantPlugins = pkgs.symlinkJoin {
     name = "tee-supplicant-plugins";
-    paths = cfg.firmware.optee.supplicantPlugins;
+    paths = cfg.firmware.optee.supplicant.plugins;
   };
 
   nvidiaContainerRuntimeActive = with config.virtualisation; (docker.enable && docker.enableNvidia) || (podman.enable && podman.enableNvidia);
@@ -219,9 +219,9 @@ in
           "--ta-path=${teeApplications}"
           "--plugin-path=${supplicantPlugins}"
         ]
-        ++ cfg.firmware.optee.supplicantExtraArgs);
+        ++ cfg.firmware.optee.supplicant.extraArgs);
       in
-      {
+      lib.mkIf cfg.firmware.optee.supplicant.enable {
         description = "Userspace supplicant for OPTEE-OS";
         serviceConfig = {
           ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -17,6 +17,9 @@ in
     (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "bootloader" "debugMode" ] [ "hardware" "nvidia-jetpack" "firmware" "uefi" "debugMode" ])
     (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "bootloader" "errorLevelInfo" ] [ "hardware" "nvidia-jetpack" "firmware" "uefi" "errorLevelInfo" ])
     (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "bootloader" "edk2NvidiaPatches" ] [ "hardware" "nvidia-jetpack" "firmware" "uefi" "edk2NvidiaPatches" ])
+    (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "firmware" "optee" "supplicantExtraArgs" ] [ "hardware" "nvidia-jetpack" "firmware" "optee" "supplicant" "extraArgs" ])
+    (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "firmware" "optee" "trustedApplications" ] [ "hardware" "nvidia-jetpack" "firmware" "optee" "supplicant" "trustedApplications" ])
+    (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "firmware" "optee" "supplicantPlugins" ] [ "hardware" "nvidia-jetpack" "firmware" "optee" "supplicant" "plugins" ])
   ];
 
   options = {
@@ -139,12 +142,35 @@ in
         };
 
         optee = {
-          supplicantExtraArgs = mkOption {
-            type = types.listOf types.str;
-            default = [ ];
-            description = lib.mdDoc ''
-              Extra arguments to pass to tee-supplicant.
-            '';
+          supplicant = {
+            enable = mkEnableOption "tee-supplicant daemon" // { default = true; };
+
+            extraArgs = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = lib.mdDoc ''
+                Extra arguments to pass to tee-supplicant.
+              '';
+            };
+
+            trustedApplications = mkOption {
+              type = types.listOf types.package;
+              default = [ ];
+              description = lib.mdDoc ''
+                Trusted applications that will be loaded into the TEE on
+                supplicant startup.
+              '';
+            };
+
+            plugins = mkOption {
+              type = types.listOf types.package;
+              default = [ ];
+              description = lib.mdDoc ''
+                A list of packages containing TEE supplicant plugins. TEE
+                supplicant will load each plugin file in the top level of each
+                package on startup.
+              '';
+            };
           };
 
           patches = mkOption {
@@ -165,25 +191,6 @@ in
               verifying loaded runtime TAs. If not provided, TAs are verified
               with the public key derived from the private key in optee's
               source tree.
-            '';
-          };
-
-          trustedApplications = mkOption {
-            type = types.listOf types.package;
-            default = [ ];
-            description = lib.mdDoc ''
-              Trusted applications that will be loaded into the TEE on
-              supplicant startup.
-            '';
-          };
-
-          supplicantPlugins = mkOption {
-            type = types.listOf types.package;
-            default = [ ];
-            description = lib.mdDoc ''
-              A list of packages containing TEE supplicant plugins. TEE
-              supplicant will load each plugin file in the top level of each
-              package on startup.
             '';
           };
         };


### PR DESCRIPTION

###### Description of changes

Add an `enable` option for tee-supplicant, but retain the current behavior of enabling it by default. This should remove some attack surface of devices that don't need tee-supplicant but have an optee instance running that is not configured to verify signatures of TAs at runtime. 

Also organize tee-supplicant related options into the `supplicant` attrset.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
