### PR TITLE
Fix eval: Rework some option types to not be nullOr

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -51,18 +51,23 @@ in
       };
 
       som = mkOption {
-        default = null;
         # You can add your own som or carrierBoard by merging the enum type
         # with additional possibilies in an external NixOS module. See:
         # "Extensible option types" in the NixOS manual
-        type = types.nullOr (types.enum [ "orin-agx" "orin-nx" "orin-nano" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ]);
-        description = "Jetson SoM (System-on-Module) to target. Can be null to target a generic jetson device, but some things may not work.";
+        # The "generic" value signals that jetpack-nixos should try to maximize compatility across all varisnts. This may lead
+        type = types.enum [ "generic" "orin-agx" "orin-nx" "orin-nano" "xavier-agx" "xavier-nx" "xavier-nx-emmc" ];
+        default = "generic";
+        description = lib.mdDoc ''
+          Jetson SoM (System-on-Module) to target. Can be set to "generic" to target a generic jetson device, but some things may not work.
+        '';
       };
 
       carrierBoard = mkOption {
-        default = null;
-        type = types.nullOr (types.enum [ "devkit" ]);
-        description = "Jetson carrier board to target.";
+        type = types.enum [ "generic" "devkit" ];
+        default = "generic";
+        description = lib.mdDoc ''
+          Jetson carrier board to target. Can be set to "generic" to target a generic jetson carrier board, but some things may not work.
+        '';
       };
 
       kernel.realtime = mkOption {

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -18,7 +18,7 @@ let
     xavier-nx-emmc = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_t194_p3668.conf";
   };
 
-  nvfancontrolConf = rec {
+  nvfancontrolConf = {
     orin-agx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3701_0000.conf";
     orin-nx = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
     orin-nano = "${pkgs.nvidia-jetpack.l4t-nvfancontrol}/etc/nvpower/nvfancontrol/nvfancontrol_p3767_0000.conf";
@@ -28,11 +28,11 @@ let
   };
 in lib.mkMerge [{
   # Turn on nvpmodel if we have a config for it.
-  services.nvpmodel.enable = mkIf (cfg.som != null && nvpModelConf ? "${cfg.som}") (mkDefault true);
-  services.nvpmodel.configFile = mkIf (cfg.som != null && nvpModelConf ? "${cfg.som}") (mkDefault nvpModelConf.${cfg.som});
+  services.nvpmodel.enable = mkIf (nvpModelConf ? "${cfg.som}") (mkDefault true);
+  services.nvpmodel.configFile = mkIf (nvpModelConf ? "${cfg.som}") (mkDefault nvpModelConf.${cfg.som});
 
   # Set fan control service if we have a config for it
-  services.nvfancontrol.configFile = mkIf (cfg.som != null && nvfancontrolConf ? "${cfg.som}") (mkDefault nvfancontrolConf.${cfg.som});
+  services.nvfancontrol.configFile = mkIf (nvfancontrolConf ? "${cfg.som}") (mkDefault nvfancontrolConf.${cfg.som});
   # Enable the fan control service if it's a devkit
   services.nvfancontrol.enable = mkIf (cfg.carrierBoard == "devkit") (mkDefault true);
 


### PR DESCRIPTION
###### Description of changes

We were implicitly using the "null" value on the som and carrierBoard options as a way to specify that the values were unset and that jetpack-nixos should try to maximize compatibility acroos all types (with caveats that this may not always include all features). Now, we just have a separate "generic" value that we can use to represent this. It's easier to work with since we don't need to have "!= null" checks everywhere.

###### Testing

`nix flake check` for eval also ran internal graphics tests successfully .
