### PR TITLE
kernel: fix gcc 13 compilation failure

### DIFF
--- a/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
+++ b/kernel/0001-bpf-Generate-BTF_KIND_FLOAT-when-linking-vmlinux.patch
@@ -1,7 +1,7 @@
-From f8b3221fd6c6b3e18c5bac8d2c75e13bfba65458 Mon Sep 17 00:00:00 2001
+From 1fd7a7022e1cde2e53771c027c46aa515bb0e7ee Mon Sep 17 00:00:00 2001
 From: Ilya Leoshkevich <iii@linux.ibm.com>
 Date: Wed, 19 Oct 2022 10:56:00 +0200
-Subject: [PATCH 1/8] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
+Subject: [PATCH 1/9] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
 
 commit db16c1fe92d7ba7d39061faef897842baee2c887  upstream.
 
@@ -48,5 +48,5 @@ index 6eded325c837..779fde480a99 100755
  	# Create ${2} which contains just .BTF section but no symbols. Add
  	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
+++ b/kernel/0002-kbuild-Quote-OBJCOPY-var-to-avoid-a-pahole-call-brea.patch
@@ -1,7 +1,7 @@
-From b2e3bf9aa750b790af9b5c64b24298dfdcf91a52 Mon Sep 17 00:00:00 2001
+From d79c689d5d1f3250c8aa85b15de8393e55c5b91f Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Wed, 19 Oct 2022 10:56:01 +0200
-Subject: [PATCH 2/8] kbuild: Quote OBJCOPY var to avoid a pahole call break
+Subject: [PATCH 2/9] kbuild: Quote OBJCOPY var to avoid a pahole call break
  the build
 
 commit ff2e6efda0d5c51b33e2bcc0b0b981ac0a0ef214 upstream.
@@ -66,5 +66,5 @@ index 779fde480a99..94c548b11db9 100755
  	# Create ${2} which contains just .BTF section but no symbols. Add
  	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
+++ b/kernel/0003-kbuild-skip-per-CPU-BTF-generation-for-pahole-v1.18-.patch
@@ -1,7 +1,7 @@
-From 24dad852ed692e9d7d53075cc20ac6060fa0cf7b Mon Sep 17 00:00:00 2001
+From ed0a13709c71ad89c2f00d80a5ddc866a4d0a68f Mon Sep 17 00:00:00 2001
 From: Andrii Nakryiko <andrii@kernel.org>
 Date: Wed, 19 Oct 2022 10:56:02 +0200
-Subject: [PATCH 3/8] kbuild: skip per-CPU BTF generation for pahole
+Subject: [PATCH 3/9] kbuild: skip per-CPU BTF generation for pahole
  v1.18-v1.21
 
 commit a0b8200d06ad6450c179407baa5f0f52f8cfcc97 upstream.
@@ -53,5 +53,5 @@ index 94c548b11db9..55bcfa85873c 100755
  	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
  
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
+++ b/kernel/0004-kbuild-Unify-options-for-BTF-generation-for-vmlinux-.patch
@@ -1,7 +1,7 @@
-From bd1fbfdcc5bb92ac3b1bcf2ff259e2085d3181a7 Mon Sep 17 00:00:00 2001
+From d04c033738483f3562f631fd5267821cfb8446c0 Mon Sep 17 00:00:00 2001
 From: Jiri Olsa <jolsa@redhat.com>
 Date: Wed, 19 Oct 2022 10:56:03 +0200
-Subject: [PATCH 4/8] kbuild: Unify options for BTF generation for vmlinux and
+Subject: [PATCH 4/9] kbuild: Unify options for BTF generation for vmlinux and
  modules
 
 commit 9741e07ece7c247dd65e1aa01e16b683f01c05a8 upstream.
@@ -102,5 +102,5 @@ index 000000000000..27445cb72974
 +
 +echo ${extra_paholeopt}
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
+++ b/kernel/0005-kbuild-Add-skip_encoding_btf_enum64-option-to-pahole.patch
@@ -1,7 +1,7 @@
-From 55112f49a9d87ed1eaac070f5be1f6b633984176 Mon Sep 17 00:00:00 2001
+From a23f2131c03eb97951859ff8bbd80f2548215e50 Mon Sep 17 00:00:00 2001
 From: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
 Date: Wed, 19 Oct 2022 10:56:04 +0200
-Subject: [PATCH 5/8] kbuild: Add skip_encoding_btf_enum64 option to pahole
+Subject: [PATCH 5/9] kbuild: Add skip_encoding_btf_enum64 option to pahole
 
 New pahole (version 1.24) generates by default new BTF_KIND_ENUM64 BTF tag,
 which is not supported by stable kernel.
@@ -41,5 +41,5 @@ index 27445cb72974..8c82173e42e5 100755
 +
  echo ${extra_paholeopt}
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
+++ b/kernel/0006-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch
@@ -1,7 +1,7 @@
-From 87524d1ea292f599c33b1b9fd55dc1f45f8119bf Mon Sep 17 00:00:00 2001
+From ee000171d1b4d11cdf62de5d676fd479c46ac312 Mon Sep 17 00:00:00 2001
 From: Jiri Olsa <jolsa@kernel.org>
 Date: Wed, 6 Jan 2021 00:42:19 +0100
-Subject: [PATCH 6/8] tools/resolve_btfids: Warn when having multiple IDs for
+Subject: [PATCH 6/9] tools/resolve_btfids: Warn when having multiple IDs for
  single type
 
 The kernel image can contain multiple types (structs/unions)
@@ -89,5 +89,5 @@ index f32c059fbfb4..c3f808a393d1 100644
  	}
  
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0007-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch
+++ b/kernel/0007-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch
@@ -1,7 +1,7 @@
-From 4a5b247af99c2d5da5d0a6720f8a535947ce57ac Mon Sep 17 00:00:00 2001
+From 3318fcece3c98b27170b8a8b59429797fe5935df Mon Sep 17 00:00:00 2001
 From: Antonio Borneo <antonio.borneo@st.com>
 Date: Wed, 25 Nov 2020 00:07:56 +0100
-Subject: [PATCH 7/8] net: phy: realtek: read actual speed on rtl8211f to
+Subject: [PATCH 7/9] net: phy: realtek: read actual speed on rtl8211f to
  detect downshift
 
 The rtl8211f supports downshift and before commit 5502b218e001
@@ -39,5 +39,5 @@ index 7c38f7fbb2e4..118c6028229b 100644
  		.config_intr	= &rtl8211f_config_intr,
  		.get_wol	= &rtl8211f_get_wol,
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0008-Lower-priority-of-tegra-se-crypto.patch
+++ b/kernel/0008-Lower-priority-of-tegra-se-crypto.patch
@@ -1,7 +1,7 @@
-From b826a540a67d9a097dfd0d3d546f6af98a3a4f2a Mon Sep 17 00:00:00 2001
+From 34095615d3d70848fef9cb12f86a03594086ac10 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <dfullmer@anduril.com>
 Date: Sat, 18 Nov 2023 21:33:53 -0800
-Subject: [PATCH 8/8] Lower priority of tegra-se crypto
+Subject: [PATCH 8/9] Lower priority of tegra-se crypto
 
 It is far too flaky and slow to be useful.  I get approximately 150MB/s
 when benchmarking encryption with AES-CBC using this module, while I get
@@ -263,5 +263,5 @@ index 62e005da3dab..9b7c360a7048 100644
  		.cra_module = THIS_MODULE,
  	}
 -- 
-2.39.1
+2.42.0
 

--- a/kernel/0009-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch
+++ b/kernel/0009-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch
@@ -1,0 +1,46 @@
+From 212f7a3e399fa3f6c695f54abccda5967c697aba Mon Sep 17 00:00:00 2001
+From: "Jiri Slaby (SUSE)" <jirislaby@kernel.org>
+Date: Mon, 31 Oct 2022 12:44:09 +0100
+Subject: [PATCH 9/9] bonding (gcc13): synchronize bond_{a,t}lb_xmit() types
+
+Both bond_alb_xmit() and bond_tlb_xmit() produce a valid warning with
+gcc-13:
+  drivers/net/bonding/bond_alb.c:1409:13: error: conflicting types for 'bond_tlb_xmit' due to enum/integer mismatch; have 'netdev_tx_t(struct sk_buff *, struct net_device *)' ...
+  include/net/bond_alb.h:160:5: note: previous declaration of 'bond_tlb_xmit' with type 'int(struct sk_buff *, struct net_device *)'
+
+  drivers/net/bonding/bond_alb.c:1523:13: error: conflicting types for 'bond_alb_xmit' due to enum/integer mismatch; have 'netdev_tx_t(struct sk_buff *, struct net_device *)' ...
+  include/net/bond_alb.h:159:5: note: previous declaration of 'bond_alb_xmit' with type 'int(struct sk_buff *, struct net_device *)'
+
+I.e. the return type of the declaration is int, while the definitions
+spell netdev_tx_t. Synchronize both of them to the latter.
+
+Cc: Martin Liska <mliska@suse.cz>
+Cc: Jay Vosburgh <j.vosburgh@gmail.com>
+Cc: Veaceslav Falico <vfalico@gmail.com>
+Cc: Andy Gospodarek <andy@greyhouse.net>
+Signed-off-by: Jiri Slaby (SUSE) <jirislaby@kernel.org>
+Link: https://lore.kernel.org/r/20221031114409.10417-1-jirislaby@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 777fa87c7682228e155cf0892ba61cb2ab1fe3ae)
+---
+ include/net/bond_alb.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/net/bond_alb.h b/include/net/bond_alb.h
+index 191c36afa1f4..9dc082b2d543 100644
+--- a/include/net/bond_alb.h
++++ b/include/net/bond_alb.h
+@@ -156,8 +156,8 @@ int bond_alb_init_slave(struct bonding *bond, struct slave *slave);
+ void bond_alb_deinit_slave(struct bonding *bond, struct slave *slave);
+ void bond_alb_handle_link_change(struct bonding *bond, struct slave *slave, char link);
+ void bond_alb_handle_active_change(struct bonding *bond, struct slave *new_slave);
+-int bond_alb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
+-int bond_tlb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
++netdev_tx_t bond_alb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
++netdev_tx_t bond_tlb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
+ struct slave *bond_xmit_alb_slave_get(struct bonding *bond,
+ 				      struct sk_buff *skb);
+ struct slave *bond_xmit_tlb_slave_get(struct bonding *bond,
+-- 
+2.42.0
+

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -88,6 +88,9 @@ pkgsAarch64.buildLinux (args // {
 
     # Lower priority of tegra-se crypto modules since they're slow and flaky
     { patch = ./0008-Lower-priority-of-tegra-se-crypto.patch; }
+
+    # Fix gcc13 compilation failure
+    { patch = ./0009-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch; }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes

Fixes the compilation failure in #178 

###### Testing

Built the kernel, cross-compiled from `x86_64-linux`.