### PR TITLE
Provide patches for new networking vulnerabilities in EDK2

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPackages
 , fetchFromGitHub
+, fetchurl
 , fetchpatch
 , fetchpatch2
 , runCommand
@@ -216,7 +217,22 @@ let
         chmod -R u+w BaseTools
       '';
 
-      patches = opensslPatches ++ edk2UefiPatches;
+      patches = opensslPatches ++ edk2UefiPatches ++ [
+        (fetchurl {
+          # Patch format does not play well with fetchpatch, it should be fine this is a static attachment in a ticket
+          name = "CVE-2023-45229_CVE-2023-45230_CVE-2023-45231_CVE-2023-45232_CVE-2023-45233_CVE-2023-45234_CVE-2023-45235.patch";
+          url = "https://bugzilla.tianocore.org/attachment.cgi?id=1457";
+          hash = "sha256-CF41lbjnXbq/6DxMW6q1qcLJ8WAs+U0Rjci+jRwJYYY=";
+        })
+        (fetchpatch {
+          name = "CVE-2022-36764.patch";
+          url = "https://bugzilla.tianocore.org/attachment.cgi?id=1436";
+          hash = "sha256-czku8DgElisDv6minI67nNt6BS+vH6txslZdqiGaQR4=";
+          excludes = [
+            "SecurityPkg/Test/SecurityPkgHostTest.dsc"
+          ];
+        })
+      ];
 
       postPatch = ''
         # This has been taken from:


### PR DESCRIPTION
###### Description of changes

See CVE-2023-45229, CVE-2023-45230, CVE-2023-45231, CVE-2023-45232, CVE-2023-45233, CVE-2023-45234, CVE-2023-45235 and CVE-2022-36764.

Rundown on CVEs:
https://blog.quarkslab.com/pixiefail-nine-vulnerabilities-in-tianocores-edk-ii-ipv6-network-stack.html

Patches found from https://bugzilla.tianocore.org/show_bug.cgi?id=4518 and https://bugzilla.tianocore.org/show_bug.cgi?id=4118.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested netbooting on:
- orin-agx-devkit
- orin-nano-devkit
- xavier-agx-devkit
- xavier-nx-devkit

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
