### PR TITLE
[kernel] Fix memory leak in kernel tegra serial driver

### DIFF
--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -1,6 +1,7 @@
 { pkgs
 , lib
 , fetchFromGitHub
+, fetchpatch
 , l4t-xusb-firmware
 , realtime ? false
 , kernelPatches ? [ ]
@@ -91,6 +92,16 @@ pkgsAarch64.buildLinux (args // {
 
     # Fix gcc13 compilation failure
     { patch = ./0009-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch; }
+
+    # Fixes a memory leak by kernel tegra serial driver
+    # This manifested via slab unreclaimable growing unbounded via repeated kmalloc-256 calls
+    # This patch is present in 35.4.1 and should be removed when we update
+    {
+      patch = fetchpatch {
+        url = "https://github.com/OE4T/linux-tegra-5.10/commit/d5b90d6b9365250adb73b2fe5b52a5228df3b1d9.patch";
+        sha256 = "sha256-a5LL4avaxQ3WYr9fRPMCfHrl4iAp1yhH95R+iI/PwYc=";
+      };
+    }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes
Fixes a memory leak in kernel tegra serial driver.
This ensures the memory allocated in function `tegra_dma_prep_slave_sg`
is cleaned up properly. Manifested as slab unreclaimable growing unbounded
via calls to kmalloc-256

Tested on Xavier AGX custom carrier board

Ref: https://forums.developer.nvidia.com/t/serial-tegra-dma-driver-bug/258168/5
