### PR TITLE
Fix libnvmedia libraries dlopen() dependency on nvsci

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -98,7 +98,8 @@ let
     # libnvos.so here instead.
     #
     # We append a postFixupHook since we need to have this happen after
-    # autoPatchelfHook, which itself also runs as a postFixupHook
+    # autoPatchelfHook, which itself also runs as a postFixupHook.
+    # TODO: Use runtimeDependencies instead
     preFixup = ''
       postFixupHooks+=('
         patchelf --add-rpath /run/opengl-driver/lib $out/lib/libnvos.so
@@ -251,6 +252,15 @@ let
 
       ln -sf ../../../libv4l2_nvcuvidvideocodec.so lib/libv4l/plugins/nv/libv4l2_nvcuvidvideocodec.so
       ln -sf ../../../libv4l2_nvvideocodec.so lib/libv4l/plugins/nv/libv4l2_nvvideocodec.so
+    '';
+
+    # We append a postFixupHook since we need to have this happen after
+    # autoPatchelfHook, which itself also runs as a postFixupHook.
+    # TODO: Use runtimeDependencies instead
+    preFixup = ''
+      postFixupHooks+=('
+        patchelf --add-rpath ${lib.getLib l4t-nvsci}/lib $out/lib/libnvmedia*.so
+      ')
     '';
   };
 

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -287,7 +287,11 @@ let
       ${multimedia-samples}/bin/video_decode H264 --disable-rendering ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264
       echo
       echo " * Running video_cuda_enc"
-      ${multimedia-samples}/bin/video_cuda_enc ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264 1920 1080 H264 "$WORKDIR"/test.h264
+      if ! grep -q -E "p3767-000[345]" /proc/device-tree/compatible; then
+        ${multimedia-samples}/bin/video_cuda_enc ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264 1920 1080 H264 "$WORKDIR"/test.h264
+      else
+        echo "Orin Nano does not support hardware video encoding--skipping test"
+      fi
       echo
       echo " * Running video_convert"
       ${multimedia-samples}/bin/video_convert "$WORKDIR"/nvidia-logo.yuv 1920 1080 YUV420 "$WORKDIR"/test.yuv 1920 1080 YUYV

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -286,6 +286,9 @@ let
       echo " * Running video_decode"
       ${multimedia-samples}/bin/video_decode H264 --disable-rendering ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264
       echo
+      echo " * Running video_cuda_enc"
+      ${multimedia-samples}/bin/video_cuda_enc ${multimedia-samples}/data/Video/sample_outdoor_car_1080p_10fps.h264 1920 1080 H264 "$WORKDIR"/test.h264
+      echo
       echo " * Running video_convert"
       ${multimedia-samples}/bin/video_convert "$WORKDIR"/nvidia-logo.yuv 1920 1080 YUV420 "$WORKDIR"/test.yuv 1920 1080 YUYV
       echo


### PR DESCRIPTION
###### Description of changes

Fix libnvmedia libraries dlopen() dependency on nvsci

###### Testing

Also adds a test to multimedia-test that reproduces the failure when this fix is not applied.

Failing test:

> Opening in BLOCKING MODE
> NvMMLiteOpen : Block : BlockType = 4
> ===== NVMEDIA: NVENC =====
> NvMMLiteBlockCreate : Block : BlockType = 4
> 875967048
> 842091865
> H264: Profile = 100, Level = 50
> NVMEDIA: Need to set EMC bandwidth : 846000
> NVMEDIA: Need to set EMC bandwidth : 846000
> NVMEDIA_ENC: bBlitMode is set to TRUE
> NvVideoEncTransferOutputBufferToBlock: DoWork failed line# 679
> NvVideoEnc: NvVideoEncTransferOutputBufferToBlock TransferBufferToBlock failed Line=690
> Could not read complete frame from input file

Succeeding test:

> Opening in BLOCKING MODE
> NvMMLiteOpen : Block : BlockType = 4
> ===== NVMEDIA: NVENC =====
> NvMMLiteBlockCreate : Block : BlockType = 4
> 875967048
> 842091865
> H264: Profile = 100, Level = 50
> NVMEDIA: Need to set EMC bandwidth : 846000
> NVMEDIA: Need to set EMC bandwidth : 846000
> NVMEDIA_ENC: bBlitMode is set to TRUE
> Could not read complete frame from input file
> Could not read complete frame from input file
> File read complete.
> App run was successful

Tested on all Xavier/Orin devkits.
