### PR TITLE
Stable link to OE4T/meta-tegra instead of master

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -204,7 +204,7 @@ let
   _l4t-multimedia-v4l = libv4l.overrideAttrs ({ nativeBuildInputs ? [ ], patches ? [ ], postPatch ? "", ... }: {
     nativeBuildInputs = nativeBuildInputs ++ [ dpkg ];
     patches = patches ++ lib.singleton (fetchpatch {
-      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/master/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
+      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/85aa94e16104debdd01a3f61a521b73d86340a9f/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
       sha256 = "sha256-vGilgHWinrKjX+ikHo0J20PL713+w+lv46dBgfdvsZM=";
     });
     # Use a placeholder path that we replace in the l4t-multimedia derivation, We avoid an infinite recursion problem this way.


### PR DESCRIPTION
Recent update in repo https://github.com/OE4T/meta-tegra (this one OE4T/meta-tegra@b86c2ae) in fact breaks `jetpack-nixos` build:
```
hash mismatch in fixed-output derivation '/nix/store/n59rw7dri9dacvrav379m3i621qql6nf-0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch.drv':
      >          specified: sha256-vGilgHWinrKjX+ikHo0J20PL713+w+lv46dBgfdvsZM=
      >             got:    sha256-6xCEjf432FLksCCk8+EpAbQU3PeGICOQ+6Q2OusUNa4=
```

I think we should refer all external repos by stable links to the certain commits instead of branches.

###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
