### PR TITLE
Add `coreutils` to device package scripts

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -16,6 +16,7 @@
 , dtc
 , l4tVersion
 , pkgsAarch64
+, coreutils
 ,
 }:
 
@@ -123,6 +124,7 @@ let
   # Generate a flash script using the built configuration options set in a NixOS configuration
   flashScript = writeShellApplication {
     name = "flash-${hostName}";
+    runtimeInputs = [ coreutils ];
     text = (mkFlashScriptAuto { });
   };
 
@@ -143,6 +145,7 @@ let
   # on x86_64, and the machine in `config` should be aarch64-linux
   rcmBoot = writeShellApplication {
     name = "rcmboot-nixos";
+    runtimeInputs = [ coreutils ];
     text = mkRcmBootScript {
       # See nixpkgs nixos/modules/system/activatation/top-level.nix for standard usage of these paths
       kernelPath = "${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile}";
@@ -192,6 +195,7 @@ let
     in
     writeShellApplication {
       name = "initrd-flash-${hostName}";
+      runtimeInputs = [ coreutils ];
       text = ''
         ${mkRcmBootScript {
           kernelPath = "${config.boot.kernelPackages.kernel}/Image";
@@ -278,6 +282,7 @@ let
 
   fuseScript = writeShellApplication {
     name = "fuse-${hostName}";
+    runtimeInputs = [ coreutils ];
     text = import ./flash-script.nix {
       inherit lib;
       flash-tools = flash-tools-patched;


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

Add `coreutils` to device scripts (i.e. flash script, initrd flash, etc.). Because the tools in this package were missing, a packaged version of the script (built for 3rd party use outside of a `nix`-enabled machine) using `nix bundle .#SCRIPT_NAME` resulted in errors like: 
```
...initrd-flash-orin-nx-devkit: line 9: mktemp: No such file or directory
```

###### Testing

rebuilding with the `coreutils` package on an x86_64-linux system results in successfully running the script packaged with `nix bundle --out-link ~/script .#SCRIPT_NAME; ~/script` without the missing file error above

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
