### PR TITLE
Use driverLink where possible

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -140,7 +140,7 @@ in
       # l4t-core provides - among others - libnvrm_gpu.so and libnvrm_mem.so.
       # The l4t-core/lib directory is directly set in the DT_RUNPATH of
       # l4t-cuda's libcuda.so, thus the standard driver doesn't need them to be
-      # added in /run/opengl-driver.
+      # added in ${driverLink}.
       #
       # However, this isn't the case for cuda_compat's driver currently, which
       # is why we're including this derivation in extraPackages.
@@ -269,6 +269,7 @@ in
     };
 
     # Used by libEGL_nvidia.so.0
-    environment.etc."egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
+    environment.etc."egl/egl_external_platform.d".source =
+      "${pkgs.addOpenGLRunpath.driverLink}/share/egl/egl_external_platform.d/";
   };
 }

--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , stdenvNoCC
+, addOpenGLRunpath
 , lib
 , fetchurl
 , fetchpatch
@@ -94,7 +95,7 @@ let
     # l4t-core. Unfortunately, calling dlopen from libnvos.so instead of the
     # original library/executable means that dlopen will use the DT_RUNPATH
     # from libnvos.so instead of the binary/library which called it. We
-    # typically just need /run/opengl-driver/lib anyway, so lets add it to
+    # typically just need ${driverLink}/lib anyway, so lets add it to
     # libnvos.so here instead.
     #
     # We append a postFixupHook since we need to have this happen after
@@ -102,7 +103,7 @@ let
     # TODO: Use runtimeDependencies instead
     preFixup = ''
       postFixupHooks+=('
-        patchelf --add-rpath /run/opengl-driver/lib $out/lib/libnvos.so
+        patchelf --add-rpath ${addOpenGLRunpath.driverLink}/lib $out/lib/libnvos.so
       ')
     '';
   };


### PR DESCRIPTION
###### Description of changes

Instead of hardcoding `/run/opengl-driver`, use `addOpenGLRunpath.driverLink`.

###### Testing

Booted on an orin-agx-devkit and ensured nvidia libraries still existed under `/run/opengl-driver`.