### PR TITLE
Add firmware needed for R816{8,9} network devices

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -147,4 +147,39 @@ lib.mkMerge [{
         else
           "-F 32 -n ESP";
     };
+  })
+  (lib.mkIf (lib.any (som: som == cfg.som) [ "orin-nx" "orin-nano" ]) {
+    hardware.firmware = [
+      (pkgs.linkFarm "r8169-firmware"
+        (map
+          (firmwarePath: {
+            name = "lib/firmware/${firmwarePath}";
+            path = "${pkgs.linux-firmware}/lib/firmware/${firmwarePath}";
+          }) [
+          # From https://github.com/OE4T/linux-tegra-5.10/blob/20443c6df8b9095e4676b4bf696987279fac30a9/drivers/net/ethernet/realtek/r8169_main.c#L38
+          # We include all the firmware referenced by the r8168 module so that
+          # `makeModulesClosure` doesn't spit out warnings.
+          "rtl_nic/rtl8168d-1.fw"
+          "rtl_nic/rtl8168d-2.fw"
+          "rtl_nic/rtl8168e-1.fw"
+          "rtl_nic/rtl8168e-2.fw"
+          "rtl_nic/rtl8168e-3.fw"
+          "rtl_nic/rtl8168f-1.fw"
+          "rtl_nic/rtl8168f-2.fw"
+          "rtl_nic/rtl8105e-1.fw"
+          "rtl_nic/rtl8402-1.fw"
+          "rtl_nic/rtl8411-1.fw"
+          "rtl_nic/rtl8411-2.fw"
+          "rtl_nic/rtl8106e-1.fw"
+          "rtl_nic/rtl8106e-2.fw"
+          "rtl_nic/rtl8168g-2.fw"
+          "rtl_nic/rtl8168g-3.fw"
+          "rtl_nic/rtl8168h-2.fw" # wanted by orin-nano and orin-nx
+          "rtl_nic/rtl8168fp-3.fw"
+          "rtl_nic/rtl8107e-2.fw"
+          "rtl_nic/rtl8125a-3.fw"
+          "rtl_nic/rtl8125b-2.fw"
+          "rtl_nic/rtl8126a-2.fw"
+        ]))
+    ];
   })]


### PR DESCRIPTION
###### Description of changes

The orin-nano and orin-nx SOMs have realtek NICs that take advantage of firmware that lives in the `linux-firmware` derivation. Instead of pulling in all of linux-firmware (1GiB+), just pull in what is needed for the `r8168` kernel module. Note that in Jetpack 35.3.1 the kernel module was called `r8169` and in Jetpack 35.4.1 the kernel module was changed to be `r8168`. This differs from mainline linux where the kernel module is `r8169`.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on an orin-nano-devkit, ensured the initrd built with a config including `{ boot.initrd.kernelModules = [ "r8168" ]; }` includes the corresponding firmware in `lib/firmware/rtl_nic`. Also ensured that the warning message produced without this PR's changes no longer appears. The warning looks like this:
```
Starting systemd-udevd version 254.6
[    9.388066] r8169 0008:01:00.0 enP8p1s0: renamed from eth0
bringing up network interface enP8p1s0...
[    9.444051] r8169 0008:01:00.0: Direct firmware load for rtl_nic/rtl8168h-2.fw failed with error -2
[    9.445086] r8169 0008:01:00.0: Unable to load firmware rtl_nic/rtl8168h-2.fw (-2)
[    9.472717] Generic FE-GE Realtek PHY r8169-8-100:00: attached PHY driver [Generic FE-GE Realtek PHY] (mii_bus:phy_addr=r8169-8-100:00, irq=IGNORE)
[    9.596951] r8169 0008:01:00.0 enP8p1s0: Link is Down
```

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
