### PR TITLE
Further fix for NvOsLibraryLoad function calls

### DIFF
--- a/UPGRADE_CHECKLIST.md
+++ b/UPGRADE_CHECKLIST.md
@@ -8,6 +8,7 @@
 - [ ] Update the kernel version in `kernel/default.nix` if it chaged.
 - [ ] Grep for the previous version strings e.g. "35.4.1"
 - [ ] Compare files from `unpackedDebs` before and after
+- [ ] Grep for NvOsLibraryLoad in libraries from debs to see if any new packages not already handled in l4t use the function
 - [ ] Ensure the soc variants in `modules/flash-script.nix` match those in `jetson_board_spec.cfg` from BSP
 - [ ] Ensure logic in `ota-utils/ota_helpers.func` matches `nvidia-l4t-init/opt/nvidia/nv-l4t-bootloader-config.sh`
 - [ ] Run `nix build .#genL4tJson` and copy output to `pkgs/containers/l4t.json`


### PR DESCRIPTION
###### Description of changes

Programs which linked against both multimedia libs and libEGL_nvidia.so would end up with two versions of NvOsLibraryLoad and one of them would be used arbitrarily.

Now, we rename the symbols to have unique names to avoid the conflict.  This required a version of patchelf that is not yet in upstream nixpkgs.

As an additional note, this was discovered when runnig the video_cuda_enc sample, and debugged using LD_DEBUG=all + grepping for NvOsLibraryLoad and seeing that it was coming from the libnvos_multimedia lib.


###### Testing

Tested by running combined-samples on a Xavier AGX devkit