### PR TITLE
fix: disable efifb driver for generic and only xavier-nx som types

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -106,7 +106,7 @@ in
 
       # Needed on Orin at least, but upstream has it for both
       "nvidia.rm_firmware_active=all"
-    ] ++ lib.optional (lib.hasPrefix "xavier-" cfg.som) "video=efifb:off"; # Disable efifb driver, which crashes Xavier AGX/NX
+    ] ++ lib.optional (lib.hasPrefix "xavier-nx" cfg.som || cfg.som == "generic") "video=efifb:off"; # Disable efifb driver, which crashes Xavier NX
 
     boot.initrd.includeDefaultModules = false; # Avoid a bunch of modules we may not get from tegra_defconfig
     boot.initrd.availableKernelModules = [ "xhci-tegra" ]; # Make sure USB firmware makes it into initrd


### PR DESCRIPTION
Fixes booting a nixosConfiguration where `hardware.nvidia-jetpack.som = "generic";` on the Xavier NX (e.g. iso_minimal) by only enabling the efifb driver when the som is explicitly not xavier-nx or generic. Also found that the original issue does not affect the Xavier AGX variant so this PR also re-enables the efifb driver for the xavier-agx som.