### PR TITLE
flashDeps: use buildPackages to fix cross-builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ let
     inherit bspSrc gitRepos l4tVersion;
   }) buildTOS buildOpteeTaDevKit opteeClient;
 
-  flash-tools = callPackage ./pkgs/flash-tools {
+  flash-tools = pkgs.buildPackages.callPackage ./pkgs/flash-tools {
     inherit bspSrc l4tVersion;
   };
 

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -35,9 +35,11 @@ let
     (lib.concatLines (map
       # all files in linux-firmware are read-only
       (firmwarePath: ''
-        install -Dm0444 \
-          --target-directory=$(dirname $out/lib/firmware/${firmwarePath}) \
-          $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath})
+        if [ -f ${pkgs.linux-firmware}/lib/firmware/${firmwarePath} ]; then
+          install -Dm0444 \
+            --target-directory=$(dirname $out/lib/firmware/${firmwarePath}) \
+            $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath})
+        fi
       ''
       )
       paths)));

--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , makeWrapper
 , fetchurl
@@ -13,7 +13,7 @@
 }:
 
 let
-  flash-tools = stdenv.mkDerivation {
+  flash-tools = stdenvNoCC.mkDerivation {
     pname = "flash-tools";
     version = l4tVersion;
 
@@ -45,7 +45,7 @@ let
       rm -rf nv_tegra
       mkdir nv_tegra
       mv bsp_version nv_tegra
-    '' + (lib.optionalString (!stdenv.hostPlatform.isx86) ''
+    '' + (lib.optionalString (!stdenvNoCC.hostPlatform.isx86) ''
       # Wrap x86 binaries in qemu
       pushd bootloader/ >/dev/null
       for filename in chkbdinfo mkbctpart mkbootimg mksparse tegrabct_v2 tegradevflash_v2 tegrahost_v2 tegrakeyhash tegraopenssl tegraparser_v2 tegrarcm_v2 tegrasign_v2; do

--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -1,35 +1,15 @@
 { stdenv
 , lib
 , makeWrapper
-, bzip2_1_1
 , fetchurl
 , python3
 , perl
-, xxd
 , libxml2
-, coreutils
-, gnugrep
-, gnused
-, gnutar
-, gawk
-, which
-, gzip
-, cpio
-, bintools-unwrapped
-, findutils
-, util-linux
-, dosfstools
-, lz4
-, gcc
-, dtc
 , qemu
 , runtimeShell
-, fetchzip
-, bc
-, openssl
 , bspSrc
 , l4tVersion
-,
+, buildPackages
 }:
 
 let
@@ -95,7 +75,7 @@ let
     # wrapProgram doesn't work here because it refers to the wrapped program by
     # absolute path, and flash-script copies the entire flash-tools dir before
     # running
-    passthru.flashDeps = [
+    passthru.flashDeps = with buildPackages; [
       coreutils
       gnugrep
       gnused


### PR DESCRIPTION
###### Issue

Cross builds of nixosConfig containing an UEFI capsule update are currently broken due to how `flashDeps` are defined and used.

```
nix-repl> :b (nixosConfigurations.installer_minimal_cross.extendModules {
    hardware.nvidia-jetpack.enable = true; 
    modules = [{
      hardware.nvidia-jetpack.firmware.autoUpdate = true;
      hardware.nvidia-jetpack.som = "orin-nx";
     }];
}).config.system.build.toplevel
```

Results in exec format error due to wrong package set of `flashDeps` being used.
```
/build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 24: /nix/store/g6s3cb7y0mmfa5i1s7xr5j9ma58rcwwn-coreutils-aarch64-unknown-linux-gnu-9.3/bin/cp: cannot execute binary file: Exec format error
/build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 6: /nix/store/g6s3cb7y0mmfa5i1s7xr5j9ma58rcwwn-coreutils-aarch64-unknown-linux-gnu-9.3/bin/rm: cannot execute binary file: Exec format error
``` 

###### Changes
Use `buildPackages` for `flashDeps` so `flash-script.nix` uses the correct package set. As far as I can tell, there's no way to change which package set callPackage uses for passthru so directly using `buildPackages` seems like the best option.

The use of `pkgs.buildPackages.callPackage` is required for `patchShebangs`  to set the correct interpreter in `flash.sh`. (Using `callPackage` for some reason just resulted in the shebang being left unmodified). There might be some other cause for this issue.

###### Testing
TODO