### PR TITLE
nvpmodel: restart on-failure

### DIFF
--- a/modules/nvpmodel.nix
+++ b/modules/nvpmodel.nix
@@ -34,6 +34,8 @@ in
       description = "Set NVPModel power profile";
       serviceConfig = {
         Type = "oneshot";
+        Restart = "on-failure";
+        RestartSec = "2s";
         ExecStart = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/bin/nvpmodel -f ${cfg.configFile}" + lib.optionalString (cfg.profileNumber != null) " -m ${builtins.toString cfg.profileNumber}";
       };
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
The `nvpmodel` service can fail to start due some files/devices under `/sys` not being writable early in boot. Simply setting `Restart="on-failure"` resolves the issue. Nvidia's upstream unit file only starts `nvpmodel` after the `nv` and `nvpower` services which likely delays the service a bit.

Allowing the service to restart gracefully successfully applies the power profile:
```
Jul 28 09:27:34 xavier-nx-emmc-quark-jp5 systemd[1]: Starting Set NVPModel power profile...
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 nvpmodel[886]: NVPM ERROR: Error opening /sys/devices/platform/c250000.i2c/i2c-7/7-0040/hwmon: 2
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 nvpmodel[886]: NVPM ERROR: failed to write PARAM VDDIN_OC_LIMIT: ARG WARN: PATH: /sys/devices/platform/c250000.i2c/i2c-7/7-0040/hwmon VAL: 4000
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 nvpmodel[886]: NVPM ERROR: failed to set power mode!
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 nvpmodel[886]: NVPM ERROR: optMask is 3, no request for power mode
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 systemd[1]: nvpmodel.service: Main process exited, code=exited, status=255/EXCEPTION
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 systemd[1]: nvpmodel.service: Failed with result 'exit-code'.
Jul 28 09:27:35 xavier-nx-emmc-quark-jp5 systemd[1]: Failed to start Set NVPModel power profile.
Jul 28 09:27:37 xavier-nx-emmc-quark-jp5 systemd[1]: nvpmodel.service: Scheduled restart job, restart counter is at 1.
Jul 28 09:27:37 xavier-nx-emmc-quark-jp5 systemd[1]: Starting Set NVPModel power profile...
Jul 28 09:27:37 xavier-nx-emmc-quark-jp5 systemd[1]: nvpmodel.service: Deactivated successfully.
Jul 28 09:27:37 xavier-nx-emmc-quark-jp5 systemd[1]: Finished Set NVPModel power profile.
```
```
> cat /sys/devices/platform/c250000.i2c/i2c-7/7-0040/hwmon/hwmon3/curr1_max
4000
> sudo cat /sys/devices/platform/c250000.i2c/i2c-7/7-0040/hwmon/hwmon3/curr1_max
5000
```

Nvidia's Unit file:
```
[Unit]
Description=nvpmodel service
; Everything depends on the NVIDIA per-boot script
After=nv.service nvpower.service
Requires=nv.service nvpower.service
; TPC power gating must be enabled before anything touching gpu
Before=graphical.target
Before=gdm3.service lightdm.service
Before=network.target network-online.target
; Prevent the GPU golden context from being initialized by the OEM config
Before=nv-oem-config-gui.service nv-oem-config-debconf@.service
```