### PR TITLE
Set a default host platform

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -91,6 +91,8 @@ in
       message = "Docker version < 25 does not support CDI";
     }];
 
+    nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+
     nixpkgs.overlays = [
       (import ../overlay.nix)
     ];


### PR DESCRIPTION
###### Description of changes

A nixos config only needs a few things set in order to build correctly, `nixpkgs.hostPlatform` being one of them. In the case of jetson devices, we can at least provide a default value for this that gets people up and running with one less thing to set.

###### Testing

Tested building a nixos config for an orin-agx-devkit with the following config:
```nix
((builtins.getFlake "nixpkgs/nixos-unstable").lib.nixosSystem {
  modules = [
    {
      # required for any nixos config
      boot.loader.systemd-boot.enable = true;
      fileSystems."/".device = "/foo/bar";
    }
    {
      imports = [
        (builtins.getFlake "github:jmbaur/jetpack-nixos?ref=default-host-platform")
        .nixosModules.default
      ];
      hardware.nvidia-jetpack.enable = true;
      hardware.nvidia-jetpack.som = "orin-agx";
      hardware.nvidia-jetpack.carrierBoard = "devkit";
    }
  ];
}).config.system.build.toplevel
```