### PR TITLE
fix libv4l patch sha

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -233,7 +233,7 @@ let
     nativeBuildInputs = nativeBuildInputs ++ [ dpkg ];
     patches = patches ++ lib.singleton (fetchpatch {
       url = "https://raw.githubusercontent.com/OE4T/meta-tegra/85aa94e16104debdd01a3f61a521b73d86340a9f/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
-      sha256 = "sha256-vGilgHWinrKjX+ikHo0J20PL713+w+lv46dBgfdvsZM=";
+      sha256 = "sha256-6xCEjf432FLksCCk8+EpAbQU3PeGICOQ+6Q2OusUNa4=";
     });
     # Use a placeholder path that we replace in the l4t-multimedia derivation, We avoid an infinite recursion problem this way.
     postPatch = postPatch + ''


### PR DESCRIPTION
###### Description of changes
I guess github changed their patch format? This was failing with a FOD hash mismatch on nixbuild testing where we didn't have a cached version.

###### Testing
Tested in anduril-nixpkgs

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
