### PR TITLE
Fix incorrect fetches of patches

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -231,9 +231,9 @@ let
   # See https://nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git
   _l4t-multimedia-v4l = libv4l.overrideAttrs ({ nativeBuildInputs ? [ ], patches ? [ ], postPatch ? "", ... }: {
     nativeBuildInputs = nativeBuildInputs ++ [ dpkg ];
-    patches = patches ++ lib.singleton (fetchpatch {
+    patches = patches ++ lib.singleton (fetchurl {
       url = "https://raw.githubusercontent.com/OE4T/meta-tegra/85aa94e16104debdd01a3f61a521b73d86340a9f/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
-      sha256 = "sha256-vGilgHWinrKjX+ikHo0J20PL713+w+lv46dBgfdvsZM=";
+      sha256 = "sha256-gzWMilEbxkQfbArkCgFSYs9A06fdciCijYYCCpEiHOc=";
     });
     # Use a placeholder path that we replace in the l4t-multimedia derivation, We avoid an infinite recursion problem this way.
     postPatch = postPatch + ''

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -245,7 +245,7 @@ let
         sha256 = "sha256-IJ1teGEUxYDEPYSvYZbqdmUYg9tOORN7WGYpDaUUnHY=";
       })
       (fetchurl {
-        url = "https://raw.githubusercontent.com/OE4T/meta-tegra/master/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch";
+        url = "https://raw.githubusercontent.com/OE4T/meta-tegra/4f825ddeb2e9a1b5fbff623955123c20b82c8274/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch";
         sha256 = "sha256-mkS2eKuDvXDhHkIglUGcYbEWGxCP5gRSdmEvuVw/chI=";
       })
     ];


### PR DESCRIPTION
###### Description of changes

No need to use fetchpatch for non-generated patches from a specific revision of another git repo.  Also, replace use of "master" with a pinned commit for another patch

###### Testing

Eval checks and built l4t-multimedia and multimedia-samples packages.
