### PR TITLE
Be more forgiving on missing linux-firmware files

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -35,9 +35,13 @@ let
     (lib.concatLines (map
       # all files in linux-firmware are read-only
       (firmwarePath: ''
-        install -Dm0444 \
-          --target-directory=$(dirname $out/lib/firmware/${firmwarePath}) \
-          $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath})
+        if [[ -f $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath}) ]]; then
+          install -Dm0444 \
+            --target-directory=$(dirname $out/lib/firmware/${firmwarePath}) \
+            $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath})
+        else
+          echo "WARNING: lib/firmware/${firmwarePath} does not exist in linux-firmware ${pkgs.linux-firmware.version}"
+        fi
       ''
       )
       paths)));


### PR DESCRIPTION
###### Description of changes

The files in `linux-firmware` may vary depending on the nixpkgs version used, so we should allow for some files to be missing.


###### Testing
