### PR TITLE
feat: add support for flashing emulation configs on AGX devkits

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,10 @@
                 value = c;
               }) [
               { som = "orin-agx"; carrierBoard = "devkit"; }
+              { som = "orin-agx"; carrierBoard = "devkit-as-nano-4gb"; }
+              { som = "orin-agx"; carrierBoard = "devkit-as-nano-8gb"; }
+              { som = "orin-agx"; carrierBoard = "devkit-as-nx-8gb"; }
+              { som = "orin-agx"; carrierBoard = "devkit-as-nx-16gb"; }
               { som = "orin-agx-industrial"; carrierBoard = "devkit"; }
               { som = "orin-nx"; carrierBoard = "devkit"; }
               { som = "orin-nano"; carrierBoard = "devkit"; }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -80,10 +80,7 @@ in
       };
 
       carrierBoard = mkOption {
-        type = types.enum [
-          "generic"
-          "devkit"
-        ];
+        type = types.enum [ "generic" "devkit" "devkit-as-nx-8gb" "devkit-as-nx-16gb" "devkit-as-nano-8gb" "devkit-as-nano-4gb" ];
         default = "generic";
         description = ''
           Jetson carrier board to target. Can be set to "generic" to target a generic jetson carrier board, but some things may not work.

--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -61,6 +61,15 @@ in
 
     hardware.nvidia-jetpack.flashScriptOverrides =
       let
+        # The AGX supports Emulating weaker Jetson SoMs on the devkit:
+        # https://developer.ridgerun.com/wiki/index.php/NVIDIA_Jetson_Orin/Flashing_commands_for_emulation#Flashing_the_board
+        agxDevkitTargetBoards = {
+          "devkit" = "jetson-agx-orin-devkit";
+          "devkit-as-nx-8gb" = "jetson-agx-orin-devkit-as-nx-8gb";
+          "devkit-as-nx-16gb" = "jetson-agx-orin-devkit-as-nx-16gb";
+          "devkit-as-nano-8gb" = "jetson-agx-orin-devkit-as-nano8gb";
+          "devkit-as-nano-4gb" = "jetson-agx-orin-devkit-as-nano4gb";
+        };
         # Remove unnecessary partitions to make it more like
         # flash_t194_uefi_sdmmc_min.xml, except also keep the A/B slots on each
         # partition
@@ -96,7 +105,7 @@ in
       in
       mkMerge [
         (mkIf (cfg.som == "orin-agx") {
-          targetBoard = mkDefault "jetson-agx-orin-devkit";
+          targetBoard = mkDefault (agxDevkitTargetBoards."${cfg.carrierBoard}");
           # We don't flash the sdmmc with kernel/initrd/etc at all. Just let it be a
           # regular NixOS machine instead of having some weird partition structure.
           partitionTemplate = mkDefault "${pkgs.nvidia-jetpack.bspSrc}/bootloader/t186ref/cfg/flash_t234_qspi.xml";


### PR DESCRIPTION
###### Description of changes

[The AGX supports Emulating weaker Jetson SoMs on the devkit.](https://developer.ridgerun.com/wiki/index.php/NVIDIA_Jetson_Orin/Flashing_commands_for_emulation#Flashing_the_board). This PR add's additional AGX devkit options that can be flashed to enable this emulation. 
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested this on an Orin AGX devkit. 
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
