### PR TITLE
kernel: restore patch to fix gcc 13 compilation failure

### DIFF
--- a/kernel/0010-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch
+++ b/kernel/0010-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch
@@ -1,0 +1,46 @@
+From 212f7a3e399fa3f6c695f54abccda5967c697aba Mon Sep 17 00:00:00 2001
+From: "Jiri Slaby (SUSE)" <jirislaby@kernel.org>
+Date: Mon, 31 Oct 2022 12:44:09 +0100
+Subject: [PATCH 9/9] bonding (gcc13): synchronize bond_{a,t}lb_xmit() types
+
+Both bond_alb_xmit() and bond_tlb_xmit() produce a valid warning with
+gcc-13:
+  drivers/net/bonding/bond_alb.c:1409:13: error: conflicting types for 'bond_tlb_xmit' due to enum/integer mismatch; have 'netdev_tx_t(struct sk_buff *, struct net_device *)' ...
+  include/net/bond_alb.h:160:5: note: previous declaration of 'bond_tlb_xmit' with type 'int(struct sk_buff *, struct net_device *)'
+
+  drivers/net/bonding/bond_alb.c:1523:13: error: conflicting types for 'bond_alb_xmit' due to enum/integer mismatch; have 'netdev_tx_t(struct sk_buff *, struct net_device *)' ...
+  include/net/bond_alb.h:159:5: note: previous declaration of 'bond_alb_xmit' with type 'int(struct sk_buff *, struct net_device *)'
+
+I.e. the return type of the declaration is int, while the definitions
+spell netdev_tx_t. Synchronize both of them to the latter.
+
+Cc: Martin Liska <mliska@suse.cz>
+Cc: Jay Vosburgh <j.vosburgh@gmail.com>
+Cc: Veaceslav Falico <vfalico@gmail.com>
+Cc: Andy Gospodarek <andy@greyhouse.net>
+Signed-off-by: Jiri Slaby (SUSE) <jirislaby@kernel.org>
+Link: https://lore.kernel.org/r/20221031114409.10417-1-jirislaby@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 777fa87c7682228e155cf0892ba61cb2ab1fe3ae)
+---
+ include/net/bond_alb.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/net/bond_alb.h b/include/net/bond_alb.h
+index 191c36afa1f4..9dc082b2d543 100644
+--- a/include/net/bond_alb.h
++++ b/include/net/bond_alb.h
+@@ -156,8 +156,8 @@ int bond_alb_init_slave(struct bonding *bond, struct slave *slave);
+ void bond_alb_deinit_slave(struct bonding *bond, struct slave *slave);
+ void bond_alb_handle_link_change(struct bonding *bond, struct slave *slave, char link);
+ void bond_alb_handle_active_change(struct bonding *bond, struct slave *new_slave);
+-int bond_alb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
+-int bond_tlb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
++netdev_tx_t bond_alb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
++netdev_tx_t bond_tlb_xmit(struct sk_buff *skb, struct net_device *bond_dev);
+ struct slave *bond_xmit_alb_slave_get(struct bonding *bond,
+ 				      struct sk_buff *skb);
+ struct slave *bond_xmit_tlb_slave_get(struct bonding *bond,
+-- 
+2.42.0
+

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -94,6 +94,9 @@ pkgsAarch64.buildLinux (args // {
     # random crashes very early in boot process on Xavier NX specifically
     # Remove when updating to 35.5.0
     { patch = ./0009-Revert-random-use-static-branch-for-crng_ready.patch; }
+
+    # Fix an issue building with gcc13
+    { patch = ./0010-bonding-gcc13-synchronize-bond_-a-t-lb_xmit-types.patch; }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes

This patch is needed to fix GCC 13 builds of the Linux kernel. This was mistakenly removed during the update to L4T 35.4.1.  Thanks @hacker1024 for pointing this out

###### Testing

Built the jetson kernel using `nixos-unstable` as of 2024-05-07