### PR TITLE
Change priority of `nixpkgs.hostPlatform`

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -91,7 +91,9 @@ in
       message = "Docker version < 25 does not support CDI";
     }];
 
-    nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+    # Use mkOptionDefault so that we prevent conflicting with the priority that
+    # `nixos-generate-config` uses.
+    nixpkgs.hostPlatform = lib.mkOptionDefault "aarch64-linux";
 
     nixpkgs.overlays = [
       (import ../overlay.nix)


### PR DESCRIPTION
###### Description of changes

We should prevent colliding priorities with configs that have `nixpkgs.hostPlatform` set from the output of `nixos-generate-config`.

###### Testing

N/A
