### PR TITLE
Add simple OCI test

### DIFF
--- a/UPGRADE_CHECKLIST.md
+++ b/UPGRADE_CHECKLIST.md
@@ -12,6 +12,7 @@
 - [ ] Ensure the soc variants in `modules/flash-script.nix` match those in `jetson_board_spec.cfg` from BSP
 - [ ] Ensure logic in `ota-utils/ota_helpers.func` matches `nvidia-l4t-init/opt/nvidia/nv-l4t-bootloader-config.sh`
 - [ ] Run `nix build .#genL4tJson` and copy output to `pkgs/containers/l4t.json`
+- [ ] Run `skopeo inspect docker://nvcr.io/nvidia/l4t-jetpack/r${l4tVersion}` to udpate FOD for l4t-jetpack OCI image in `./pkgs/tests/default.nix`
 
 ### Testing
 - [ ] Run `nix flake check`

--- a/default.nix
+++ b/default.nix
@@ -95,6 +95,8 @@ let
 
   samples = callPackages ./pkgs/samples { inherit debs cudaVersion autoAddOpenGLRunpathHook l4t cudaPackages; };
 
+  tests = callPackages ./pkgs/tests { inherit l4tVersion; };
+
   kernel = callPackage ./kernel { inherit (l4t) l4t-xusb-firmware; kernelPatches = [ ]; };
   kernelPackagesOverlay = self: super: {
     nvidia-display-driver = self.callPackage ./kernel/display-driver.nix { inherit gitRepos l4tVersion; };

--- a/pkgs/tests/default.nix
+++ b/pkgs/tests/default.nix
@@ -1,0 +1,43 @@
+{ l4tVersion
+, dockerTools
+, writeShellScriptBin
+}:
+let
+  l4tImage = dockerTools.pullImage {
+    imageName = "nvcr.io/nvidia/l4t-jetpack";
+    imageDigest = "sha256:d1c8e971ab994235840eacc31c4ef4173bf9156317b1bf8aabe7e01eb21b2a0e";
+    finalImageTag = "r35.4.1";
+    sha256 = "sha256-IDePYGssk6yrcaocnluxBaRJb7BrXxS7tBlEo6hNtHw=";
+    os = "linux";
+    arch = "arm64";
+  };
+in
+{
+  oci = writeShellScriptBin "oci-test" ''
+    image=${l4tImage.imageName}:${l4tImage.imageTag}
+    container_commands="cd /usr/local/cuda/samples/1_Utilities/deviceQuery && make && ./deviceQuery"
+
+    for runtime in docker podman; do
+      if command -v $runtime 2>&1 >/dev/null; then
+        echo "testing $runtime runtime"
+      else
+        echo "$runtime runtime not found, skipping"
+        continue
+      fi
+
+      "$runtime" load --input=${l4tImage}
+
+      if "$runtime" run --rm "$image" bash -c "$container_commands"; then
+        echo "container run w/o nvidia passthru unexpectedly succeeded"
+        exit 1
+      fi
+
+      if ! "$runtime" run --rm --device=nvidia.com/gpu=all "$image" bash -c "$container_commands"; then
+        echo "container run w/nvidia passthru unexpectedly failed"
+        exit 1
+      fi
+
+      "$runtime" image rm "$image"
+    done
+  '';
+}


### PR DESCRIPTION
###### Description of changes

This test ensures that device passthrough to OCI containers works for the docker and podman runtime by using the `deviceQuery` tool NVIDIA ships source for in their l4t-jetpack image. It also tests for false- positives.


###### Testing

Tested on an orin-agx-devkit and xavier-agx-devkit with both docker and podman enabled at the same time (docker version 25.0.0)
