### PR TITLE
Retain linux-firmware basename

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -38,7 +38,7 @@ let
         if [[ -f $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath}) ]]; then
           install -Dm0444 \
             --target-directory=$(dirname $out/lib/firmware/${firmwarePath}) \
-            $(realpath ${pkgs.linux-firmware}/lib/firmware/${firmwarePath})
+            ${pkgs.linux-firmware}/lib/firmware/${firmwarePath}
         else
           echo "WARNING: lib/firmware/${firmwarePath} does not exist in linux-firmware ${pkgs.linux-firmware.version}"
         fi


### PR DESCRIPTION

###### Description of changes

Some files in linux-firmware are symlinks, so when we extract them into a smaller derivation, we should retain the same filename to ensure a driver needing firmware is able to find the right file. The `install` tool will dereference the symlink and use the symlink's basename to ensure we get the right content at the right location.


###### Testing

Tested building a nixos config's `config.hardware.firmware` for an orin-nx and confirmed that all the correct rtl nic firmware was present
