### PR TITLE
Bump to NixOS 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702780907,
-        "narHash": "sha256-blbrBBXjjZt6OKTcYX1jpe9SRof2P9ZYWPzq22tzXAA=",
+        "lastModified": 1718208800,
+        "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e2e384c5b7c50dbf8e9c441a9e58d85f408b01f",
+        "rev": "cc54fb41d13736e92229c21627ea4f22199fee6b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
   };
 
   outputs = { self, nixpkgs, ... }@inputs:

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -4,7 +4,6 @@
 , dpkg
 , pkg-config
 , autoAddOpenGLRunpathHook
-, freeimage
 , cmake
 , opencv
 , opencv2
@@ -86,7 +85,7 @@ let
     sourceRoot = "source/usr/src/cudnn_samples_v8";
 
     nativeBuildInputs = [ dpkg autoAddOpenGLRunpathHook ];
-    buildInputs = with cudaPackages; [ cudatoolkit cudnn freeimage ];
+    buildInputs = with cudaPackages; [ cudatoolkit cudnn ];
 
     buildFlags = [
       "CUDA_PATH=${cudaPackages.cudatoolkit}"
@@ -96,10 +95,11 @@ let
 
     enableParallelBuilding = true;
 
+    # Disabled mnistCUDNN since it requires freeimage which is marked vulnerable in upstream as of 24.05
     buildPhase = ''
       runHook preBuild
 
-      for dirname in conv_sample mnistCUDNN multiHeadAttention RNN_v8.0; do
+      for dirname in conv_sample multiHeadAttention RNN_v8.0; do
         pushd "$dirname"
         make $buildFlags
         popd 2>/dev/null
@@ -113,7 +113,6 @@ let
 
       install -Dm755 -t $out/bin \
         conv_sample/conv_sample \
-        mnistCUDNN/mnistCUDNN \
         multiHeadAttention/multiHeadAttention \
         RNN_v8.0/RNN
 


### PR DESCRIPTION
###### Description of changes

Bumps flake.nix to NixOS 24.05

###### Testing

Tested by `nix flake check` and running all internal automated device tests. (boot, flash, samples, etc)