### PR TITLE
Fix flashing Orin AGX Industrial variant

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -60,6 +60,9 @@ let
         export CHIP_SKU=${variant.chipsku}
         ''}
         export CHIPREV=${variant.chiprev}
+        ${lib.optionalString (variant.ramcode != null) ''
+        export RAMCODE=${variant.ramcode}
+        ''}
 
         ${cfg.firmware.secureBoot.preSignCommands}
 
@@ -67,9 +70,6 @@ let
 
         cp -r ./ $out
       '';
-      # TODO: Do we also need these? Set in l4t_create_images_for_kernel_flash.sh
-      # export RAMCODE_ID
-      # export RAMCODE
     in
     import ./flashcmd-script.nix {
       inherit lib;
@@ -151,7 +151,7 @@ let
     (mkFlashScript nvidia-jetpack.flash-tools {
       flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
         (v: with v; ''
-          BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
+          BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ${lib.optionalString (ramcode != null) "RAMCODE=${ramcode}"} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
 
           outdir=$out/${boardid}-${fab}-${boardsku}-${boardrev}-${if fuselevel == "fuselevel_production" then "1" else "0"}-${chiprev}--
           mkdir -p $outdir

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -56,7 +56,10 @@ let
         export BOARDSKU=${variant.boardsku}
         export FAB=${variant.fab}
         export BOARDREV=${variant.boardrev}
-        export CHIP_SKU=${variant.chiprev}
+        ${lib.optionalString (variant.chipsku != null) ''
+        export CHIP_SKU=${variant.chipsku}
+        ''}
+        export CHIPREV=${variant.chiprev}
 
         ${cfg.firmware.secureBoot.preSignCommands}
 
@@ -148,7 +151,7 @@ let
     (mkFlashScript nvidia-jetpack.flash-tools {
       flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
         (v: with v; ''
-          BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
+          BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
 
           outdir=$out/${boardid}-${fab}-${boardsku}-${boardrev}-${if fuselevel == "fuselevel_production" then "1" else "0"}-${chiprev}--
           mkdir -p $outdir

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -391,24 +391,24 @@ in
             ];
 
             orin-agx = [
-              { boardid = "3701"; boardsku = "0000"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D0"; }
-              { boardid = "3701"; boardsku = "0004"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D2"; } # 32GB
-              { boardid = "3701"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D0"; } # 64GB
+              { boardid = "3701"; boardsku = "0000"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D0"; }
+              { boardid = "3701"; boardsku = "0004"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D2"; } # 32GB
+              { boardid = "3701"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D0"; } # 64GB
             ];
 
             orin-agx-industrial = [
-              { boardid = "3701"; boardsku = "0008"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:90"; }
+              { boardid = "3701"; boardsku = "0008"; fab = "500"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:90"; }
             ];
 
             orin-nx = [
-              { boardid = "3767"; boardsku = "0000"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D3"; } # Orin NX 16GB
-              { boardid = "3767"; boardsku = "0001"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D4"; } # Orin NX 8GB
+              { boardid = "3767"; boardsku = "0000"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D3"; } # Orin NX 16GB
+              { boardid = "3767"; boardsku = "0001"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D4"; } # Orin NX 8GB
             ];
 
             orin-nano = [
-              { boardid = "3767"; boardsku = "0003"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D5"; } # Orin Nano 8GB
-              { boardid = "3767"; boardsku = "0004"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D6"; } # Orin Nano 4GB
-              { boardid = "3767"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D5"; } # Orin Nano devkit module
+              { boardid = "3767"; boardsku = "0003"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D5"; } # Orin Nano 8GB
+              { boardid = "3767"; boardsku = "0004"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D6"; } # Orin Nano 4GB
+              { boardid = "3767"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D5"; } # Orin Nano devkit module
             ];
           }.${cfg.som}
         )) else lib.mkOptionDefault [ ];

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -261,6 +261,10 @@ in
                 type = types.str;
                 default = "";
               };
+              ramcode = lib.mkOption {
+                type = types.nullOr types.str;
+                default = null;
+              };
             };
           }));
         };
@@ -397,7 +401,7 @@ in
             ];
 
             orin-agx-industrial = [
-              { boardid = "3701"; boardsku = "0008"; fab = "500"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:90"; }
+              { boardid = "3701"; boardsku = "0008"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:90"; ramcode = "4"; }
             ];
 
             orin-nx = [

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -401,7 +401,11 @@ in
             ];
 
             orin-agx-industrial = [
-              { boardid = "3701"; boardsku = "0008"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:90"; ramcode = "4"; }
+              # jetson_board_spec.cfg says this is FAB 300, but the devices
+              # encountered in the wild, and NVIDIA has said FAB 500 should be
+              # right
+              # See: https://forums.developer.nvidia.com/t/jetson-agx-orin-board-id-sku-fab/278977/13
+              { boardid = "3701"; boardsku = "0008"; fab = "500"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:90"; ramcode = "4"; }
             ];
 
             orin-nx = [

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -242,6 +242,10 @@ in
               boardsku = lib.mkOption {
                 type = types.str;
               };
+              chipsku = lib.mkOption {
+                type = types.nullOr types.str;
+                default = null;
+              };
               fab = lib.mkOption {
                 type = types.str;
               };
@@ -387,24 +391,24 @@ in
             ];
 
             orin-agx = [
-              { boardid = "3701"; boardsku = "0000"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; }
-              { boardid = "3701"; boardsku = "0004"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # 32GB
-              { boardid = "3701"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # 64GB
+              { boardid = "3701"; boardsku = "0000"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D0"; }
+              { boardid = "3701"; boardsku = "0004"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D2"; } # 32GB
+              { boardid = "3701"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D0"; } # 64GB
             ];
 
             orin-agx-industrial = [
-              { boardid = "3701"; boardsku = "0008"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; }
+              { boardid = "3701"; boardsku = "0008"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:90"; }
             ];
 
             orin-nx = [
-              { boardid = "3767"; boardsku = "0000"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # Orin NX 16GB
-              { boardid = "3767"; boardsku = "0001"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # Orin NX 8GB
+              { boardid = "3767"; boardsku = "0000"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D3"; } # Orin NX 16GB
+              { boardid = "3767"; boardsku = "0001"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D4"; } # Orin NX 8GB
             ];
 
             orin-nano = [
-              { boardid = "3767"; boardsku = "0003"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # Orin Nano 8GB
-              { boardid = "3767"; boardsku = "0004"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # Orin Nano 4GB
-              { boardid = "3767"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; } # Orin Nano devkit module
+              { boardid = "3767"; boardsku = "0003"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D5"; } # Orin Nano 8GB
+              { boardid = "3767"; boardsku = "0004"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D6"; } # Orin Nano 4GB
+              { boardid = "3767"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku="00:00:00:D5"; } # Orin Nano devkit module
             ];
           }.${cfg.som}
         )) else lib.mkOptionDefault [ ];

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -116,7 +116,7 @@ final: prev: (
             # TODO: Remove preSignCommands when we switch to using signedFirmware directly
             flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
               (v: with v;
-              "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ./flash.sh ${lib.optionalString (cfg.flashScriptOverrides.partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString cfg.flashScriptOverrides.flashArgs}"
+              "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ./flash.sh ${lib.optionalString (cfg.flashScriptOverrides.partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString cfg.flashScriptOverrides.flashArgs}"
               )
               cfg.firmware.variants;
           }) + ''

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -116,7 +116,7 @@ final: prev: (
             # TODO: Remove preSignCommands when we switch to using signedFirmware directly
             flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
               (v: with v;
-              "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ./flash.sh ${lib.optionalString (cfg.flashScriptOverrides.partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString cfg.flashScriptOverrides.flashArgs}"
+              "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ${lib.optionalString (ramcode != null) "RAMCODE=${ramcode}"} ./flash.sh ${lib.optionalString (cfg.flashScriptOverrides.partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString cfg.flashScriptOverrides.flashArgs}"
               )
               cfg.firmware.variants;
           }) + ''


### PR DESCRIPTION
###### Description of changes

The standard flash.sh script would successfully flash the device, however, the single variant flash script and the initrd-based flash scripts would not.  This was due to not setting various necessary environment variables.

###### Testing

Tested both flash scripts and booted Orin AGX Industrial on a devkit.