### PR TITLE
Fixed fuse script build error

### DIFF
--- a/device-pkgs/flash-script.nix
+++ b/device-pkgs/flash-script.nix
@@ -1,4 +1,3 @@
-flash-tools:
 { lib
 , preFlashCommands ? ""
 , flashCommands ? ""
@@ -17,6 +16,8 @@ flash-tools:
   eksFile ? null
 , # Additional DTB overlays to use during device flashing
   additionalDtbOverlays ? [ ]
+,
+  flash-tools
 }:
 (''
   set -euo pipefail

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -97,8 +97,8 @@ final: prev: (
       # you give it, so if your flash-tools is for an x86_64-linux
       # hostPlatform, then mkFlashScript will generate script commands that
       # will need to be ran on x86_64-linux.
-      mkFlashScript = flash-tools: args: (import ./device-pkgs/flash-script.nix flash-tools) ({
-        inherit lib;
+      mkFlashScript = flash-tools: args: import ./device-pkgs/flash-script.nix ({
+        inherit lib flash-tools;
         inherit (cfg.firmware) eksFile;
         inherit (cfg.flashScriptOverrides) additionalDtbOverlays flashArgs partitionTemplate;
         inherit (finalJetpack) tosImage socType uefi-firmware;


### PR DESCRIPTION
###### Description of changes
Fixed fuse script build error:
```
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'write-pulsar-nx-fuse'
         whose name attribute is located at /nix/store/gxzsyp45pxvwk5yj4q9sdb6rrndyfc1z-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'text' of derivation 'write-pulsar-nx-fuse'

         at /nix/store/gxzsyp45pxvwk5yj4q9sdb6rrndyfc1z-source/pkgs/build-support/trivial-builders/default.nix:148:16:

          147|     runCommand name
          148|       { inherit text executable checkPhase allowSubstitutes preferLocalBuild;
             |                ^
          149|         passAsFile = [ "text" ];

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: cannot coerce a function to a string
```


###### Testing
With this changes, the fuse script closure builds