### PR TITLE
Remove uses of lib.mdDoc

### DIFF
--- a/device-pkgs/flash-script.nix
+++ b/device-pkgs/flash-script.nix
@@ -16,8 +16,7 @@
   eksFile ? null
 , # Additional DTB overlays to use during device flashing
   additionalDtbOverlays ? [ ]
-,
-  flash-tools
+, flash-tools
 }:
 (''
   set -euo pipefail

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -75,7 +75,7 @@ in
           "xavier-nx-emmc"
         ];
         default = "generic";
-        description = lib.mdDoc ''
+        description = ''
           Jetson SoM (System-on-Module) to target. Can be set to "generic" to target a generic jetson device, but some things may not work.
         '';
       };
@@ -86,7 +86,7 @@ in
           "devkit"
         ];
         default = "generic";
-        description = lib.mdDoc ''
+        description = ''
           Jetson carrier board to target. Can be set to "generic" to target a generic jetson carrier board, but some things may not work.
         '';
       };

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -59,7 +59,7 @@ in
 
           edk2NvidiaPatches = mkOption {
             type = types.listOf types.path;
-            description = lib.mdDoc ''
+            description = ''
               Patches that will be applied to the edk2-nvidia repo
             '';
             default = [ ];
@@ -67,7 +67,7 @@ in
 
           edk2UefiPatches = mkOption {
             type = types.listOf types.path;
-            description = lib.mdDoc ''
+            description = ''
               Patches that will be applied to the nvidia edk2 repo which is nvidia's fork of the upstream edk2 repo
             '';
             default = [ ];
@@ -77,19 +77,19 @@ in
             enrollDefaultKeys = lib.mkEnableOption "enroll default UEFI keys";
             defaultPkEslFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to the UEFI PK EFI Signature List (ESL).
               '';
             };
             defaultKekEslFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to the UEFI KEK Signature List (ESL).
               '';
             };
             defaultDbEslFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to the UEFI DB Signature List (ESL).
               '';
             };
@@ -100,7 +100,7 @@ in
 
             trustedPublicCertPemFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to the public certificate (in DER format) that will be
                 used for validating capsule updates. Capsule files must be signed
                 with a private key in the same certificate chain. This file will
@@ -110,7 +110,7 @@ in
 
             otherPublicCertPemFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to another public certificate (in PEM format) that will
                 be used when signing capsule payloads. This can be the same as
                 `trustedPublicCertPem`, but it can also be an intermediate
@@ -120,7 +120,7 @@ in
 
             signerPrivateCertPemFile = mkOption {
               type = lib.types.path;
-              description = lib.mdDoc ''
+              description = ''
                 The path to the private certificate (in PEM format) that will be
                 used for signing capsule payloads.
               '';
@@ -129,7 +129,7 @@ in
             requiredSystemFeatures = lib.mkOption {
               type = types.listOf types.str;
               default = [ ];
-              description = lib.mdDoc ''
+              description = ''
                 Additional `requiredSystemFeatures` to add to derivations which
                 make use of capsule authentication private keys.
               '';
@@ -150,7 +150,7 @@ in
             extraArgs = mkOption {
               type = types.listOf types.str;
               default = [ ];
-              description = lib.mdDoc ''
+              description = ''
                 Extra arguments to pass to tee-supplicant.
               '';
             };
@@ -158,7 +158,7 @@ in
             trustedApplications = mkOption {
               type = types.listOf types.package;
               default = [ ];
-              description = lib.mdDoc ''
+              description = ''
                 Trusted applications that will be loaded into the TEE on
                 supplicant startup.
               '';
@@ -167,7 +167,7 @@ in
             plugins = mkOption {
               type = types.listOf types.package;
               default = [ ];
-              description = lib.mdDoc ''
+              description = ''
                 A list of packages containing TEE supplicant plugins. TEE
                 supplicant will load each plugin file in the top level of each
                 package on startup.
@@ -188,7 +188,7 @@ in
           taPublicKeyFile = mkOption {
             type = types.nullOr types.path;
             default = null;
-            description = lib.mdDoc ''
+            description = ''
               The public key to build into optee OS that will be used for
               verifying loaded runtime TAs. If not provided, TAs are verified
               with the public key derived from the private key in optee's


### PR DESCRIPTION
###### Description of changes
`mdDoc` is no longer used in upstream Nixpkgs as of 24.05.

###### Testing
`nix flake check --system aarch64-linux` passes.