### PR TITLE
cudaPackages.autoAddOpenGLRunpathHook -> autoAddDriverRunpath

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -87,12 +87,12 @@ in
         l4t-cuda
         l4t-cupva
         l4t-multimedia;
-      inherit (prev.cudaPackages) autoAddOpenGLRunpathHook;
+      inherit (prev) autoAddDriverRunpath;
     };
 
     samples = prev.callPackages ./pkgs/samples {
       inherit (self) debs cudaVersion cudaPackages l4t-cuda l4t-multimedia l4t-camera;
-      inherit (prev.cudaPackages) autoAddOpenGLRunpathHook;
+      inherit (prev) autoAddDriverRunpath;
     };
 
     tests = prev.callPackages ./pkgs/tests { inherit l4tVersion; };

--- a/pkgs/cuda-packages/default.nix
+++ b/pkgs/cuda-packages/default.nix
@@ -10,7 +10,7 @@ in
 , dpkg
 , makeWrapper
 , autoPatchelfHook
-, autoAddOpenGLRunpathHook
+, autoAddDriverRunpath
 , symlinkJoin
 , expat
 , pkg-config
@@ -90,7 +90,7 @@ let
       pname = name;
       inherit version srcs;
 
-      nativeBuildInputs = [ dpkg autoPatchelfHook autoAddOpenGLRunpathHook ] ++ nativeBuildInputs;
+      nativeBuildInputs = [ dpkg autoPatchelfHook autoAddDriverRunpath ] ++ nativeBuildInputs;
       buildInputs = [ stdenv.cc.cc.lib ] ++ buildInputs;
 
       unpackCmd = "for src in $srcs; do dpkg-deb -x $src source; done";

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , dpkg
 , pkg-config
-, autoAddOpenGLRunpathHook
+, autoAddDriverRunpath
 , cmake
 , opencv
 , opencv2
@@ -44,7 +44,7 @@ let
 
     patches = [ ./cuda-samples.patch ];
 
-    nativeBuildInputs = [ dpkg pkg-config autoAddOpenGLRunpathHook ];
+    nativeBuildInputs = [ dpkg pkg-config autoAddDriverRunpath ];
     buildInputs = [ cudaPackages.cudatoolkit ];
 
     preConfigure = ''
@@ -86,7 +86,7 @@ let
     unpackCmd = "dpkg -x $src source";
     sourceRoot = "source/usr/src/cudnn_samples_v8";
 
-    nativeBuildInputs = [ dpkg autoAddOpenGLRunpathHook ];
+    nativeBuildInputs = [ dpkg autoAddDriverRunpath ];
     buildInputs = with cudaPackages; [ cudatoolkit cudnn ];
 
     buildFlags = [
@@ -190,7 +190,7 @@ let
     unpackCmd = "dpkg -x $src source";
     sourceRoot = "source/usr/src/tensorrt/samples";
 
-    nativeBuildInputs = [ dpkg autoAddOpenGLRunpathHook ];
+    nativeBuildInputs = [ dpkg autoAddDriverRunpath ];
     buildInputs = with cudaPackages; [ tensorrt cuda_profiler_api cudnn ];
 
     # These environment variables are required by the /usr/src/tensorrt/samples/README.md


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

Updates all references of `cudaPackages.autoAddOpenGLRunpathHook` to `autoAddDriverRunpath`. See https://github.com/NixOS/nixpkgs/issues/141803.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
