### PR TITLE
Remove pre-built dtc binaries

### DIFF
--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -59,6 +59,13 @@ let
       # We should never be flashing upstream's kernel, so just remove it so we get errors if it is used
       #rm -f kernel/Image*
 
+      # Replace pre-built binaries for utilities that we already have available
+      # with nix. There are places in flash.sh that expect for these paths to
+      # exist, so it is not enough to just remove them and have the utilities
+      # available in PATH.
+      ln -sf ${lib.getExe' dtc "dtc"} kernel/dtc
+      ln -sf ${lib.getExe' dtc "fdtoverlay"} kernel/fdtoverlay
+
       # Remove the big nv_tegra dir, since its not neede by flash scripts.
       # However, save the needed bsp_version file
       mv nv_tegra/bsp_version .


### PR DESCRIPTION
###### Description of changes

Since we aren't always using flash-tools on x86_64-linux, using pre-built dtc and fdtoverlay doesn't always work. We should prefer the dtc package that we provide with nix over the pre-built ones nvidia provides.

There aren't actually that many pre-built binaries, and these appear to be the only ones that are otherwise available through nixpkgs:
```
$ fd --type executable . ./result-bspSrc --exec file {} \; | rg ELF
./result/tools/ota_tools/version_upgrade/nv_kernel_bootctrl_generator: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=b4e95940fbcb81d1e276a8d19b5db920ddb8ae40, with debug_info, not stripped
./result/tools/dcb_tool/dcb_tool: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=848aef403c4d94185434ff3a84801a16b136edb5, with debug_info, not stripped
./result/kernel/fdtoverlay: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=b5beef2abc45f47495706ac90af5b49ae473cd03, not stripped
./result/tools/kernel_flash/bin/nvsimg2img: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=a3ece0738a21aacc9d50d9fb8dbf680cbe8608d3, with debug_info, not stripped
./result/kernel/dtc: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.2.0, BuildID[sha1]=f9a50491970142625789a203ae9f70bb3530f572, not stripped
./result/bootloader/tegrahost_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=c02d332f935090dd130a0939c5856b592c31e8bd, with debug_info, not stripped
./result/tools/kernel_flash/bin/aarch64/simg2img: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=72d8c216f06bab16112226d4046f6aa9da87adac, not stripped
./result/bootloader/tegrarcm_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=5742958219f853ef82704446ebb1bae1d8c99d52, with debug_info, not stripped
./result/bootloader/tegraopenssl: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=5314828452ea3dad4a0c67bd487c5c9cd4715a10, with debug_info, not stripped
./result/bootloader/tegrabct_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=f2422d45d7294a03ae309003439bc7e79b7b6898, with debug_info, not stripped
./result/bootloader/mkbootimg: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=af11cc3c5344b225ba760dfc6150a7d0516a807c, with debug_info, not stripped
./result/bootloader/tegraparser_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=c68a19ff5c38a7d50e486736d8ff76147f7c4386, with debug_info, not stripped
./result/bootloader/chkbdinfo: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=e7593bb90662e589e1a7cd4041b858d6ca398600, with debug_info, not stripped
./result/bootloader/mksparse: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=d8cd2d6b1ca31f39f7080c22a40bdacdd82e15b0, with debug_info, not stripped
./result/bootloader/mkbctpart: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=9b63a637c3fbb2a875922eafdbc30172635cedde, with debug_info, not stripped
./result/bootloader/tegrasign_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=bdaa1e62a9fd78568ead9b97cb5755bd97bf7cca, with debug_info, not stripped
./result/bootloader/tegradevflash_v2: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=4aca841006744170085ea0e6e70d34e85dc9606c, with debug_info, not stripped
./result/bootloader/tegrakeyhash: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, for GNU/Linux 2.6.8, BuildID[sha1]=bc13267d96bf9368442aa0f00a60ff41ffdf6adb, with debug_info, not stripped
```
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested building the `config.system.build.uefiCapsuleUpdate` attribute for an orin-agx-devkit (natively compiled, aka aarch64-linux builder) and ensured that building the BUP (dependency of capsule update derivation) didn't complain about being unable to run the program at ./kernel/dtc.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
