### PR TITLE
Add option for postFlashCommands

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -315,6 +315,14 @@ in
           default = [ ];
           description = "A list of paths to compiled .dtbo files to include with the UEFI image while flashing. These overlays are applied by UEFI at runtime";
         };
+
+        postFlashCommands = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Additional commands to run after a successful flash.
+          '';
+        };
       };
 
       flashScript = mkOption {

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -100,7 +100,7 @@ final: prev: (
       mkFlashScript = flash-tools: args: import ./device-pkgs/flash-script.nix ({
         inherit lib flash-tools;
         inherit (cfg.firmware) eksFile;
-        inherit (cfg.flashScriptOverrides) additionalDtbOverlays flashArgs partitionTemplate;
+        inherit (cfg.flashScriptOverrides) additionalDtbOverlays flashArgs partitionTemplate postFlashCommands;
         inherit (finalJetpack) tosImage socType uefi-firmware;
 
         dtbsDir = config.hardware.deviceTree.package;


### PR DESCRIPTION


###### Description of changes

The argument to `flash-script.nix` already existed, this just adds an option that allows users to hook into this.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested building the flash script with a non-empty value set in the new option and ensured the value was present in the final script.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
