### PR TITLE
Move libnvidia-ptxjitcompiler library into l4t-cuda

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -102,6 +102,7 @@ let
     buildInputs = [ stdenv.cc.cc.lib expat libglvnd ];
   };
 
+  # TODO: Split this package up into subpackages similar to what is done in meta-tegra: vulkan, glx, egl, etc
   l4t-3d-core = buildFromDeb {
     name = "nvidia-l4t-3d-core";
     buildInputs = [ l4t-core libglvnd egl-wayland ];
@@ -121,9 +122,8 @@ let
       rm -rf lib/tegra-egl
       rm -f lib/nvidia.json
 
-      # Make some symlinks also done by OE4T
-      ln -sf libnvidia-ptxjitcompiler.so.${l4tVersion} lib/libnvidia-ptxjitcompiler.so.1
-      ln -sf libnvidia-ptxjitcompiler.so.${l4tVersion} lib/libnvidia-ptxjitcompiler.so
+      # Remove libnvidia-ptxjitcompiler, which is included in l4t-cuda instead
+      rm -f lib/libnvidia-ptxjitcompiler.*
 
       # Some libraries, like libEGL_nvidia.so.0 from l4t-3d-core use a dlopen
       # wrapper called NvOsLibraryLoad, which originates in libnvos.so in
@@ -177,6 +177,18 @@ let
       # Additional libcuda symlinks
       ln -sf libcuda.so.1.1 lib/libcuda.so.1
       ln -sf libcuda.so.1.1 lib/libcuda.so
+
+      # Also unpack l4t-3d-core so we can grab libnvidia-ptxjitcompiler from it
+      # and include it in this library.
+      #
+      # It's unclear why NVIDIA has this library in l4t-3d-core and not in
+      # l4t-core. Even more so since the cuda compat package has libcuda as
+      # well as libnvidia-ptxjitcompiler in the same package. meta-tegra does a
+      # similar thing where they pull libnvidia-ptxjitcompiler out of
+      # l4t-3d-core and place it in the same package as libcuda.
+      dpkg --fsys-tarfile ${debs.t234.nvidia-l4t-3d-core.src} | tar -xO ./usr/lib/aarch64-linux-gnu/tegra/libnvidia-ptxjitcompiler.so.${l4tVersion} > lib/libnvidia-ptxjitcompiler.so.${l4tVersion}
+      ln -sf libnvidia-ptxjitcompiler.so.${l4tVersion} lib/libnvidia-ptxjitcompiler.so.1
+      ln -sf libnvidia-ptxjitcompiler.so.${l4tVersion} lib/libnvidia-ptxjitcompiler.so
     '';
 
     # libcuda.so actually depends on libnvcucompat.so at runtime (probably

--- a/pkgs/samples/default.nix
+++ b/pkgs/samples/default.nix
@@ -68,10 +68,15 @@ let
   cuda-test = writeShellApplication {
     name = "cuda-test";
     text = ''
-      for binary in deviceQuery deviceQueryDrv bandwidthTest clock clock_nvrtc; do
+      BINARIES=(
+        deviceQuery deviceQueryDrv bandwidthTest clock clock_nvrtc
+        matrixMul matrixMulCUBLAS matrixMulDrv matrixMulDynlinkJIT
+      )
+      # clock_nvrtc expects .cu files under $PWD/data
+      cd ${cuda-samples}/bin
+      for binary in "''${BINARIES[@]}"; do
         echo " * Running $binary"
-        # clock_nvrtc expects .cu files under $PWD/data
-        (cd ${cuda-samples}; ${cuda-samples}/bin/$binary)
+        ./"$binary"
         echo
         echo
       done


### PR DESCRIPTION
###### Description of changes

This library is needed for runtime PTX compilation. It's unclear why NVIDIA has this library in l4t-3d-core and not in l4t-cuda. Even more so since the cuda compat package has libcuda as well as libnvidia-ptxjitcompiler in the same package. meta-tegra does a similar thing where they pull libnvidia-ptxjitcompiler out of l4t-3d-core and place it in the same package as libcuda.

Additionally, add matrixMul* samples, including matrixMulDynlinkJIT specifically, which was failing to run previously.

Fixes #184 

###### Testing

Tested matrixMulDynlinkJIT sample now runs on an Orin AGX devkit