### PR TITLE
Fix libcupti RPATH and add CUPTI samples

### DIFF
--- a/pkgs/cuda-packages/default.nix
+++ b/pkgs/cuda-packages/default.nix
@@ -180,7 +180,19 @@ let
       '';
     };
     cuda_cuobjdump = buildFromSourcePackage { name = "cuda-cuobjdump"; };
-    cuda_cupti = buildFromSourcePackage { name = "cuda-cupti"; };
+    cuda_cupti = buildFromSourcePackage {
+      name = "cuda-cupti";
+
+      # We append a postFixupHook since we need to have this happen after
+      # autoPatchelfHook, which itself also runs as a postFixupHook.
+      # TODO: Use runtimeDependencies instead
+      preFixup = ''
+        postFixupHooks+=('
+          # dlopen in libcupti.so needs to be able to access these libnvperf_host.so in this directory
+          patchelf --add-rpath $out/lib $(readlink -f $out/lib/libcupti.so)
+        ')
+      '';
+    };
     cuda_cuxxfilt = buildFromSourcePackage { name = "cuda-cuxxfilt"; };
     cuda_documentation = buildFromSourcePackage { name = "cuda-documentation"; };
     cuda_gdb = buildFromSourcePackage { name = "cuda-gdb"; buildInputs = [ expat ]; };


### PR DESCRIPTION
###### Description of changes

CUPTI was not working because it was lacking an RPATH entry that would ensure it can load libraries in the same directory (e.g. libnvperf_host.so).

###### Testing

Tested by running CUPTI samples on Orin AGX devkit and Xavier AGX devkit
