### PR TITLE
Add bc to nv_fuse_read.sh path

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -19,6 +19,8 @@
 , gst_all_1
 , gtk3
 , libv4l
+, makeWrapper
+, bc
 , debs
 , l4tVersion
 }:
@@ -361,10 +363,14 @@ let
   # For tegrastats and jetson_clocks
   l4t-tools = buildFromDeb {
     name = "nvidia-l4t-tools";
+    nativeBuildInputs = [ makeWrapper ];
     buildInputs = [ stdenv.cc.cc.lib l4t-core ];
     # Remove some utilities that bring in too many libraries
     postPatch = ''
       rm bin/nv_macsec_wpa_supplicant
+    '';
+    postFixup = ''
+      wrapProgram $out/bin/nv_fuse_read.sh --prefix PATH : ${lib.makeBinPath [ bc ]}
     '';
   };
 


### PR DESCRIPTION
###### Description of changes

The nv_fuse_read.sh shell script (in `l4t-tools`) expects `bc` to be in PATH.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Tested on a fused xavier-agx and an unfused orin-agx.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
