### PR TITLE
Allow accessing correct `pkgs` during `preSignCommands`

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -15,6 +15,7 @@
 , runCommand
 , writeScript
 , writeShellApplication
+, buildPackages
 }:
 
 let
@@ -64,7 +65,7 @@ let
         export RAMCODE=${variant.ramcode}
         ''}
 
-        ${cfg.firmware.secureBoot.preSignCommands}
+        ${cfg.firmware.secureBoot.preSignCommands buildPackages}
 
         ${mkFlashScript nvidia-jetpack.flash-tools (args // { flashArgs = [ "--no-root-check" "--no-flash" ] ++ (args.flashArgs or flashArgs); }) }
 
@@ -149,7 +150,9 @@ let
       inherit (cfg.firmware.secureBoot) requiredSystemFeatures;
     }
     (mkFlashScript nvidia-jetpack.flash-tools {
-      flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
+      flashCommands = ''
+        ${cfg.firmware.secureBoot.preSignCommands buildPackages}
+      '' + lib.concatMapStringsSep "\n"
         (v: with v; ''
           BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ${lib.optionalString (ramcode != null) "RAMCODE=${ramcode}"} ./flash.sh ${lib.optionalString (partitionTemplate != null) "-c flash.xml"} --no-root-check --no-flash --sign ${builtins.toString flashArgs}
 

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -136,9 +136,20 @@ in
             };
 
             preSignCommands = lib.mkOption {
-              type = types.lines;
+              type = types.oneOf [ (types.functionTo types.lines) types.lines ];
+              apply = val: if lib.isFunction val then val else _: val;
               default = "";
-              description = "Additional commands to run before performing operation that involve signing. Can be used to set up environment to interact with an external HSM.";
+              description = ''
+                Additional commands to run before performing operation that
+                involve signing. Can be used to set up environment to interact
+                with an external HSM.
+
+                Since preSignCommands is used in different contexts where the
+                package-set in use may differ (mostly in order to satisfy
+                building NVIDIA's flash scripts for x86_64-linux), you should
+                define this option to be a function that accepts the `pkgs`
+                package-set if you need to access something from it.
+              '';
             };
           };
         };
@@ -225,9 +236,20 @@ in
           };
 
           preSignCommands = lib.mkOption {
-            type = types.lines;
+            type = types.oneOf [ (types.functionTo types.lines) types.lines ];
+            apply = val: if lib.isFunction val then val else _: val;
             default = "";
-            description = "Additional commands to run before performing operation that involve signing. Can be used to set up environment to interact with an external HSM.";
+            description = ''
+              Additional commands to run before performing operation that
+              involve signing. Can be used to set up environment to interact
+              with an external HSM.
+
+              Since preSignCommands is used in different contexts where the
+              package-set in use may differ (mostly in order to satisfy
+              building NVIDIA's flash scripts for x86_64-linux), you should
+              define this option to be a function that accepts the `pkgs`
+              package-set if you need to access something from it.
+            '';
           };
         };
 

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -114,7 +114,9 @@ final: prev: (
           final.pkgsBuildBuild.nvidia-jetpack.flash-tools # we need flash-tools for the buildPlatform
           {
             # TODO: Remove preSignCommands when we switch to using signedFirmware directly
-            flashCommands = cfg.firmware.secureBoot.preSignCommands + lib.concatMapStringsSep "\n"
+            flashCommands = ''
+              ${cfg.firmware.secureBoot.preSignCommands final.buildPackages}
+            '' + lib.concatMapStringsSep "\n"
               (v: with v;
               "BOARDID=${boardid} BOARDSKU=${boardsku} FAB=${fab} BOARDREV=${boardrev} FUSELEVEL=${fuselevel} CHIPREV=${chiprev} ${lib.optionalString (chipsku != null) "CHIP_SKU=${chipsku}"} ${lib.optionalString (ramcode != null) "RAMCODE=${ramcode}"} ./flash.sh ${lib.optionalString (cfg.flashScriptOverrides.partitionTemplate != null) "-c flash.xml"} --no-flash --bup --multi-spec ${builtins.toString cfg.flashScriptOverrides.flashArgs}"
               )
@@ -133,7 +135,7 @@ final: prev: (
           inherit (cfg.firmware.uefi.capsuleAuthentication) requiredSystemFeatures;
         }
         (''
-          ${cfg.firmware.uefi.capsuleAuthentication.preSignCommands}
+          ${cfg.firmware.uefi.capsuleAuthentication.preSignCommands final.buildPackages}
           bash ${finalJetpack.flash-tools}/generate_capsule/l4t_generate_soc_capsule.sh \
         '' + (lib.optionalString cfg.firmware.uefi.capsuleAuthentication.enable ''
           --trusted-public-cert ${cfg.firmware.uefi.capsuleAuthentication.trustedPublicCertPemFile} \


### PR DESCRIPTION
###### Description of changes

`preSignCommands` is used in two different contexts, when building derivations that are using the package-set defined in the NixOS config for a machine (defaults to a native aarch64-linux package-set) and when building flash scripts (defaults to a native x86_64-linux package-set). In order to support the use-case of using nix outputs obtained from a package-set within `preSignCommands`, the value set in this option must not carry in any output paths from package-sets defined elsewhere. For example, the following configuration is problematic and will not work when building the flash script, due to `pkgs` having a `hostPlatform` of aarch64-linux, thus `hello` will be an ELF binary targeting aarch64-linux:

```nix
{ pkgs, ... }: {
  hardware.nvidia-jetpack.firmware.secureBoot.preSignCommands = ''
    ${pkgs.hello}/bin/hello
  '';
}
```

The correct usage would be:
```nix
{ ... }: {
  hardware.nvidia-jetpack.firmware.secureBoot.preSignCommands = pkgs: ''
    ${pkgs.hello}/bin/hello
  '';
}
```



<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

Tested building a simple config with the example above and ensuring we do not get an error running `hello`.