### PR TITLE
Prevent usage of hardware.nvidia-container-toolkit.enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ You can run OCI containers with jetpack-nixos by enabling the following nixos op
 }
 ```
 
+Note that on newer nixpkgs the `virtualisation.{docker,podman}.enableNvidia` option is deprecated in favor of using `hardware.nvidia-container-toolkit.enable` instead. This new option does not work yet with Jetson devices, see [this issue](https://github.com/nixos/nixpkgs/issues/344729).
+
 To run a container with access to nvidia hardware, you must specify a device to
 passthrough to the container in the [CDI](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md#overview)
 format. By default, there will be a single device setup of the kind

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,8 +25,8 @@ let
     paths = cfg.firmware.optee.supplicant.plugins;
   };
 
-  nvidiaDockerActive = with config.virtualisation; docker.enable && (docker.enableNvidia || config.hardware.nvidia-container-toolkit.enable);
-  nvidiaPodmanActive = with config.virtualisation; podman.enable && (podman.enableNvidia || config.hardware.nvidia-container-toolkit.enable);
+  nvidiaDockerActive = with config.virtualisation; docker.enable && docker.enableNvidia;
+  nvidiaPodmanActive = with config.virtualisation; podman.enable && podman.enableNvidia;
 in
 {
   imports = [
@@ -148,6 +148,10 @@ in
       {
         assertion = nvidiaDockerActive -> lib.versionAtLeast config.virtualisation.docker.package.version "25";
         message = "Docker version < 25 does not support CDI";
+      }
+      {
+        assertion = (nvidiaDockerActive || nvidiaPodmanActive) -> (!config.hardware.nvidia-container-toolkit.enable);
+        message = "hardware.nvidia-container-toolkit.enable does not work with jetson devices (yet), use virtualisation.{docker,podman}.enableNvidia instead";
       }
     ];
 


### PR DESCRIPTION
###### Description of changes

This option is not yet compatible with Jetson devices.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
Tested as in https://github.com/NixOS/nixpkgs/issues/344729. Also tested assertion is hit if we enable `hardware.nvidia-container-toolkit.enable`.