### PR TITLE
Add console.enable option to modules/default.nix

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -125,7 +125,8 @@ in
       };
 
       console.enable = mkOption {
-        default = true;
+        default = config.console.enable;
+        defaultText = "config.console.enable";
         type = types.bool;
         description = "Enable boot.kernelParams default console configuration";
       };


### PR DESCRIPTION
###### Description of changes
Added console.enable option to allow for disabling the default console boot kernelParams
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
