### PR TITLE
nvidia-ctk: 1.15.0 -> 1.16.3

### DIFF
--- a/pkgs/containers/nvidia-ctk.nix
+++ b/pkgs/containers/nvidia-ctk.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, fetchpatch }:
+{ buildGoModule, fetchFromGitHub }:
 
 let
   # From https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/Makefile#L54
@@ -6,34 +6,18 @@ let
 in
 buildGoModule rec {
   pname = "nvidia-ctk";
-  version = "1.15.0";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "nvidia";
     repo = "nvidia-container-toolkit";
     rev = "v${version}";
-    hash = "sha256-LOglihWESq9Ha+e8yvKBQwiy+v/dxNRxImKuKxPuw/8=";
+    hash = "sha256-ldEBF+5zuJAyDSUVnMPja2BvdMCNMDkp0Ye5+qFEm14=";
   };
-
-  patches = [
-    # ensure nvidia-ctk can build with Go versions less than 1.20 (currently
-    # required on their latest release)
-    (fetchpatch {
-      name = "Add-errors-Join-wrapper";
-      url = "https://github.com/NVIDIA/nvidia-container-toolkit/commit/92f17e94939bf8c213419749f5f7b48d2f0e618c.patch";
-      hash = "sha256-ioWstYky7LbIGtlfMMlbhIVN8yH7Qgp3z4wrkytT3TY=";
-    })
-    (fetchpatch {
-      name = "Fix-double-error-wrap-fmt";
-      url = "https://github.com/NVIDIA/nvidia-container-toolkit/commit/f23fd2ce38ee3a9e87ac41c265b637cf97990ac7.patch";
-      hash = "sha256-hoeMUUPWKToCR7V/JG26wF6SCoHQwQORcGimH6EXDJ8=";
-    })
-  ];
 
   subPackages = [ "cmd/nvidia-ctk" ];
 
   vendorHash = null;
-
 
   ldflags = [
     "-s"


### PR DESCRIPTION


###### Description of changes

This update also drops the patches needed to build nvidia-ctk with go < v1.20, as this version is no longer in any supported nixos release.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

OCI test in `pkgs/tests/default.nix` runs successfully on an xavier-agx and orin-agx (both devkit).
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
