### PR TITLE
Ensure declarative boot order doesn't influence initrd flash script

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -67,8 +67,6 @@ let
   );
 
   # Produces a script which boots into this NixOS system via RCM mode
-  # TODO: This doesn't work currently because `rcmBoot` would need to be built
-  # on x86_64, and the machine in `config` should be aarch64-linux
   rcmBoot = writeShellApplication {
     name = "rcmboot-nixos";
     text = mkRcmBootScript {

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -53,16 +53,18 @@ let
   };
 
   # Produces a script that boots a given kernel, initrd, and cmdline using the RCM boot method
-  mkRcmBootScript = { kernelPath, initrdPath, kernelCmdline }: mkFlashScriptAuto {
-    preFlashCommands = ''
-      cp ${kernelPath} kernel/Image
-      cp ${initrdPath} bootloader/l4t_initrd.img
+  mkRcmBootScript = { kernelPath, initrdPath, kernelCmdline, ... }@args: mkFlashScriptAuto (
+    builtins.removeAttrs args [ "kernelPath" "initrdPath" "kernelCmdline" ] // {
+      preFlashCommands = ''
+        cp ${kernelPath} kernel/Image
+        cp ${initrdPath} bootloader/l4t_initrd.img
 
-      export CMDLINE="${builtins.toString kernelCmdline}"
-      export INITRD_IN_BOOTIMG="yes"
-    '';
-    flashArgs = [ "--rcm-boot" ] ++ cfg.flashScriptOverrides.flashArgs;
-  };
+        export CMDLINE="${builtins.toString kernelCmdline}"
+        export INITRD_IN_BOOTIMG="yes"
+      '';
+      flashArgs = [ "--rcm-boot" ] ++ cfg.flashScriptOverrides.flashArgs;
+    }
+  );
 
   # Produces a script which boots into this NixOS system via RCM mode
   # TODO: This doesn't work currently because `rcmBoot` would need to be built
@@ -87,6 +89,19 @@ let
           kernelPath = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
           initrdPath = "${flashInitrd}/initrd";
           kernelCmdline = "initrd=initrd console=ttyTCU0,115200";
+          # During the initrd flash script, we upload two edk2 builds to the
+          # board, one that is only used temporarily to boot into our
+          # kernel/initrd to perform the flashing, and another one that is
+          # persisted to the firmware storage medium for future booting. We
+          # don't want to influence the boot order of the temporary edk2 since
+          # this may cause that edk2 to boot from something other than our
+          # intended flashing kernel/initrd combo (e.g. disk or network). Since
+          # the edk2 build that we actually persist to the board is embedded in
+          # the initrd used for flashing, we have the desired boot order (as
+          # configured in nix) in there and is not affected dynamically during
+          # the flashing procedure. NVIDIA ensures that when the device is
+          # using RCM boot, only the boot mode named "boot.img" is used (see https://gist.github.com/jmbaur/1ca79436e69eadc0a38ec0b43b16cb2f#file-flash-sh-L1675).
+          additionalDtbOverlays = lib.filter (path: (path.name or "") != "DefaultBootOrder.dtbo") cfg.flashScriptOverrides.additionalDtbOverlays;
         }}
         echo
         echo "Jetson device should now be flashing and will reboot when complete."

--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -75,7 +75,7 @@ let
       # See nixpkgs nixos/modules/system/activatation/top-level.nix for standard usage of these paths
       kernelPath = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
       initrdPath = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
-      kernelCmdline = "init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams}";
+      kernelCmdline = "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}";
     };
     meta.platforms = [ "x86_64-linux" ];
   };
@@ -88,7 +88,7 @@ let
         ${mkRcmBootScript {
           kernelPath = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
           initrdPath = "${flashInitrd}/initrd";
-          kernelCmdline = "initrd=initrd console=ttyTCU0,115200";
+          kernelCmdline = "console=ttyTCU0,115200";
           # During the initrd flash script, we upload two edk2 builds to the
           # board, one that is only used temporarily to boot into our
           # kernel/initrd to perform the flashing, and another one that is

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -107,11 +107,12 @@ final: prev: (
       mkFlashScript = flash-tools: args: import ./device-pkgs/flash-script.nix ({
         inherit lib flash-tools;
         inherit (cfg.firmware) eksFile;
-        inherit (cfg.flashScriptOverrides) additionalDtbOverlays flashArgs partitionTemplate;
+        inherit (cfg.flashScriptOverrides) flashArgs partitionTemplate;
         inherit (finalJetpack) tosImage socType uefi-firmware;
 
+        additionalDtbOverlays = args.additionalDtbOverlays or cfg.flashScriptOverrides.additionalDtbOverlays;
         dtbsDir = config.hardware.deviceTree.package;
-      } // args);
+      } // (builtins.removeAttrs args [ "additionalDtbOverlays" ]));
 
       bup = prev.runCommand "bup-${config.networking.hostName}-${finalJetpack.l4tVersion}"
         {

--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -136,7 +136,7 @@ let
     patches =
       # Remove this one patch (CryptoPkg/OpensslLib: Upgrade OpenSSL to 1.1.1t)
       # present on nixos-23.05, as it will be added in the opensslPatches below
-      (builtins.filter (patch: patch.url != "https://bugzilla.tianocore.org/attachment.cgi?id=1330") (prev.patches or []))
+      (builtins.filter (patch: patch.url != "https://bugzilla.tianocore.org/attachment.cgi?id=1330") (prev.patches or [ ]))
       ++ opensslPatches;
     postUnpack = ''
       # This has been taken from:


### PR DESCRIPTION
###### Description of changes

Including the DTBO used for configuring the boot order in the initrd flash script means that the temporary edk2 build used only for flashing has the possibility of booting from something other than the kernel/initrd meant for flashing. Excluding this DTBO when performing the initrd flash method means that this is no longer possible.

###### Testing

Tested on an xavier-agx-devkit that was previously netbooting when attempting to use the initrd flash script.
