### PR TITLE
flash-tools: add back missing lz4c program

### DIFF
--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -29,7 +29,7 @@
 , openssl
 , bspSrc
 , l4tVersion
-,
+, symlinkJoin
 }:
 
 let
@@ -121,13 +121,22 @@ let
       python3
       util-linux
       dosfstools
-      lz4
       bc
       openssl
 
       # Needed by bootloader/tegraflash_impl_t234.py
       gcc
       dtc
+
+      # flash.sh wants lz4c, which used to be a symlink to lz4, but does not
+      # exist in more recent nixpkgs.
+      (symlinkJoin {
+        inherit (lz4) name;
+        paths = [ (lib.getBin lz4) ];
+        postBuild = ''
+          ln -sf $out/bin/lz4{,c}
+        '';
+      })
     ];
   };
 


### PR DESCRIPTION
###### Description of changes

Since lz4/lz4@65998fe,
the lz4c symlink no longer exists, but is wanted by `flash.sh`. The
`lz4` program adds a set of legacy cmdline flags when `argv[0]` is
`lz4c` (see https://github.com/lz4/lz4/blob/6cf42afbea04c9ea6a704523aead273715001330/programs/lz4cli.c#L444),
however NVIDIA doesn't use any of these legacy flags in `flash.sh`, they
only require the `lz4c` program to be in PATH.

###### Testing

Building the `bup` derivation for an orin-agx-devkit no longer fails using a nixpkgs rev from the nixos-24.11 release.