### PR TITLE
fix: pull edk2 patches from github, rather than deprecated bugzilla urls

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -225,14 +225,14 @@ let
           # previously hosted at https://bugzilla.tianocore.org/attachment.cgi?id=1457, but moved as per Bugzilla to
           # GitHub issue migration: https://github.com/tianocore/edk2/discussions/6544
           name = "CVE-2023-45229_CVE-2023-45230_CVE-2023-45231_CVE-2023-45232_CVE-2023-45233_CVE-2023-45234_CVE-2023-45235.patch";
-          url = "https://raw.githubusercontent.com/tianocore/user-attachments/refs/heads/main/tianocore/edk2/BZ-1457-TCBZ4534_to_TCBZ4540.patch";
+          url = "https://raw.githubusercontent.com/tianocore/user-attachments/147607ddbc1751a297d15e1293cecf4c08037366/tianocore/edk2/BZ-1457-TCBZ4534_to_TCBZ4540.patch";
           hash = "sha256-CF41lbjnXbq/6DxMW6q1qcLJ8WAs+U0Rjci+jRwJYYY=";
         })
         (fetchpatch {
           # previously hosted at https://bugzilla.tianocore.org/attachment.cgi?id=1436, but moved as per Bugzilla to
           # GitHub issue migration: https://github.com/tianocore/edk2/discussions/6544
           name = "CVE-2022-36764.patch";
-          url = "https://raw.githubusercontent.com/tianocore/user-attachments/refs/heads/main/tianocore/edk2/BZ-1436-4118.patch";
+          url = "https://raw.githubusercontent.com/tianocore/user-attachments/147607ddbc1751a297d15e1293cecf4c08037366/tianocore/edk2/BZ-1436-4118.patch";
           hash = "sha256-czku8DgElisDv6minI67nNt6BS+vH6txslZdqiGaQR4=";
           excludes = [
             "SecurityPkg/Test/SecurityPkgHostTest.dsc"

--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -222,13 +222,17 @@ let
       patches = opensslPatches ++ edk2UefiPatches ++ [
         (fetchurl {
           # Patch format does not play well with fetchpatch, it should be fine this is a static attachment in a ticket
+          # previously hosted at https://bugzilla.tianocore.org/attachment.cgi?id=1457, but moved as per Bugzilla to
+          # GitHub issue migration: https://github.com/tianocore/edk2/discussions/6544
           name = "CVE-2023-45229_CVE-2023-45230_CVE-2023-45231_CVE-2023-45232_CVE-2023-45233_CVE-2023-45234_CVE-2023-45235.patch";
-          url = "https://bugzilla.tianocore.org/attachment.cgi?id=1457";
+          url = "https://raw.githubusercontent.com/tianocore/user-attachments/refs/heads/main/tianocore/edk2/BZ-1457-TCBZ4534_to_TCBZ4540.patch";
           hash = "sha256-CF41lbjnXbq/6DxMW6q1qcLJ8WAs+U0Rjci+jRwJYYY=";
         })
         (fetchpatch {
+          # previously hosted at https://bugzilla.tianocore.org/attachment.cgi?id=1436, but moved as per Bugzilla to
+          # GitHub issue migration: https://github.com/tianocore/edk2/discussions/6544
           name = "CVE-2022-36764.patch";
-          url = "https://bugzilla.tianocore.org/attachment.cgi?id=1436";
+          url = "https://raw.githubusercontent.com/tianocore/user-attachments/refs/heads/main/tianocore/edk2/BZ-1436-4118.patch";
           hash = "sha256-czku8DgElisDv6minI67nNt6BS+vH6txslZdqiGaQR4=";
           excludes = [
             "SecurityPkg/Test/SecurityPkgHostTest.dsc"


### PR DESCRIPTION
###### Description of changes

Fixes #258.

<!--
What has changed as a result of this PR? Why was the change made?
-->

Previously, `nix build github:anduril/jetpack-nixos#flash-orin-nano-devkit` would fail with one of:

```
[2/0/5 built] building CVE-2023-45229_CVE-2023-45230_CVE-2023-45231_CVE-2023-45232_CVE-2023-45233_CVE-2023-45234_CVE-2023-45235.patch: Warning: Problem : HTTP error. Will retry in 3600 seconds. 3 retries left.
```
or
```
[2/0/5 built] building CVE-2022-36764.patch: Warning: Problem : HTTP error. Will retry in 3600 seconds. 3 retries left.
```

because EDK2 moved from using Bugzilla to GitHub issues. As a result they migrated all their attachments over to a new GitHub repo. More here: https://github.com/tianocore/edk2/discussions/6544

This PR simply changes the URL to the GitHub URLs for the same patches. The hashes aren't changed.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

```
nix build github:alkasm/jetpack-nixos/alkasm/elk2-patches-bugzilla-to-github#flash-orin-nano-devkit
```

successfully builds.
