### PR TITLE
Allow `nixos-rebuild boot` to work with automated firmware updates

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -34,6 +34,10 @@ final: prev: (
         else if lib.hasPrefix "xavier-" cfg.som then "0x19"
         else throw "Unknown SoC type";
 
+      otaUtils = prevJetpack.otaUtils.override {
+        inherit (config.boot.loader.efi) efiSysMountPoint;
+      };
+
       uefi-firmware = prevJetpack.uefi-firmware.override ({
         bootLogo = cfg.firmware.uefi.logo;
         debugMode = cfg.firmware.uefi.debugMode;

--- a/pkgs/ota-utils/ota-apply-capsule-update.sh
+++ b/pkgs/ota-utils/ota-apply-capsule-update.sh
@@ -8,17 +8,18 @@ capsuleFile=$1
 boardspec=$(tegra-boardspec)
 detect_can_write_runtime_uefi_vars "$boardspec"
 
-# Check for /boot being an ESP. On Xavier AGX, even though the efi vars need to
-# be written to an ESP on the emmc, capsule updates can still be written to an
-# ESP partition at /boot on other devices (e.g. nvme)
-if ! mountpoint -q /boot; then
-    echo "/boot is not mounted"
-    exit 1
+# Check for @efiSysMountPoint@ (defaults to /boot) being an ESP. On Xavier AGX,
+# even though the efi vars need to be written to an ESP on the emmc, capsule
+# updates can still be written to an ESP partition at @efiSysMountPoint@ on
+# other devices (e.g. nvme)
+if ! mountpoint -q @efiSysMountPoint@; then
+	echo "@efiSysMountPoint@ is not mounted"
+	exit 1
 fi
 
-mkdir -p /boot/EFI/UpdateCapsule
-cp "$capsuleFile" /boot/EFI/UpdateCapsule/TEGRA_BL.Cap
-sync /boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+mkdir -p @efiSysMountPoint@/EFI/UpdateCapsule
+cp "$capsuleFile" @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap
+sync @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap
 
 set_efi_var OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c "\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00"
 

--- a/pkgs/ota-utils/ota_helpers.func
+++ b/pkgs/ota-utils/ota_helpers.func
@@ -89,7 +89,7 @@ detect_can_write_runtime_uefi_vars() {
         noRuntimeUefiWrites=true
         espDir=/opt/nvidia/esp
     else
-        espDir=/boot
+        espDir=@efiSysMountPoint@
     fi
 }
 


### PR DESCRIPTION
###### Description of changes

In 9cea389171151c28dab47dfc1b08401e87aabfa0, we broke the ability for using `nixos-rebuild boot` to apply capsule updates. This change adds that ability back. The systemd service is kept as we still want capsule updates to be applied in cases where a different bootloader is being used (or perhaps some other niche setup).

###### Testing

Manually tested on an xavier-agx-devkit:
- `nixos-rebuild boot` and `nixos-rebuild switch` installs the capsule update if no prior one exists
- `nixos-rebuild test` does nothing