### PR TITLE
Fix platform firmware and UEFI capsule builds when cross compiling

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -144,7 +144,7 @@ final: prev: (
         }
         (''
           ${cfg.firmware.uefi.capsuleAuthentication.preSignCommands final.buildPackages}
-          bash ${finalJetpack.flash-tools}/generate_capsule/l4t_generate_soc_capsule.sh \
+          bash ${final.pkgsBuildBuild.nvidia-jetpack.flash-tools}/generate_capsule/l4t_generate_soc_capsule.sh \
         '' + (lib.optionalString cfg.firmware.uefi.capsuleAuthentication.enable ''
           --trusted-public-cert ${cfg.firmware.uefi.capsuleAuthentication.trustedPublicCertPemFile} \
           --other-public-cert ${cfg.firmware.uefi.capsuleAuthentication.otherPublicCertPemFile} \
@@ -157,7 +157,7 @@ final: prev: (
 
       signedFirmware = final.runCommand "signed-${hostName}-${finalJetpack.l4tVersion}"
         { inherit (cfg.firmware.secureBoot) requiredSystemFeatures; }
-        (finalJetpack.mkFlashScript finalJetpack.flash-tools {
+        (finalJetpack.mkFlashScript final.pkgsBuildBuild.nvidia-jetpack.flash-tools {
           flashCommands = ''
             ${cfg.firmware.secureBoot.preSignCommands final}
           '' + lib.concatMapStringsSep "\n"


### PR DESCRIPTION

###### Description of changes

We must ensure we are using `flash-tools` for the build platform when we are using it during a build (i.e. not on a machine performing the flashing at "runtime").

This change fixes the immediate issue of some of the `packages` flake outputs not building (since we cross compile them), however there is some good future work that can be done to re-organize these derivations where we can just `callPackage` them and automatically get the right `flash-tools`.

###### Testing

Tested against internal test suite as well as tested the fixed flake outputs for uefi capsule updating and initrd flashing for an orin-nx devkit.