### PR TITLE
nv-display-driver: GCC14 fix implicit function

### DIFF
--- a/kernel/display-driver.nix
+++ b/kernel/display-driver.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   ];
 
   # Avoid an error in modpost: "__stack_chk_guard" [.../nvidia.ko] undefined
-  NIX_CFLAGS_COMPILE = "-fno-stack-protector";
+  NIX_CFLAGS_COMPILE = "-fno-stack-protector -Wno-implicit-function-declaration";
 
   installTargets = [ "modules_install" ];
   enableParallelBuilding = true;


### PR DESCRIPTION
With the latest changes to gcc, introduced in gcc14 there conftest is failing. GCC14 is now part of the nixos-unstable so this is a preventative change and does not introduce a regression on gcc < 14.

###### Description of changes

do not enforce the strict checking of implicit-function-declaration

###### Testing

built against nixos-unstable
