### PR TITLE
uefi-firmware: Fix GCC 14 compile issue

### DIFF
--- a/pkgs/uefi-firmware/default.nix
+++ b/pkgs/uefi-firmware/default.nix
@@ -46,12 +46,22 @@ let
   ###
 
   # See: https://github.com/NVIDIA/edk2-edkrepo-manifest/blob/main/edk2-nvidia/Jetson/NVIDIAJetsonManifest.xml
-  edk2-src = fetchFromGitHub {
-    owner = "NVIDIA";
-    repo = "edk2";
-    rev = "r${l4tVersion}-edk2-stable202208";
-    fetchSubmodules = true;
-    sha256 = "sha256-w+rZq7Wjni62MJds6QmqpLod+zSFZ/qAN7kRDOit+jo=";
+  edk2-src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = "edk2";
+      rev = "r${l4tVersion}-edk2-stable202208";
+      fetchSubmodules = true;
+      sha256 = "sha256-w+rZq7Wjni62MJds6QmqpLod+zSFZ/qAN7kRDOit+jo=";
+    };
+    patches = [
+      # Fix GCC 14 compile issue.
+      # PR: https://github.com/tianocore/edk2/pull/5781
+      (fetchpatch {
+        url = "https://github.com/NVIDIA/edk2/commit/57a890fd03356350a1b7a2a0064c8118f44e9958.patch";
+        hash = "sha256-on+yJOlH9B2cD1CS9b8Pmg99pzrlrZT6/n4qPHAbDcA=";
+      })
+    ];
   };
 
   edk2-platforms = fetchFromGitHub {


### PR DESCRIPTION
UEFI-firmware compile fails with "missing binary operator before token "("", because "__has_builtin"-operator is not defined within gcc 14. Patching edk2-sources with existing patch. Patch is fetched from NVIDIA EDK2 repo.

###### Description of changes
Fetched patch checks if  "__has_builtin"-operator has been defined and then uses it. Further information:
*  GNU CPP [documentation](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/cpp/_005f_005fhas_005fbuiltin.html) about "__has_builtin"-operator.
* tianocore/edk2 [pull request](https://github.com/tianocore/edk2/pull/5781)

###### Testing
Compiled with gcc 14 and  gcc 13 and both compiles. 
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
