### PR TITLE
unused module errors

### DIFF
--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -16,6 +16,19 @@ buildLinux (args // {
 
   defconfig = "tegra_defconfig";
 
+  # https://github.com/NixOS/nixpkgs/pull/366004
+  # introduced a breaking change that if a module is declared but it is not being used it will fail
+  # if you try to suppress each of he errors e.g.
+  # REISERFS_FS_SECURITY = lib.mkForce unset; within structuredExtraConfig
+  # that list runs to a long 100+ modules so we go back to the previous default and ignore them
+  ignoreConfigErrors = true;
+
+  # disabling the dependency on the common-config would seem appropriate as we define our own defconfig
+  # however, it seems that some of the settings for e.g. fw loading are only made available there.
+  # TODO: a future task could be to set this, disable ignoreConfigErrors and add the needed modules to the
+  # structuredExtraConfig below.
+  #enableCommonConfig = false;
+
   # Using applyPatches here since it's not obvious how to append an extra
   # postPatch. This is not very efficient.
   src = applyPatches {
@@ -102,6 +115,10 @@ buildLinux (args // {
 
     ### So nat.service and firewall work ###
     NF_TABLES = module; # This one should probably be in common-config.nix
+    # this NFT_NAT is not actually being set. when build with enableCommonConfig = false;
+    # and not ignoreConfigErrors = true; it will fail with error about unused option
+    # unused means that it wanted to set it as a module, but make oldconfig didn't ask it about that option,
+    # so it didn't get a chance to set it.
     NFT_NAT = module;
     NFT_MASQ = module;
     NFT_REJECT = module;


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/pull/366004 introduced a change that
warns and errors out when modules are defined and not acutally set for a
particular target.

This patch rectifies that by going back the the previous method of
ignoring those errors and not breaking the build. Commentary is left
inline to explain the situation and possible future solutions.

tested against orin agx target for ghaf.

there are similar solutions being deployed in nixpkgs to work around
this e.g.

https://github.com/NixOS/nixpkgs/pull/375165

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
