### PR TITLE
Use kernelPackages scope for nvidia-display-driver callPackage

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -99,14 +99,14 @@ in
     tests = prev.callPackages ./pkgs/tests { inherit l4tVersion; };
 
     kernelPackagesOverlay = final: prev: {
-      nvidia-display-driver = self.callPackage ./kernel/display-driver.nix { };
+      nvidia-display-driver = final.callPackage ./kernel/display-driver.nix { inherit (self) gitRepos l4tVersion; };
     };
 
     kernel = self.callPackage ./kernel { kernelPatches = [ ]; };
-    kernelPackages = (prev.linuxPackagesFor self.kernel).extend self.kernelPackagesOverlay;
+    kernelPackages = (final.linuxPackagesFor self.kernel).extend self.kernelPackagesOverlay;
 
     rtkernel = self.callPackage ./kernel { kernelPatches = [ ]; realtime = true; };
-    rtkernelPackages = (prev.linuxPackagesFor self.rtkernel).extend self.kernelPackagesOverlay;
+    rtkernelPackages = (final.linuxPackagesFor self.rtkernel).extend self.kernelPackagesOverlay;
 
     nxJetsonBenchmarks = self.callPackage ./pkgs/jetson-benchmarks {
       targetSom = "nx";


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

The `nvidia-display-manager` is not actually `callPackage`d from the `kernelPackages` scope, meaning that changes to packages within the scope (like the kernel itself) are not used in the `nvidia-display-manager` derivation.

In particular, this means that when using options like [`boot.kernelPatches`](https://search.nixos.org/options?channel=unstable&show=boot.kernelPatches), `nvidia-display-manager` erroneously still references the stock kernel, leading to two kernels being built.

This MR fixes this.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
