### PR TITLE
modules: flash-script: Add coreutils to updateFirmware script

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -14,7 +14,7 @@ let
 
   updateFirmware = pkgs.writeShellApplication {
     name = "update-jetson-firmware";
-    runtimeInputs = [ pkgs.nvidia-jetpack.otaUtils ];
+    runtimeInputs = with pkgs; [ coreutils nvidia-jetpack.otaUtils ];
     text = ''
       # This directory is populated by ota-apply-capsule-update, don't run if
       # we already have a capsule update present on the ESP. We check the exact


### PR DESCRIPTION
###### Description of changes

Add `coreutils` to the `updateScript` for `cat` and `echo`.

```
updating systemd-boot from 256.7 to 257.2
Copied "/nix/store/2bxf2a2215zspixdmw03vyi31q098ij6-systemd-257.2/lib/systemd/boot/efi/systemd-bootaa64.efi" to "/boot/EFI/systemd/systemd-bootaa64.efi".
Copied "/nix/store/2bxf2a2215zspixdmw03vyi31q098ij6-systemd-257.2/lib/systemd/boot/efi/systemd-bootaa64.efi" to "/boot/EFI/BOOT/BOOTAA64.EFI".
Created EFI boot entry "Linux Boot Manager".
/nix/store/zv8x2rf4lx3fs8pdhpzdhx3wxysr8m6x-update-jetson-firmware/bin/update-jetson-firmware: line 25: cat: command not found
Failed to install bootloader
warning: error(s) occurred while switching to the new configuration
```

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

TODO:

- [ ] Check that this actually works