### PR TITLE
Skip firmware updates if script is run on a virtualised system

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -14,8 +14,16 @@ let
 
   updateFirmware = pkgs.writeShellApplication {
     name = "update-jetson-firmware";
-    runtimeInputs = with pkgs; [ coreutils nvidia-jetpack.otaUtils ];
+    runtimeInputs = [ pkgs.coreutils config.systemd.package pkgs.nvidia-jetpack.otaUtils ];
     text = ''
+      # If this script is not run on real hardware, don't attempt to perform an
+      # update. This script could potentially run in a few places, for example
+      # in <nixpkgs/nixos/lib/make-disk-image.nix>.
+      if systemd-detect-virt --quiet; then
+        echo "virtualisation detected, skipping jetson firmware update"
+        exit 0
+      fi
+
       # This directory is populated by ota-apply-capsule-update, don't run if
       # we already have a capsule update present on the ESP. We check the exact
       # path that we populate because it is possible for multiple capsule


### PR DESCRIPTION
###### Description of changes

We should not attempt to perform a firmware update if the system is being virtualised (e.g. in make-disk-image.nix).

Fixes #276

###### Testing

Tested to work with the following expression:

```nix
let
  jetpack-nixos = builtins.getFlake "github:jmbaur/jetpack-nixos/firmware-update-detect-virt";
  nixpkgs = builtins.getFlake "github:nixos/nixpkgs/nixos-24.11";
in
(nixpkgs.lib.nixosSystem {
  modules = [
    (
      {
        config,
        lib,
        pkgs,
        ...
      }:
      {
        imports = [ jetpack-nixos.nixosModules.default ];

        fileSystems."/".device = "/dev/foo";

        boot.loader.systemd-boot.enable = true;

        hardware.nvidia-jetpack = {
          enable = true;
          som = "orin-agx";
          carrierBoard = "devkit";
        };

        system.build.diskImage = import "${pkgs.path}/nixos/lib/make-disk-image.nix" {
          inherit config lib pkgs;
          label = "nixos";
          format = "qcow2";
          partitionTableType = "efi";
          touchEFIVars = true;
          installBootLoader = true;
        };
      }
    )
  ];
}).config.system.build.diskImage
```

Also tested that capsule updates on real hardware still work.