### PR TITLE
Orin AGX 64gb fab from "000" to "300"

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -473,7 +473,7 @@ in
             orin-agx = [
               { boardid = "3701"; boardsku = "0000"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D0"; }
               { boardid = "3701"; boardsku = "0004"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D2"; } # 32GB
-              { boardid = "3701"; boardsku = "0005"; fab = "000"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D0"; } # 64GB
+              { boardid = "3701"; boardsku = "0005"; fab = "300"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = ""; chipsku = "00:00:00:D0"; } # 64GB
             ];
 
             orin-agx-industrial = [


### PR DESCRIPTION
###### Description of changes
Jetson 35.6 BSP "jetson_board_spec.cfg"-file uses/defines Orin AGX 64gb "300" as a fab value. 
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing
Evaluates and compiles.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
