### PR TITLE
flash-from-device: workaround build failure for mtdutils

### DIFF
--- a/pkgs/flash-from-device/default.nix
+++ b/pkgs/flash-from-device/default.nix
@@ -1,11 +1,20 @@
 { lib, pkgsStatic, runCommand, tegra-eeprom-tool-static }:
 
 let
+  # Workaround build failure with pkgsStatic.mtdutils in NixOS 24.11
+  # > configure: WARNING: cannot find CMocka library required for unit tests
+  # > configure: unit tests can optionally be disabled
+  # > configure: error: missing one or more dependencies
+  mtdutils = pkgsStatic.mtdutils.overrideAttrs (_: {
+    configureFlags = [ ];
+    doCheck = false;
+  });
+
   # Make the package smaller so it doesn't blow up the initrd size
   staticDeps = runCommand "static-deps" { } ''
     mkdir -p $out/bin
-    cp ${pkgsStatic.mtdutils}/bin/mtd_debug $out/bin
-    cp ${pkgsStatic.mtdutils}/bin/flash_erase $out/bin
+    cp ${mtdutils}/bin/mtd_debug $out/bin
+    cp ${mtdutils}/bin/flash_erase $out/bin
     cp ${tegra-eeprom-tool-static}/bin/tegra-boardspec $out/bin
   '';
   name = "flash-from-device";


### PR DESCRIPTION
###### Description of changes

`pkgsStatic.mtdutils` fails to build natively in NixOS 24.11 due to the cmoka dependency not being found for package tests.  However, the cross-compiled static mtdutils _does_ build successfully due to the tests being disabled in that case upstream.  This leads to initrd flash scripts building in some cases, and others not, depending on if the NixOS system they're based on is cross-compiled or natively-compiled.  Concretely, the `initrd-flash-*` flake package outputs all currently work (since they are cross-compile firmware), but the `.config.system.build.initrdFlashScript` from a natively-built NixOS system does not.

###### Testing

Built the `initrdFlashScript` from a natively-built NixOS system.