### PR TITLE
flash-from-device: remove extraneous dependencies on stdenv tools

### DIFF
--- a/pkgs/flash-from-device/default.nix
+++ b/pkgs/flash-from-device/default.nix
@@ -24,7 +24,7 @@ runCommand name { meta.mainProgram = name; } ''
 
   cat > $out/bin/flash-from-device <<EOF
   #!${pkgsStatic.busybox}/bin/sh
-  export PATH="${lib.makeBinPath [ pkgsStatic.busybox staticDeps ]}:$PATH"
+  export PATH="${lib.makeBinPath [ pkgsStatic.busybox staticDeps ]}"
   EOF
   cat ${./flash-from-device.sh} >> $out/bin/flash-from-device
   substituteInPlace $out/bin/flash-from-device \


### PR DESCRIPTION
###### Description of changes

The `flash-from-device` script was inadvertently bringing in all stdenv tools available in the `runCommand` itself.  The $PATH here wasn't intended to be substituted in the `runCommand`, but rather when running the script itself! Consequently, the `/nix/store` output for `flash-from-device` had references to `coreutils`, `gnused`, `gnugrep`, etc. present in this line.

It turns out this $PATH wasn't necessary at all, since all required tools to run `flash-from-device` are already present in `pkgsStatic.busybox` and `staticDeps`, so I'm removing it.

This decreases the size of an Orin AGX devkit initrd from 47M down to 25M.

###### Testing

Flashed an Orin AGX devkit