### PR TITLE
flash-tools: use smaller qemu build-time dependency

### DIFF
--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -22,7 +22,7 @@
 , lz4
 , gcc
 , dtc
-, qemu
+, qemu-user
 , runtimeShell
 , fetchzip
 , bc
@@ -79,7 +79,7 @@ let
         mv "$filename" ."$filename"-wrapped
         cat >"$filename" <<EOF
       #!${runtimeShell}
-      exec -a "\$0" ${qemu}/bin/qemu-i386 "$out/bootloader/.$filename-wrapped" "\$@"
+      exec -a "\$0" ${qemu-user}/bin/qemu-i386 "$out/bootloader/.$filename-wrapped" "\$@"
       EOF
         chmod +x "$filename"
       done


### PR DESCRIPTION
###### Description of changes

The qemu-user package is a much build-time dependency than the qemu package (~185MiB vs ~1.7GiB), and it contains everything we need in flash-tools.

###### Testing

Tested building a capsule update for an orin-agx-devkit (natively compiled, aarch64-linux build platform & aarch64-linux host platform), which tests the codepath where qemu-user is used.
