### PR TITLE
Fix initrd flash script with Jetpack 5.1.5

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -86,7 +86,9 @@ let
         ${mkRcmBootScript {
           kernelPath = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
           initrdPath = "${flashInitrd}/initrd";
-          kernelCmdline = "console=ttyTCU0,115200";
+          kernelCmdline = lib.concatStringsSep " " [
+            "console=ttyTCU0,115200" "sdhci_tegra.en_boot_part_access=1"
+          ];
           # During the initrd flash script, we upload two edk2 builds to the
           # board, one that is only used temporarily to boot into our
           # kernel/initrd to perform the flashing, and another one that is

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -142,6 +142,25 @@ in
                 The path to the UEFI DB Signature List (ESL).
               '';
             };
+
+            signer.cert = mkOption {
+              type = lib.types.path;
+              description = ''
+                x509 certificate used for signing.
+                https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-descriptor
+              '';
+            };
+            signer.key = mkOption {
+              type = lib.types.path;
+              description = ''
+                RSA Private key in PEM format used for signing.
+                This is currently only used for RCM payload verification used in initrd flash script.
+                Besides this specific option, UEFI secure boot behaves as it normally would for any other NixOS system.
+                Do _not_ include a signing key in the Nix store. How to do this
+                is left as an exercise to the reader.
+                https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#using-the-efi-variable-authentication-descriptor
+              '';
+            };
           };
 
           capsuleAuthentication = {

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -88,8 +88,11 @@ final: prev: (
               sync
               reboot -f
             else
-              echo "Flashing platform firmware unsuccessful. Entering console"
+              echo "Flashing platform firmware unsuccessful."
+              ${lib.optionalString (cfg.firmware.secureBoot.pkcFile == null) ''
+              echo "Entering console"
               exec ${prev.pkgsStatic.busybox}/bin/sh
+              ''}
             fi
           '';
         in

--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -27,6 +27,7 @@
 , fetchzip
 , bc
 , openssl
+, sbsigntool
 , bspSrc
 , l4tVersion
 , symlinkJoin
@@ -123,6 +124,7 @@ let
       dosfstools
       bc
       openssl
+      sbsigntool # In l4t_uefi_sign_image.sh, which is needed by RCM flashing
 
       # Needed by bootloader/tegraflash_impl_t234.py
       gcc

--- a/pkgs/flash-tools/flash-tools.patch
+++ b/pkgs/flash-tools/flash-tools.patch
@@ -1,6 +1,6 @@
-diff -Naur bsp-5.1.4/bootloader/l4t_bup_gen.func bsp-5.1.4-new/bootloader/l4t_bup_gen.func
---- bsp-5.1.4/bootloader/l4t_bup_gen.func	1969-12-31 16:00:01.000000000 -0800
-+++ bsp-5.1.4-new/bootloader/l4t_bup_gen.func	2024-10-27 17:38:54.890791212 -0700
+diff -Naur bsp-5.1.5/bootloader/l4t_bup_gen.func bsp-5.1.5-new/bootloader/l4t_bup_gen.func
+--- bsp-5.1.5/bootloader/l4t_bup_gen.func	1969-12-31 16:00:01.000000000 -0800
++++ bsp-5.1.5-new/bootloader/l4t_bup_gen.func	2025-05-06 16:03:46.283865204 -0700
 @@ -23,7 +23,6 @@
  
  declare -A ENTRY_LIST
@@ -9,15 +9,16 @@ diff -Naur bsp-5.1.4/bootloader/l4t_bup_gen.func bsp-5.1.4-new/bootloader/l4t_bu
  
  PART_NAME=""
  IMAGE_SIGNED=0
-diff -Naur bsp-5.1.4/flash.sh bsp-5.1.4-new/flash.sh
---- bsp-5.1.4/flash.sh	1969-12-31 16:00:01.000000000 -0800
-+++ bsp-5.1.4-new/flash.sh	2024-10-27 17:41:11.472780429 -0700
-@@ -2711,6 +2711,8 @@
+diff -Naur bsp-5.1.5/flash.sh bsp-5.1.5-new/flash.sh
+--- bsp-5.1.5/flash.sh	1969-12-31 16:00:01.000000000 -0800
++++ bsp-5.1.5-new/flash.sh	2025-05-06 16:03:25.411864346 -0700
+@@ -2737,6 +2737,9 @@
  		fi
  		cmdline+="${string} ";
  	done
 +
 +	# Just use the cmdline as-is, needed for RCM-boot in jetpack-nixos
++	cmdline="${CMDLINE}"
  fi;
  
  ##########################################################################


### PR DESCRIPTION
###### Description of changes

Jetpack 5.1.5 changed how RCM (recovery mode) booting happened, which broke Xavier AGX and any fused/securebooting device.   This PR fixes those two issues.

###### Testing

Tested initrdFlashScript on Xavier AGX and on a fused Orin Nano.
