### PR TITLE
Add ucsi drivers to ramdisk for orin-agx-devkit

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -226,7 +226,7 @@ in
     ++ lib.optional (lib.hasPrefix "xavier-" cfg.som || cfg.som == "generic") "video=efifb:off"; # Disable efifb driver, which crashes Xavier NX and possibly AGX
 
     boot.initrd.includeDefaultModules = false; # Avoid a bunch of modules we may not get from tegra_defconfig
-    boot.initrd.availableKernelModules = [ "xhci-tegra" ]; # Make sure USB firmware makes it into initrd
+    boot.initrd.availableKernelModules = [ "xhci-tegra" "ucsi_ccg" "typec_ucsi" "typec" ]; # Make sure USB firmware makes it into initrd
 
     boot.kernelModules =
       [ "nvgpu" ]


### PR DESCRIPTION
###### Description of changes

If booting off USB-C port, these drivers will be needed to detect the attached drive and configure the USB stack to act as host mode.

###### Testing

 - [x] Manually boot orin-agx-devkit with USB drive attached to the typec port next to 40-pin. ISO enters 2nd stage
 - [x] Build xavier and few others to ensure those modules exist. They should, and do because it's the same kernel.