### PR TITLE
Remove dangling lib64 symlink for 25.05

### DIFF
--- a/pkgs/cuda-packages/cuda_nvml_dev/fixup.nix
+++ b/pkgs/cuda-packages/cuda_nvml_dev/fixup.nix
@@ -14,10 +14,8 @@ finalAttrs: prevAttrs: {
   # Not sure about the version number though!
   # NOTE: Add symlinks inside $stubs/lib so autoPatchelfHook can find them -- it doesn't recurse into subdirectories.
   postInstall =
-    (prevAttrs.postInstall or "") + ''
-      # What this is pointing to was moved by multi-output logic, remove
-      [[ -L ''${!outputLib}/lib64 ]] && rm ''${!outputLib}/lib64
-    '' + optionalString (elem "stubs" finalAttrs.outputs) ''
+    prevAttrs.postInstall or "" +
+    optionalString (elem "stubs" finalAttrs.outputs) ''
       pushd "''${!outputStubs:?}/lib/stubs" >/dev/null
       if [[ -f libnvidia-ml.so && ! -f libnvidia-ml.so.1 ]]; then
         echo "creating versioned symlink for libnvidia-ml.so stub"

--- a/pkgs/cuda-packages/deb-builder/fixup.nix
+++ b/pkgs/cuda-packages/deb-builder/fixup.nix
@@ -332,7 +332,10 @@ in
   # TODO(@connorbaker): https://github.com/NixOS/nixpkgs/issues/323126.
   # _multioutPropagateDev() currently expects a space-separated string rather than an array.
   # Because it is a postFixup hook, we correct it in preFixup.
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isAarch64 ''
+    # What this is pointing to was moved by multi-output logic, remove
+    [[ -L ''${!outputLib}/lib64 ]] && rm ''${!outputLib}/lib64
+  '' + ''
     echo "converting propagatedBuildOutputs to a space-separated string"
     export propagatedBuildOutputs="''${propagatedBuildOutputs[@]}"
   '';


### PR DESCRIPTION
###### Description of changes

This was a dangling symlink, and those are now in enforced in 25.05

###### Testing

