### PR TITLE
uefi-firmware: update version to include unique hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Otherwise, the instructions to apply the update manually are below.
 To determine if the currently running firmware matches the software, run, `ota-check-firmware`:
 ```
 $ ota-check-firmware
-Current firmware version is: 35.6.1
-Current software version is: 35.6.1
+Current firmware version is: 35.6.1-06cb4270ebfe
+Expected firmware version is: 35.6.1-06cb4270ebfe
 ```
 
 If these versions do not match, you can update your firmware using the UEFI Capsule update mechanism. The procedure to do so is below:

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -41,14 +41,7 @@ let
         exit 1
       fi
 
-      CUR_VER=$(cat /sys/devices/virtual/dmi/id/bios_version)
-      NEW_VER=${pkgs.nvidia-jetpack.l4tVersion}
-
-      if [[ "$CUR_VER" != "$NEW_VER" ]]; then
-        echo "Current Jetson firmware version is: $CUR_VER"
-        echo "New Jetson firmware version is: $NEW_VER"
-        echo
-
+      if ! ota-check-firmware; then
         # Set efi vars here as well as in systemd service, in case we're
         # upgrading from an older nixos generation that doesn't have the
         # systemd service. Plus, this ota-setup-efivars will be from the
@@ -575,5 +568,10 @@ in
         ${pkgs.nvidia-jetpack.otaUtils}/bin/ota-apply-capsule-update ${pkgs.nvidia-jetpack.uefiCapsuleUpdate}
       '')
     ];
+
+    # biosVersion can only be evaluated if there is buildable firmware, which requires som being set
+    environment.etc = lib.mkIf (cfg.som != "generic") {
+      jetson_expected_bios_version.text = pkgs.nvidia-jetpack.uefi-firmware.biosVersion;
+    };
   };
 }

--- a/pkgs/optee/default.nix
+++ b/pkgs/optee/default.nix
@@ -64,10 +64,10 @@ let
         "PLATFORM=tegra"
         "PLATFORM_FLAVOR=${socType}"
         "CFG_WITH_STMM_SP=y"
-        "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin"
         "NV_CCC_PREBUILT=${nvCccPrebuilt}"
         "O=$(out)"
       ]
+      ++ (lib.optional (uefi-firmware != null) "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin")
       ++ (lib.optional (taPublicKeyFile != null) "TA_PUBLIC_KEY=${taPublicKeyFile}")
       ++ extraMakeFlags;
     in

--- a/pkgs/ota-utils/default.nix
+++ b/pkgs/ota-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, bash, util-linux, e2fsprogs, tegra-eeprom-tool, l4tVersion, efiSysMountPoint ? "/boot" }:
+{ lib, stdenvNoCC, bash, util-linux, e2fsprogs, tegra-eeprom-tool, efiSysMountPoint ? "/boot" }:
 
 stdenvNoCC.mkDerivation {
   name = "ota-utils";
@@ -32,9 +32,6 @@ stdenvNoCC.mkDerivation {
         --replace "@ota_helpers@" "$out/share/ota_helpers.func"
       sed -i '2a export PATH=${lib.makeBinPath [ util-linux e2fsprogs tegra-eeprom-tool ]}:$PATH' $out/bin/$fname
     done
-
-    substituteInPlace $out/bin/ota-check-firmware \
-      --replace "@l4tVersion@" "${l4tVersion}"
 
     patchShebangs --host $out/bin
 

--- a/pkgs/ota-utils/ota-check-firmware.sh
+++ b/pkgs/ota-utils/ota-check-firmware.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-FW_VER=$(cat /sys/devices/virtual/dmi/id/bios_version)
-SW_VER=@l4tVersion@
+CURRENT_FW_VER=$(cat /sys/devices/virtual/dmi/id/bios_version || echo Unknown)
+EXPECTED_FW_VER=$(cat /etc/jetson_expected_bios_version || echo Unknown)
 
-echo "Current firmware version is: ${FW_VER}"
-echo "Current software version is: ${SW_VER}"
+echo "Current firmware version is: ${CURRENT_FW_VER}"
+echo "Expected firmware version is: ${EXPECTED_FW_VER}"
 
-if [[ "$FW_VER" != "$SW_VER" ]]; then
+if [[ "$CURRENT_FW_VER" != "$EXPECTED_FW_VER" ]]; then
     exit 1
 fi


### PR DESCRIPTION
###### Description of changes


Currently, the version field we bake into the UEFI firmware is just the L4T version.  A simple version field does not any of the additional customizations (such as patches) we or the end-user may do on top of it. This makes it difficult to determine if the current firmware on a device includes the customizations expected.

Additionally, since the firmware autoupgrade feature keys off of the version number, a user has to know to manually apply a capsule update if they changed something that affects the platform firmware, which is not always obvious.

This adds a hash to the version field, like: `35.6.1-06cb4270ebfe`. Now, firmware should automatically be upgraded if there is a change that can affect platform firmware. This gets us a level of "congruence" similar to NixOS itself.  The downside is that _any_ change which affects the derivation hashes included in the firmware build will cause an upgrade, such as minor bumps to nixpkgs which cause mass-rebuilds. These upgrades can take approximately 4 minutes during reboot.  Overall, I believe the tradeoff is worth it.

Fixes #275

Co-authored-by: Elliot Berman <eberman@anduril.com>

###### Testing

Manually tested on an Orin NX devkit that the hash is included in the firmware, and that `ota-check-firmware` shows the current and expected firmware version match.
Also tested flashing, booting, and capsule updating across all 4 variants.