### PR TITLE
Ignore existing capsule file

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -24,16 +24,6 @@ let
         exit 0
       fi
 
-      # This directory is populated by ota-apply-capsule-update, don't run if
-      # we already have a capsule update present on the ESP. We check the exact
-      # path that we populate because it is possible for multiple capsule
-      # updates to be applied at once, so we don't want other files in this
-      # directory to influence our behavior.
-      if [[ -e ${config.boot.loader.efi.efiSysMountPoint}/EFI/UpdateCapsule/TEGRA_BL.Cap ]]; then
-        echo "Existing capsule update for platform firmware exists, exiting"
-        exit 0
-      fi
-
       # Jetpack 5.0 didn't expose this DMI variable,
       if [[ ! -f /sys/devices/virtual/dmi/id/bios_version ]]; then
         echo "Unable to determine current Jetson firmware version."

--- a/pkgs/ota-utils/ota-apply-capsule-update.sh
+++ b/pkgs/ota-utils/ota-apply-capsule-update.sh
@@ -17,8 +17,7 @@ if ! mountpoint -q @efiSysMountPoint@; then
 	exit 1
 fi
 
-mkdir -p @efiSysMountPoint@/EFI/UpdateCapsule
-cp "$capsuleFile" @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap
+install -Dm0644 "$capsuleFile" @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap
 sync @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap
 
 set_efi_var OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c "\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00"


### PR DESCRIPTION
###### Description of changes

We don't actually care if an existing capsule file is present on the ESP when we are applying the capsule built with a NixOS configuration. We actually _do_ want to always apply the capsule tied to the current NixOS configuration, since it may be needed for booting that configuration's kernel or other components (e.g. a NixOS config has a Jetpack 6 kernel and a capsule update to Jetpack 6 firmware, however some other Jetpack 5.x capsule file is already present).

###### Testing

TODO