### PR TITLE
ota-utils: bake expectedBiosVersion in ota-check-firmware

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -568,10 +568,5 @@ in
         ${pkgs.nvidia-jetpack.otaUtils}/bin/ota-apply-capsule-update ${pkgs.nvidia-jetpack.uefiCapsuleUpdate}
       '')
     ];
-
-    # biosVersion can only be evaluated if there is buildable firmware, which requires som being set
-    environment.etc = lib.mkIf (cfg.som != "generic") {
-      jetson_expected_bios_version.text = pkgs.nvidia-jetpack.uefi-firmware.biosVersion;
-    };
   };
 }

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -36,6 +36,9 @@ final: prev: (
 
       otaUtils = prevJetpack.otaUtils.override {
         inherit (config.boot.loader.efi) efiSysMountPoint;
+
+        # uefi-firmware can be evaluated only if som is set
+        expectedBiosVersion = if (cfg.som != "generic") then finalJetpack.uefi-firmware.biosVersion else "Unknown";
       };
 
       uefi-firmware = prevJetpack.uefi-firmware.override ({

--- a/pkgs/ota-utils/default.nix
+++ b/pkgs/ota-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, bash, util-linux, e2fsprogs, tegra-eeprom-tool, efiSysMountPoint ? "/boot" }:
+{ lib, stdenvNoCC, bash, util-linux, e2fsprogs, tegra-eeprom-tool, efiSysMountPoint ? "/boot", expectedBiosVersion ? "Unknown" }:
 
 stdenvNoCC.mkDerivation {
   name = "ota-utils";
@@ -32,6 +32,9 @@ stdenvNoCC.mkDerivation {
         --replace "@ota_helpers@" "$out/share/ota_helpers.func"
       sed -i '2a export PATH=${lib.makeBinPath [ util-linux e2fsprogs tegra-eeprom-tool ]}:$PATH' $out/bin/$fname
     done
+
+    substituteInPlace $out/bin/ota-check-firmware \
+      --replace "@expectedBiosVersion@" "${expectedBiosVersion}"
 
     patchShebangs --host $out/bin
 

--- a/pkgs/ota-utils/ota-check-firmware.sh
+++ b/pkgs/ota-utils/ota-check-firmware.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 CURRENT_FW_VER=$(cat /sys/devices/virtual/dmi/id/bios_version || echo Unknown)
-EXPECTED_FW_VER=$(cat /etc/jetson_expected_bios_version || echo Unknown)
+EXPECTED_FW_VER=@expectedBiosVersion@
 
 echo "Current firmware version is: ${CURRENT_FW_VER}"
 echo "Expected firmware version is: ${EXPECTED_FW_VER}"


### PR DESCRIPTION
###### Description of changes

The `ota-check-firmware` script is called by both firmware-update.service, as well as by pre-switch commands run as part of systemd-boot or grub extraInstallCommands.  In the second case, the `/etc/jetson_expected_bios_version` we are referencing will correspond to the currently running NixOS system, _not_ the one we are intending to switch to. Thus, the firmware update would not be applied by the
pre-switch commands.  Instead, we now bake this expected firmware version into the ota-check-firmware script so that it corresponds to the firmware version we are intending to update to.

###### Testing

Booted an orin-agx-devkit and noted that `ota-check-firmware` had a baked-in expectedBiosVersion