### PR TITLE
Skip capsule update if certain environment variable is set

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -20,7 +20,12 @@ let
       # update. This script could potentially run in a few places, for example
       # in <nixpkgs/nixos/lib/make-disk-image.nix>.
       if systemd-detect-virt --quiet; then
-        echo "virtualisation detected, skipping jetson firmware update"
+        echo "Skipping Jetson firmware update because we've detected we are in a virtualized environment."
+        exit 0
+      fi
+
+      if [[ -n "$JETPACK_NIXOS_SKIP_CAPSULE_UPDATE" ]]; then
+        echo "Skipping Jetson firmware update because JETPACK_NIXOS_SKIP_CAPSULE_UPDATE is set"
         exit 0
       fi
 


### PR DESCRIPTION
###### Description of changes

There are many cases where we may want to "switch-to-configuration boot" a NixOS system with hardware.nvidia-jetpack.firmware.autoUpdate, but not apply the capsule update. This lets us control that at runtime, so we don't have to disable the `autoUpdate` option and then get a different system hash...

###### Testing

Manually ran a `switch-to-configuration boot` command with the `JETPACK_NIXOS_SKIP_CAPSULE_UPDATE` and noted that it skipped applying the update.
