### PR TITLE
Fix bashism

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -24,7 +24,7 @@ let
         exit 0
       fi
 
-      if [[ -n "$JETPACK_NIXOS_SKIP_CAPSULE_UPDATE" ]]; then
+      if [[ ! -v JETPACK_NIXOS_SKIP_CAPSULE_UPDATE ]]; then
         echo "Skipping Jetson firmware update because JETPACK_NIXOS_SKIP_CAPSULE_UPDATE is set"
         exit 0
       fi


### PR DESCRIPTION
###### Description of changes

Otherwise, this will fail with:
```
line 16: JETPACK_NIXOS_SKIP_CAPSULE_UPDATE: unbound variable
```

I have never made a mistake, ever, in my life.

###### Testing

Booted a device, noticed the `firmware-update` service succeeds.
Still passed UEFI capsule update test still