### PR TITLE
fixup! Fix bashism

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -24,7 +24,7 @@ let
         exit 0
       fi
 
-      if [[ ! -v JETPACK_NIXOS_SKIP_CAPSULE_UPDATE ]]; then
+      if [[ -v JETPACK_NIXOS_SKIP_CAPSULE_UPDATE ]]; then
         echo "Skipping Jetson firmware update because JETPACK_NIXOS_SKIP_CAPSULE_UPDATE is set"
         exit 0
       fi


### PR DESCRIPTION
###### Description of changes

Test should check if JETPACK_NIXOS_SKIP_CAPSULE_UPDATE is set.

-v varname returns True if the shell variable varname is set [1].

[1]: https://www.gnu.org/software/bash/manual/bash.html#Bash-Conditional-Expressions

###### Testing

- [x] Check that capsule update applies when JETPACK_NIXOS_SKIP_CAPSULE_UPDATE is unset.
