### PR TITLE
Flash from device fixes for 25.05

### DIFF
--- a/pkgs/flash-from-device/default.nix
+++ b/pkgs/flash-from-device/default.nix
@@ -1,13 +1,14 @@
 { lib, pkgsStatic, runCommand, tegra-eeprom-tool-static }:
 
 let
-  # Workaround build failure with pkgsStatic.mtdutils in NixOS 24.11
-  # > configure: WARNING: cannot find CMocka library required for unit tests
-  # > configure: unit tests can optionally be disabled
-  # > configure: error: missing one or more dependencies
   mtdutils = pkgsStatic.mtdutils.overrideAttrs (_: {
-    configureFlags = [ ];
-    doCheck = false;
+    # Grab patches merged after 2.3.0 to let mtdutils build with musl
+    # https://lists.openembedded.org/g/openembedded-core/topic/patch_mtd_utils_upgrade_to/111205949
+    src = fetchGit {
+      url = "git://git.infradead.org/mtd-utils.git";
+      rev = "77981a2888c711268b0e7f32af6af159c2288e23";
+    };
+    version = "2.3.0-unstable-2025-06-02";
   });
 
   # Make the package smaller so it doesn't blow up the initrd size

--- a/pkgs/flash-from-device/flash-from-device.sh
+++ b/pkgs/flash-from-device/flash-from-device.sh
@@ -147,7 +147,7 @@ erase_bootdev() {
     BOOTDEV_TYPE=
 
     # Detect type to erase
-    while IFS=", " read -r partnumber partloc start_location partsize partfile partattrs partsha; do
+    while IFS=", " read -r partnumber partloc start_location partsize partfile filesize partattrs partsha; do
         devnum=$(echo "$partloc" | cut -d':' -f 1)
         instnum=$(echo "$partloc" | cut -d':' -f 2)
         partname=$(echo "$partloc" | cut -d':' -f 3)
@@ -187,7 +187,7 @@ erase_bootdev() {
 
 write_partitions() {
     # shellcheck disable=SC2034
-    while IFS=", " read -r partnumber partloc start_location partsize partfile partattrs partsha; do
+    while IFS=", " read -r partnumber partloc start_location partsize partfile filesize partattrs partsha; do
         # Need to trim off leading blanks
         devnum=$(echo "$partloc" | cut -d':' -f 1)
         instnum=$(echo "$partloc" | cut -d':' -f 2)


### PR DESCRIPTION
###### Description of changes

- flash-from-device: Add patches to compile mtdutils with musl 
  nixpkgs 25.05 bumped mtdutils to 2.3.0. This version had some
  regressions in order to compile with musl.
- flash-from-device: Add missing fields from flash.idx
  flash.idx contains a filesize field. We don't currently use this field
  nor the fields after, but let's fix it since it was noticed.

###### Testing

- [x] nix run .#initrd-flash-orin-agx-devkit
