### PR TITLE
s/buildFHSUserEnv/buildFHSEnv/

### DIFF
--- a/pkgs/cuda-packages/nsight_compute_host.nix
+++ b/pkgs/cuda-packages/nsight_compute_host.nix
@@ -1,5 +1,5 @@
 { alsa-lib
-, buildFHSUserEnv
+, buildFHSEnv
 , buildFromDebs
 , dbus
 , debs
@@ -53,7 +53,7 @@ in
 # ncu-ui has some hardcoded /usr access so use fhs instead of trying to patchelf
   # it also comes with its own qt6 .so, trying to use Nix qt6 libs results in weird
   # behavior(blank window) so just supply qt6 dependency instead of qt6 itself
-buildFHSUserEnv {
+buildFHSEnv {
   pname = "ncu-ui";
   inherit (nsight_out) version;
   targetPkgs =

--- a/pkgs/cuda-packages/nsight_systems_host.nix
+++ b/pkgs/cuda-packages/nsight_systems_host.nix
@@ -1,5 +1,5 @@
 { alsa-lib
-, buildFHSUserEnv
+, buildFHSEnv
 , buildFromDebs
 , dbus
 , debs
@@ -78,7 +78,7 @@ in
 # nsys-ui has some hardcoded /usr access so use fhs instead of trying to patchelf
   # it also comes with its own qt6 .so, trying to use Nix qt6 libs results in weird
   # behavior(blank window) so just supply qt6 dependency instead of qt6 itself
-buildFHSUserEnv {
+buildFHSEnv {
   pname = "nsys-ui";
   inherit (nsight_out) version;
   targetPkgs =


### PR DESCRIPTION
buildFHSUserEnv is deprecated for buildFHSEnv.

Fixes: de01bba154f2 ("Upgrade to nixos-25.05")
