### PR TITLE
kernel: remove l4t-xusb-firmware from EXTRA_FIRMWARE_DIR

### DIFF
--- a/pkgs/kernels/r36/default.nix
+++ b/pkgs/kernels/r36/default.nix
@@ -44,11 +44,6 @@ buildLinux (args // {
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {
-    # stage-1 links /lib/firmware to the /nix/store path in the initramfs.
-    # However, since it's builtin and not a module, that's too late, since
-    # the kernel will have already tried loading!
-    EXTRA_FIRMWARE_DIR = freeform "${l4t-xusb-firmware}/lib/firmware";
-
     # Override the default CMA_SIZE_MBYTES=32M setting in common-config.nix with the default from tegra_defconfig
     # Otherwise, nvidia's driver craps out
     CMA_SIZE_MBYTES = lib.mkForce (freeform "64");


### PR DESCRIPTION
###### Description of changes

This package only contains t194 (Xavier) firmware under lib/firmware, which isn't relevant for Jetpack 6.  t234 (Orin) xusb firmware is included as another partition on the QSPI.

###### Testing

Tested by booting `orin-agx-devkit` and noting USB still worked