### PR TITLE
uefi-firmware: fix inclusion of hash in JP6 firmware

### DIFF
--- a/pkgs/uefi-firmware/r36/default.nix
+++ b/pkgs/uefi-firmware/r36/default.nix
@@ -291,7 +291,7 @@ let
         unset STRIP
 
         export WORKSPACE=$(pwd)
-        GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
+        export GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
         CFLAGS=$NIX_CFLAGS_COMPILE_FOR_BUILD LDFLAGS=$NIX_LDFLAGS_FOR_BUILD python edk2/BaseTools/Edk2ToolsBuild.py -t GCC5
 
         ${lib.optionalString (trustedPublicCertPemFile != null) ''


### PR DESCRIPTION
###### Description of changes

GIT_SYNC_REVISION is used by stuart to determine the hash suffix to add to the version number. This variable wasn't being exported so stuart wasn't picking it up.

###### Testing

Switched to a new configuration with autoUpdate enabled, noted it applied a capsule update and the new firmware had a hash in the version field
