### PR TITLE
ota-utils: Introduce ota-abort-capsule-update

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -45,6 +45,8 @@ let
         ota-setup-efivars ${cfg.flashScriptOverrides.targetBoard}
 
         ota-apply-capsule-update ${pkgs.nvidia-jetpack.uefiCapsuleUpdate}
+      else
+        ota-abort-capsule-update
       fi
     '';
   };

--- a/pkgs/ota-utils/default.nix
+++ b/pkgs/ota-utils/default.nix
@@ -20,14 +20,15 @@ stdenvNoCC.mkDerivation {
     cp ${./ota-setup-efivars.sh} $out/bin/ota-setup-efivars
     cp ${./ota-apply-capsule-update.sh} $out/bin/ota-apply-capsule-update
     cp ${./ota-check-firmware.sh} $out/bin/ota-check-firmware
+    cp ${./ota-abort-capsule-update.sh} $out/bin/ota-abort-capsule-update
     cp ${./ota_helpers.func} $out/share/ota_helpers.func
-    chmod +x $out/bin/ota-setup-efivars $out/bin/ota-apply-capsule-update $out/bin/ota-check-firmware
+    chmod +x $out/bin/ota-setup-efivars $out/bin/ota-apply-capsule-update $out/bin/ota-check-firmware $out/bin/ota-abort-capsule-update
 
-    for path in $out/bin/ota-apply-capsule-update $out/share/ota_helpers.func; do
+    for path in $out/bin/ota-apply-capsule-update $out/share/ota_helpers.func $out/bin/ota-abort-capsule-update; do
       substituteInPlace "$path" --subst-var efiSysMountPoint
     done
 
-    for fname in ota-setup-efivars ota-apply-capsule-update; do
+    for fname in ota-setup-efivars ota-apply-capsule-update ota-abort-capsule-update; do
       substituteInPlace $out/bin/$fname \
         --replace "@ota_helpers@" "$out/share/ota_helpers.func"
       sed -i '2a export PATH=${lib.makeBinPath [ util-linux e2fsprogs tegra-eeprom-tool ]}:$PATH' $out/bin/$fname

--- a/pkgs/ota-utils/ota-abort-capsule-update.sh
+++ b/pkgs/ota-utils/ota-abort-capsule-update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "@ota_helpers@"
+
+boardspec=$(tegra-boardspec)
+detect_can_write_runtime_uefi_vars "$boardspec"
+
+# Check for @efiSysMountPoint@ (defaults to /boot) being an ESP. On Xavier AGX,
+# even though the efi vars need to be written to an ESP on the emmc, capsule
+# updates can still be written to an ESP partition at @efiSysMountPoint@ on
+# other devices (e.g. nvme)
+if ! mountpoint -q @efiSysMountPoint@; then
+	echo "@efiSysMountPoint@ is not mounted"
+	exit 1
+fi
+
+set_efi_var OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c "\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+rm -f @efiSysMountPoint@/EFI/UpdateCapsule/TEGRA_BL.Cap


### PR DESCRIPTION
###### Description of changes

If one tries to switch to a switch-to-configuration a generation which uses new firmware version (vNext), doesn't reboot, and then switch-to-confiugration a generation which matches the current firmware, the vNext capsule update isn't cleared, but should be. Implement a new helper script: ota-abort-capsule-update which uninstalls a pending capsule update. Run the script if the firmware version matches.

###### Testing

- [x] run switch-to-configuration as described above
- [x] Run switch-to-configuration "normally" with capsule update needed
- [x] Run switch-to-configuration "normally" with no capsule update already present
