### PR TITLE
vpi-test: Rename as "vpi-test"

### DIFF
--- a/pkgs/samples/vpi-test.nix
+++ b/pkgs/samples/vpi-test.nix
@@ -2,7 +2,7 @@
 # Tested via "./result/bin/vpi_sample_05_benchmark <cpu|pva|cuda>" (Try pva especially)
 # Getting a bunch of "pva 16000000.pva0: failed to get firmware" messages, so unsure if its working.
 writeShellApplication {
-  name = "vpi2-test";
+  name = "vpi-test";
   text = ''
     echo " * Running vpi_sample_05_benchmark cuda"
     ${vpi-samples}/bin/vpi_sample_05_benchmark cuda


### PR DESCRIPTION
Finish renaming "vpi2-test" as "vpi-test".

Fixes: 6c40cc625c83 ("cuda-packages: Build vpi2 for jetpack 5, vpi3 for jetpack 6")

###### Testing
- [x] vpi-test on JP5
- [x] vpi-test on JP6