### PR TITLE
Replace som check for null with check for "generic"

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -464,7 +464,7 @@ in
 
     # These are from l4t_generate_soc_bup.sh, plus some additional ones found in the wild.
     hardware.nvidia-jetpack.firmware.variants =
-      if (cfg.som != null) then
+      if (cfg.som != "generic") then
         (lib.mkOptionDefault (
           {
             xavier-agx = [


### PR DESCRIPTION
###### Description of changes

The option `hardware.nvidia-jetpack.som` can no longer be null, all checks besides this one were replaced with a check for "generic".

###### Testing

N/A