### PR TITLE
apparmor: Ensure lsm argument is sufficiently early in list

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -465,6 +465,10 @@ in
     (lib.mkIf (jetpackAtLeast "6")
       {
         hardware.deviceTree.dtbSource = pkgs.nvidia-jetpack.kernelPackages.devicetree;
+
+        # Nvidia's jammy kernel has downstream apparmor patches which require "apparmor"
+        # to appear sufficiently early in the `lsm=<list of security modules>` kernel argument
+        security.lsm = lib.mkIf config.security.apparmor.enable (lib.mkBefore [ "apparmor" ]);
       })
   ]);
 }


### PR DESCRIPTION
###### Description of changes

Nvidia's jammy kernel has downstream apparmor patches which require "apparmor" to appear sufficiently early in the lsm= kernel parameter.

Add a mkBefore [ "apparmor" ] to ensure it's early in the list. This causes apparmor to appear twice in the list: once at the beginning from the mkBefore and once at the end (default). This doesn't appear to be a problem.

nixos-25.05 introduces a new security.lsm option which sets the lsm= kernel parameter. The current implementation doesn't guarantee that apparmor is first in the list. Note that upstream implementation of apparmor does not care whether it is first or last in the list, so this change is not suitable for upstream nixpkgs.

###### Testing

- [x] Check that `config.boot.kernelParams` has `lsm=apparmor,landlock,yama,bpf,apparmor`
