### PR TITLE
nvidia-oot-modules: Add dev output with combined Module.symvers

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -87,6 +87,16 @@ stdenv.mkDerivation (finalAttrs: {
     "INSTALL_MOD_PATH=$(out)"
   ];
 
+  postInstall = ''
+    mkdir -p $dev
+    cat **/Module.symvers > $dev/Module.symvers
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   # # GCC 14.2 seems confused about DRM_MODESET_LOCK_ALL_BEGIN/DRM_MODESET_LOCK_ALL_END in nvdisplay/kernel-open/nvidia-drm/nvidia-drm-drv.c:1344
   # extraMakeFlags = [ "KCFLAGS=-Wno-error=unused-label" ];
 


### PR DESCRIPTION
###### Description of changes

If compiling an out-of-tree module which depends on nvidia-oot-modules, we need the sources (for headers) and Module.symvers for CRC symbol versioning. Export a concatenated Module.symvers in the dev output.

###### Testing

- [x] nix build and check result-dev/Module.symvers contains the needed information
