### PR TITLE
CDI: don't add before docker.socket

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -444,9 +444,8 @@ in
         wantedBy = [ "multi-user.target" ];
         wants = [ "modprobe@nvgpu.service" ];
         after = [ "modprobe@nvgpu.service" ];
-        before = lib.optionals nvidiaDockerActive [
+        before = lib.optionals config.virtualisation.docker.enable [
           "docker.service"
-          "docker.socket"
         ];
         script =
           let


### PR DESCRIPTION
###### Description of changes

It doesn't make sense to do "Before" a socket. In my testing, this causes docker to never start.

Also, docker.enableNvidia is optional with the new container-toolkit.enable option. Just guard the before on Docker enabled.

###### Testing

- [x] Running OCI tests
