### PR TITLE
uefi-firmware: fix changed r36.4.4 tag from edk2-nvidia repo

### DIFF
--- a/pkgs/uefi-firmware/r36/default.nix
+++ b/pkgs/uefi-firmware/r36/default.nix
@@ -139,7 +139,7 @@ let
       owner = "NVIDIA";
       repo = "edk2-nvidia";
       rev = "r${l4tMajorMinorPatchVersion}";
-      sha256 = "sha256-Hz4IfDotlWRBRad8gfPAUVc2C1+bkTSW04+JpA3aqTY=";
+      sha256 = "sha256-eTX+/B6TtpYyeoeQxJcoN2eS+Mh4DtLthabW7p7jzYQ=";
     };
     patches = edk2NvidiaPatches ++ [
       ###### git log r36.4.3-updates ^r36.4.3 (kept these even in 36.4.4) ######
@@ -162,11 +162,6 @@ let
         # fix: bug in secureboot hash compute and optimize reads
         url = "https://github.com/NVIDIA/edk2-nvidia/commit/9d4a790e7786d9699405f15927f2fc391915bb19.patch";
         hash = "sha256-MVzWEzzKPRfDWiqgGnfl9dwgDnPLJxjsvijH5jM2Pgw=";
-      })
-      (fetchpatch {
-        # fix: switch default value of PcdSocDisplayHandoffMode to Auto (#125)
-        url = "https://github.com/NVIDIA/edk2-nvidia/commit/a85e6cecf3e37eda685c7c8c9041a570a6397640.patch";
-        hash = "sha256-f4XSCEYE1NOF4sr/OfHxcD/n06o5aod33+6TWyMaoRs=";
       })
       #####################################################
 


### PR DESCRIPTION
###### Description of changes

The only difference between the previous tag and the current one is the inclusion of commit [350c50a](https://github.com/NVIDIA/edk2-nvidia/commit/350c50a65a7b30d916b8c1901ed940f6d69bbcaa) titled:
"fix: switch default value of PcdSocDisplayHandoffMode to Auto (#125)"  (Originally from https://github.com/NVIDIA/edk2-nvidia/pull/125)
This lets us remove that additional patch we already applied ourselves.

Fixes https://github.com/anduril/jetpack-nixos/issues/332 .

###### Testing

`nix build .#flash-orin-nano-devkit` succeeds.
