### PR TITLE
uefi-firmware: r35: backport: Reclaim() fails after ~355 reboots

### DIFF
--- a/pkgs/uefi-firmware/r35/default.nix
+++ b/pkgs/uefi-firmware/r35/default.nix
@@ -106,6 +106,14 @@ let
       # As of (2025-05-23), this is still not fixed in any release branch of 35.x.x
       ./0001-fix-varint-read-records-per-erase-block-and-fix-leak.patch
       ./0002-fix-bug-in-block-erase-logic.patch
+
+      # fix: split ftw writes if they span blocks
+      # https://forums.developer.nvidia.com/t/possible-uefi-memory-leak-and-partition-full/308540/50
+      # https://github.com/NVIDIA/edk2-nvidia/issues/114
+      (fetchpatch {
+        url = "https://github.com/NVIDIA/edk2-nvidia/commit/c101ba515b2737fb78d8929c2852f5c8f9607330.patch";
+        sha256 = "sha256-M+9y5lmUoUrc985MDuZzHIa2EySqoPWzRu2QSTc0Q1A=";
+      })
     ];
     postPatch = lib.optionalString errorLevelInfo ''
       sed -i 's#PcdDebugPrintErrorLevel|.*#PcdDebugPrintErrorLevel|0x8000004F#' Platform/NVIDIA/NVIDIA.common.dsc.inc


### PR DESCRIPTION
###### Description of changes

We've noticed a failure after ~300-350 reboots on Xavier AGX where the following assertion is hit:

RecordVarErrorFlag (0xEF)
PlatformConfigData:ED3374EF-767B-42FA-AF70-DB520A392822 - 0x00000003 -0xEA CommonVariableSpace = 0x1FF9C - CommonVariableTotalSize = 0x1FF5C PlatformConfigured: Error setting Platform Config data: Bad Buffer Size

The fix for this assertion provided by NVIDIA is:
https://github.com/NVIDIA/edk2-nvidia/commit/c101ba515b2737fb78d8929c2852f5c8f9607330

This was pulled this into jetpack-nixos:
commit a44074feb977 ("uefi-firmware: bump edk2-nvidia to latest r35.6.0-updates branch")

Subsequent L4T releases dropped this change and thus this issue has reappeared. Bring the patch back in explicitly.

Link: https://github.com/NVIDIA/edk2-nvidia/issues/114

###### Testing

- [x] 550+ reboots and counting
