### PR TITLE
optee: Allow specifying log level from NixOS option

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -264,6 +264,23 @@ in
               source tree.
             '';
           };
+
+          coreLogLevel = mkOption {
+            type = types.int;
+            default = 2;
+            description = ''
+              OP-TEE core log level, corresponds to CFG_TEE_CORE_LOG_LEVEL
+            '';
+          };
+
+          taLogLevel = mkOption {
+            type = types.int;
+            default = cfg.firmware.optee.coreLogLevel;
+            defaultText = "hardware.nvidia-jetpack.firmware.optee.coreLogLevel";
+            description = ''
+              OP-TEE trusted application log level, corresponds to CFG_TEE_TA_LOG_LEVEL
+            '';
+          };
         };
 
         eksFile = mkOption {

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -13,9 +13,8 @@ final: prev: (
 
     tosArgs = {
       inherit (final.nvidia-jetpack) socType;
-      inherit (cfg.firmware.optee) taPublicKeyFile;
+      inherit (cfg.firmware.optee) taPublicKeyFile extraMakeFlags coreLogLevel taLogLevel;
       opteePatches = cfg.firmware.optee.patches;
-      extraMakeFlags = cfg.firmware.optee.extraMakeFlags;
     };
 
     flashTools = cfg.flasherPkgs.callPackages (import ./device-pkgs { inherit config; pkgs = final; }) { };

--- a/pkgs/optee/default.nix
+++ b/pkgs/optee/default.nix
@@ -52,6 +52,8 @@ let
                                     , extraMakeFlags ? [ ]
                                     , opteePatches ? [ ]
                                     , taPublicKeyFile ? null
+                                    , coreLogLevel ? 2
+                                    , taLogLevel ? coreLogLevel
                                     , ...
                                     }:
     let
@@ -68,6 +70,8 @@ let
         "CFG_WITH_STMM_SP=y"
         "NV_CCC_PREBUILT=${nvCccPrebuilt}"
         "O=$(out)"
+        "CFG_TEE_CORE_LOG_LEVEL=${toString coreLogLevel}"
+        "CFG_TEE_TA_LOG_LEVEL=${toString taLogLevel}"
       ]
       ++ (lib.optional (uefi-firmware != null) "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin")
       ++ (lib.optional (taPublicKeyFile != null) "TA_PUBLIC_KEY=${taPublicKeyFile}")
@@ -77,7 +81,7 @@ let
       inherit pname;
       version = l4tMajorMinorPatchVersion;
       src = nvopteeSrc;
-      patches = opteePatches;
+      patches = opteePatches ++ [ ./remove-force-log-level.diff ];
       postPatch = ''
         patchShebangs $(find optee/optee_os -type d -name scripts -printf '%p ')
       '';

--- a/pkgs/optee/remove-force-log-level.diff
+++ b/pkgs/optee/remove-force-log-level.diff
@@ -1,0 +1,14 @@
+diff --git a/optee/optee_os/core/arch/arm/plat-tegra/conf.mk b/optee/optee_os/core/arch/arm/plat-tegra/conf.mk
+index 69f025e..9945200 100644
+--- a/optee/optee_os/core/arch/arm/plat-tegra/conf.mk
++++ b/optee/optee_os/core/arch/arm/plat-tegra/conf.mk
+@@ -61,9 +61,6 @@ $(call force,CFG_RPMB_TESTKEY,n)
+ # Enable PKCS11 tests in xtest
+ $(call force,CFG_PKCS11_TA,y)
+ 
+-# Set the default log level to INFO
+-$(call force,CFG_TEE_CORE_LOG_LEVEL,2)
+-
+ # Do not halt system if an invalid EKB is detected
+ $(call force,CFG_JETSON_MANDATORY_EKB,n)
+ 


### PR DESCRIPTION
###### Description of changes

Increasing/decreasing the log level is a convenient way to get more information from OP-TEE. Expose this optee configuration parameter as a NixOS option.
 - hardware.nvidia-jetpack.firmware.optee.coreLogLevel
 - hardware.nvidia-jetpack.firmware.optee.taLogLevel

###### Testing

- [x] Builds, similar logging to current output
- [x] Increase coreLogLevel/taLogLevel and see more messages
