### PR TITLE
Add isp-setup service

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -172,6 +172,16 @@ in
         description = "Enable boot.kernelParams default console configuration";
       };
 
+      ispPkgs = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          The list of packages that contain isp files. This
+          will copy any files in the /nvcam directory of each package to the
+          /var/nvidia/nvcam directory on the device at boot time.
+        '';
+      };
+
       console.args = mkOption {
         internal = true;
         type = types.listOf types.str;
@@ -571,6 +581,35 @@ in
         after = [ "nvpmodel.service" ];
         wantedBy = [ "multi-user.target" ];
       };
+
+      systemd.services.isp-setup =
+        let
+          ispHash = builtins.hashString "sha256" (builtins.concatStringsSep "\x1f" cfg.ispPkgs);
+          copyCmd = builtins.concatStringsSep "\n" (builtins.map (pkg: "${lib.getExe' pkgs.coreutils "cp"} -r ${pkg}/nvcam/. /var/nvidia/nvcam") cfg.ispPkgs);
+          copyISPfiles = pkgs.writeShellScriptBin "copy-isp-files" ''
+            if [[ -f "/var/nvidia/nvcam/.version" ]]; then
+              curVersion=$(cat /var/nvidia/nvcam/.version)
+              if [[ $curVersion == ${ispHash} ]]; then
+                exit 0
+              fi
+              rm -rf /var/nvidia/nvcam
+            fi
+
+            ${lib.getExe' pkgs.coreutils "mkdir"} -p /var/nvidia/nvcam
+            echo ${ispHash} > /var/nvidia/nvcam/.version
+            ${copyCmd}
+            ${lib.getExe' pkgs.coreutils "chmod"} -R 644 /var/nvidia/nvcam
+          '';
+        in
+        mkIf (builtins.length cfg.ispPkgs != 0) {
+          enable = true;
+          description = "Copy ISP files to /var/nvidia/nvcam";
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = lib.getExe copyISPfiles;
+          };
+          wantedBy = [ "multi-user.target" ];
+        };
 
       hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications = [ ]
         ++ lib.optional cfg.firmware.optee.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta


### PR DESCRIPTION
###### Description of changes

Creates a service that will copy all files under `nvcam` specified in `hardware.nvidia-jetpack.ispPkgs` into the `/var/nvidia/nvcam` directory. Whenever this list of pkgs gets updated the `/var/nvidia/nvcam` directory will be recreated. 

###### Testing

Verified files were copied into /var/nvidia/nvcam on an orin-agx. nvargus was able to read the .isp files and image captured using nvargus pipeline had isp configuration applied.
