### PR TITLE
Updating optee's compiling environment

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -88,9 +88,15 @@ makeScope final.newScope (self: {
     edk2-jetson uefi-firmware;
 
   inherit (final.callPackages ./pkgs/optee {
-    # Nvidia's recommended toolchain is gcc9:
-    # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
-    stdenv = final.gcc9Stdenv;
+    # As today as this comment is written then nixpkgs unstabble has removed
+    # gcc12Stdenv and below support. The next "oldest" is gcc13Stdenv.
+    #
+    # Jetson 36.x; Anticipating upcomming nixpkgs updates and
+    # therefore swithching directly to use gcc13Stdenv. Officially NVIDIA
+    # uses gcc11
+    #
+    # Jetson 35.x: Keeping gcc9 as per NVIDIA recommends
+    stdenv = if self.l4tAtLeast "36" then final.gcc13Stdenv else final.gcc9Stdenv;
     inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion l4tAtLeast uefi-firmware;
   }) buildTOS buildOpteeTaDevKit opteeClient;
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };


### PR DESCRIPTION
nixpkgs unstable has removed gcc12Stdenv and below support. The next "oldest" is gcc13Stdenv.

###### Description of changes
Jetson 36.x; Anticipating upcomming nixpkgs update(s) and therefore switching directly to use gcc13Stdenv. Officially NVIDIA uses gcc11.

Jetson 35.x: Keeps gcc9 as per NVIDIA recommends.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing
NX target evaluates and compiles. Boots with iso_minimal. 
