### PR TITLE
oot-modules: enable __structuredAttrs to handle flags with spaces

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -71,6 +71,9 @@ let
     );
 in
 stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "l4t-oot-modules";
   version = "${l4tMajorMinorPatchVersion}";
   src = l4t-oot-modules-sources;

--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -3,6 +3,7 @@
 , buildPackages
 , gitRepos
 , kernel
+, kernelModuleMakeFlags
 , l4tMajorMinorPatchVersion
 , lib
 , runCommand
@@ -70,7 +71,7 @@ let
       ''
     );
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -78,15 +79,13 @@ stdenv.mkDerivation (finalAttrs: {
   version = "${l4tMajorMinorPatchVersion}";
   src = l4t-oot-modules-sources;
 
-  inherit kernel;
-
-  nativeBuildInputs = finalAttrs.kernel.moduleBuildDependencies;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # See bspSrc/source/Makefile
-  makeFlags = finalAttrs.kernel.makeFlags ++ [
-    "KERNEL_HEADERS=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/source"
-    "KERNEL_OUTPUT=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/build"
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNEL_HEADERS=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+    "KERNEL_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
 
@@ -105,4 +104,4 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "modules" ];
   installTargets = [ "modules_install" ];
-})
+}


### PR DESCRIPTION
###### Description of changes

`l4t-oot-modules` does not build when using any nixpkgs past https://github.com/nixos/nixpkgs/commit/9f9b582 due to it inheriting the kernel make flags. If we set `__structuredAttrs` here as well, it will work regardless.

###### Testing

Tested `l4t-oot-modules` successfully builds before `9f9b582` as well as after `9f9b582`.