### PR TITLE
Add xavier-agx 2888-401-0004-F.0-1-2 variant

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -487,6 +487,7 @@ in
             xavier-agx = [
               { boardid = "2888"; boardsku = "0001"; fab = "400"; boardrev = "D.0"; fuselevel = "fuselevel_production"; chiprev = "2"; }
               { boardid = "2888"; boardsku = "0001"; fab = "400"; boardrev = "E.0"; fuselevel = "fuselevel_production"; chiprev = "2"; } # 16GB
+              { boardid = "2888"; boardsku = "0004"; fab = "401"; boardrev = "F.0"; fuselevel = "fuselevel_production"; chiprev = "2"; } # 32GB
               { boardid = "2888"; boardsku = "0004"; fab = "400"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = "2"; } # 32GB
               { boardid = "2888"; boardsku = "0005"; fab = "402"; boardrev = ""; fuselevel = "fuselevel_production"; chiprev = "2"; } # 64GB
             ];


### PR DESCRIPTION
Found `fab=401` and `boardrev=F.0` xavier-agx variant using OE4T tegra-eeprom-tool.
