### PR TITLE
oot-modules: enable __structuredAttrs to handle flags with spaces (Fixes #347)

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -71,6 +71,9 @@ let
     );
 in
 stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "l4t-oot-modules";
   version = "${l4tMajorMinorPatchVersion}";
   src = l4t-oot-modules-sources;


### PR DESCRIPTION
(cherry picked from commit ebe4acdad605aaa997f045642b71a3dc1ee585ad)

###### Description of changes

The #351 PR fixed the original issue it was aiming to solve, but introduced a separate issue, #352, so it was reverted in #353. However, applying just the first commit from #351 fixes the issue, so I am making this PR that cherry-picks it.

Fixes #347.

###### Testing

Built using latest nixos-unstable, for a Jetson Orin Nano.