### PR TITLE
l4t-oot-modules: use kernel from callPackage argument

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -286,9 +286,7 @@ in
           [ config.boot.kernelPackages.nvidia-display-driver ]
         ++
         lib.optionals (jetpackAtLeast "6") [
-          (pkgs.nvidia-jetpack.kernelPackages.nvidia-oot-modules.overrideAttrs {
-            inherit (config.boot.kernelPackages) kernel;
-          })
+          pkgs.nvidia-jetpack.kernelPackages.nvidia-oot-modules
         ];
 
       hardware.firmware = with pkgs.nvidia-jetpack; [

--- a/pkgs/kernels/r35/display-driver.nix
+++ b/pkgs/kernels/r35/display-driver.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.commonMakeFlags ++ [
     "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"

--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -70,7 +70,7 @@ let
       ''
     );
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -78,15 +78,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "${l4tMajorMinorPatchVersion}";
   src = l4t-oot-modules-sources;
 
-  inherit kernel;
-
-  nativeBuildInputs = finalAttrs.kernel.moduleBuildDependencies;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # See bspSrc/source/Makefile
-  makeFlags = finalAttrs.kernel.makeFlags ++ [
-    "KERNEL_HEADERS=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/source"
-    "KERNEL_OUTPUT=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/build"
+  # We can't use kernelModuleMakeFlags because it sets KBUILD_OUTPUT, which nvdisplay won't like. DON'T DO IT!
+  makeFlags = kernel.commonMakeFlags ++ [
+    "KERNEL_HEADERS=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+    "KERNEL_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
 
@@ -105,4 +104,4 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "modules" ];
   installTargets = [ "modules_install" ];
-})
+}


### PR DESCRIPTION
###### Description of changes

The `kernel` derivation is already something that is passed via `kernelPackages.callPackage`, so there is no reason to store it as an attribute on the oot-modules derivation for usage through `finalAttrs`.

###### Testing

- [ ] Boot devkits
