### PR TITLE
modules: nixpkgs.config must contain plain values

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib)
+    mkBefore
     mkEnableOption
     mkIf
     mkOption
@@ -223,18 +224,16 @@ in
       ];
 
       # Advertise support for CUDA.
-      nixpkgs.config = mkIf cfg.configureCuda {
-        cudaSupport = lib.mkDefault true;
+      nixpkgs.config = mkIf cfg.configureCuda (mkBefore {
+        cudaSupport = true;
         cudaCapabilities =
           let
             isGeneric = cfg.som == "generic";
             isXavier = lib.hasPrefix "xavier-" cfg.som;
             isOrin = lib.hasPrefix "orin-" cfg.som;
           in
-          lib.mkDefault
-            (lib.optionals (isXavier || isGeneric) [ "7.2" ]
-              ++ lib.optionals (isOrin || isGeneric) [ "8.7" ]);
-      };
+          lib.optionals (isXavier || isGeneric) [ "7.2" ] ++ lib.optionals (isOrin || isGeneric) [ "8.7" ];
+      });
 
       boot.kernelPackages =
         if cfg.kernel.realtime then


### PR DESCRIPTION
###### Description of changes

The `nixpkgs.config` option defined for NixOS systems does not allow use of functionality like `lib.mkDefault` or `lib.mkForce` for individual values: instead, `nixpkgs.config` is defined as an attribute set and computes the final, merged value by doing `foldr` with `lib.recursiveUpdate` over the definitions. See https://github.com/NixOS/nixpkgs/blob/9c9589bf1efd76081ad81e7a84004550f26a0622/nixos/modules/misc/nixpkgs.nix#L16-L45.

Overriding values then needs to happen through `mkAfter`, as the latest value wins.

Example before this change:

```console
nix-repl> :p nixosConfigurations.my-orin.config.nixpkgs.config
{
  allowUnfree = true;
  cudaCapabilities = {
    _type = "override";
    content = [ "8.7" ];
    priority = 1000;
  };
  cudaSupport = {
    _type = "override";
    content = true;
    priority = 1000;
  };
}
```

Example after this change:

```console
nix-repl> :p nixosConfigurations.my-orin.config.nixpkgs.config
{
  allowUnfree = true;
  cudaCapabilities = [ "8.7" ];
  cudaSupport = true;
}
```

###### Testing

- [x] Manual verification
- [x] CI