### PR TITLE
optee: use default stdenv

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -88,9 +88,6 @@ makeScope final.newScope (self: {
     edk2-jetson uefi-firmware;
 
   inherit (final.callPackages ./pkgs/optee {
-    # Nvidia's recommended toolchain is gcc9:
-    # https://nv-tegra.nvidia.com/r/gitweb?p=tegra/optee-src/nv-optee.git;a=blob;f=optee/atf_and_optee_README.txt;h=591edda3d4ec96997e054ebd21fc8326983d3464;hb=5ac2ab218ba9116f1df4a0bb5092b1f6d810e8f7#l33
-    stdenv = final.gcc9Stdenv;
     inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion l4tAtLeast uefi-firmware;
   }) buildTOS buildOpteeTaDevKit opteeClient;
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };


### PR DESCRIPTION
###### Description of changes

OP-TEE was originally pinned to use gcc 9 because that's what NVIDIA's toolchain was using by default.  GCC 9 has now been removed from nixpkgs.  This makes optee similar to our kernel and edk2 builds and just uses the default stdenv provided by nixpkgs.

Fixes: https://github.com/anduril/jetpack-nixos/issues/346

###### Testing

Tested booting and nvluks trusted app with JP5 and JP6 on Orin AGX and Orin Nano. Also tested JP5 on Xavier AGX.