### PR TITLE
optee: PKCS11 ta and xtest

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -85,11 +85,11 @@ makeScope final.newScope (self: {
   );
 
   inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion; })
-    edk2-jetson uefi-firmware;
+    uefi-firmware;
 
   inherit (final.callPackages ./pkgs/optee {
-    inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion l4tAtLeast uefi-firmware;
-  }) buildTOS buildOpteeTaDevKit opteeClient;
+    inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion l4tOlder l4tAtLeast uefi-firmware;
+  }) buildTOS buildOpteeTaDevKit opteeClient buildPkcs11Ta buildOpteeXtest;
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };
 
   flash-tools = self.callPackage ./pkgs/flash-tools { };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -420,6 +420,10 @@ in
         wantedBy = [ "multi-user.target" ];
       };
 
+      hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications = [ ]
+        ++ lib.optional cfg.firmware.optee.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
+        ++ lib.optional cfg.firmware.optee.xtest pkgs.nvidia-jetpack.opteeXtest;
+
       systemd.services.tee-supplicant =
         let
           args = lib.escapeShellArgs (
@@ -442,7 +446,7 @@ in
       environment.systemPackages = with pkgs.nvidia-jetpack; [
         l4t-tools
         otaUtils # Tools for UEFI capsule updates
-      ];
+      ] ++ lib.optional cfg.firmware.optee.xtest pkgs.nvidia-jetpack.opteeXtest;
 
       # Used by libEGL_nvidia.so.0
       environment.etc."egl/egl_external_platform.d".source =

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -244,6 +244,22 @@ in
             };
           };
 
+          pkcs11Support = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Adds OP-TEE's PKCS#11 TA.
+            '';
+          };
+
+          xtest = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Adds OP-TEE's xtest and related TA/Plugins
+            '';
+          };
+
           patches = mkOption {
             type = types.listOf types.path;
             default = [ ];

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -73,6 +73,8 @@ final: prev: (
 
       tosImage = finalJetpack.buildTOS tosArgs;
       taDevKit = finalJetpack.buildOpteeTaDevKit tosArgs;
+      pkcs11Ta = finalJetpack.buildPkcs11Ta tosArgs;
+      opteeXtest = finalJetpack.buildOpteeXtest tosArgs;
       inherit (finalJetpack.tosImage) nvLuksSrv hwKeyAgent;
 
       flashInitrd =


### PR DESCRIPTION
This pull request is basically refactoring PR #149. #149 did not caught any comments and therefore this PR have a different approach: Minimal and avoids changes to existing targets.

###### Description of changes

OP-TEE has a support for PKCS#11, but currently OP-TEE's PKCS#11 support is not working within Jetpack-nixos project due it is missing required [PKCS#11 TA](https://github.com/OP-TEE/optee_os/tree/master/ta/pkcs11). This pull request adds PKCS#11 derivation and option for enabling it.

Also OP-TEE project has a sanity testsuite (xtest). Pull request adds xtest derivation and option for enabling it.

Projects, which uses Jetpack-nixos as a input, can enable PKCS11 support and xtest with option, but unfortunately pkcs11 support nor xtest has not been integrated into iso_minimal-targets. It would require a bit more extensive changes into flake.nix-file.   

###### Testing
Xtest ran on Orin NX and following tests fails:
- 1008: Loads corrupt TA. Requires investigation. It seems like the test requires write permission to TA-directory, but TAs are in nix store.
- 1033: Plugin test case. Plugin support can be disabled or passing an extra argument to tee-supplicant
