### PR TITLE
cudaPackages.cuda_cudart: propagate stubs output by default

### DIFF
--- a/pkgs/cuda-packages/cuda_cudart/fixup.nix
+++ b/pkgs/cuda-packages/cuda_cudart/fixup.nix
@@ -5,7 +5,8 @@
 }:
 prevAttrs: {
   # Include the static libraries as well since CMake needs them during the configure phase.
-  propagatedBuildOutputs = prevAttrs.propagatedBuildOutputs or [ ] ++ [ "static" ];
+  # Include the stubs libraries so packages linking against CUDA::cuda_driver also build (e.g., llama-cpp).
+  propagatedBuildOutputs = prevAttrs.propagatedBuildOutputs or [ ] ++ [ "static" "stubs" ];
 
   postPatch =
     prevAttrs.postPatch or ""


### PR DESCRIPTION
###### Description of changes

The stubs output allows packages to link against driver stubs.

As an example, upstream `llama-cpp` will fail in its `configurePhase` because it is unable to locate `CUDA::cuda_driver` (the `cuda_cudart` stubs).

###### Testing

- [x] Able to build `llama-cpp` (internally)
- [x] CI
- [x] HITL manual tests