### PR TITLE
fix cross compile patchelfUnstable

### DIFF
--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -4,7 +4,6 @@
 , lib
 , fetchurl
 , fetchpatch
-, patchelfUnstable
 , autoPatchelfHook
 , dpkg
 , expat
@@ -162,7 +161,7 @@ let
       echo NvOsLibraryLoad NvOsLibraryLoad_3d > $remapFile
       for lib in $(find ./lib -name "*.so*"); do
         if isELF $lib; then
-          ${lib.getExe patchelfUnstable} "$lib" \
+          ${lib.getExe buildPackages.patchelfUnstable} "$lib" \
             --rename-dynamic-symbols "$remapFile" \
             --replace-needed libnvos.so libnvos_3d.so
         fi
@@ -359,7 +358,7 @@ let
       echo NvOsLibraryLoad NvOsLibraryLoad_multimedia > $remapFile
       for lib in $(find ./lib -name "*.so*"); do
         if isELF $lib; then
-          ${lib.getExe patchelfUnstable} "$lib" \
+          ${lib.getExe buildPackages.patchelfUnstable} "$lib" \
             --rename-dynamic-symbols "$remapFile" \
             --replace-needed libnvos.so libnvos_multimedia.so
         fi


### PR DESCRIPTION
The patchelfUnstable that is being picked up is the aarch64 version which can not run on an x86_64 system, unless binfmt is enabled.

```
/nix/store/i5j0b0x9vvzwgbj3ydk14hp2rqc4lll7-stdenv-linux/setup: line 318: /nix/store/l9zagx3fyg26amzxhzjg51dshzv11kk6-patchelf-aarch64-unknown-linux-gnu-0.18.0-unstable-2025-08-13/bin/patchelf: cannot execute binary file: Exec format error
```

So ensure that the build system package is being used for patchelfUnstable.

###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->
Fixed cross-compilation issue

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

build a cross compiled image on an x86 machine that does not have binfmt enabled.
