### PR TITLE
Apply the kernelPackages overlay in the NixOS module, to use a single fixed point

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,32 @@ format. By default, there will be a single device setup of the kind
 
 If you are using Podman, it is recommended to add a dependency to any systemd services that run podman to specify `After=nvidia-container-toolkit-cdi-generator.service`. Due to Podman's daemonless nature, this ensures that the CDI configuration files are generated prior to container start.
 
+### Using the kernel package sets
+
+There are two predefined kernel package sets in the overlay. They use sources
+from Jetson Linux.
+
+- `pkgs.nvidia-jetpack.kernelPackages`
+- `pkgs.nvidia-jetpack.rtkernelPackages`
+
+The NixOS module uses these sets by default.
+
+On JetPack 6+, however, you may use a mainline package set instead.
+Consult the [Bring Your Own Kernel](https://docs.nvidia.com/jetson/archives/r36.4.4/DeveloperGuide/SD/Kernel/BringYourOwnKernel.html) documentation for more details.
+
+When using a custom package set in the NixOS configuration, the out-of-tree
+modules must be added using the provided overlay.
+
+e.g. (using the `pkgs.nvidia-jetpack.kernelPackages` set)
+
+```nix
+{ pkgs, ... }:
+
+{
+  config.boot.kernelPackages = pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay
+}
+```
+
 ## Configuring CUDA for Nixpkgs
 
 > [!NOTE]

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -137,7 +137,7 @@ makeScope final.newScope (self: {
 
   kernelPackagesOverlay = final: _:
     if self.l4tAtLeast "36" then {
-      devicetree = self.callPackage ./pkgs/kernels/r${l4tMajorVersion}/devicetree.nix { };
+      devicetree = final.callPackage ./pkgs/kernels/r${l4tMajorVersion}/devicetree.nix { inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion; };
       nvidia-oot-modules = final.callPackage ./pkgs/kernels/r${l4tMajorVersion}/oot-modules.nix { inherit (self) bspSrc gitRepos l4tMajorMinorPatchVersion; };
     } else {
       nvidia-display-driver = final.callPackage ./pkgs/kernels/r${l4tMajorVersion}/display-driver.nix { inherit (self) gitRepos l4tMajorMinorPatchVersion; };

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -144,10 +144,10 @@ makeScope final.newScope (self: {
     };
 
   kernel = self.callPackage ./pkgs/kernels/r${l4tMajorVersion} { kernelPatches = [ ]; };
-  kernelPackages = (final.linuxPackagesFor self.kernel).extend self.kernelPackagesOverlay;
+  kernelPackages = final.linuxPackagesFor self.kernel;
 
   rtkernel = self.callPackage ./pkgs/kernels/r${l4tMajorVersion} { kernelPatches = [ ]; realtime = true; };
-  rtkernelPackages = (final.linuxPackagesFor self.rtkernel).extend self.kernelPackagesOverlay;
+  rtkernelPackages = final.linuxPackagesFor self.rtkernel;
 
   nxJetsonBenchmarks = self.callPackage ./pkgs/jetson-benchmarks {
     targetSom = "nx";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -236,10 +236,10 @@ in
       });
 
       boot.kernelPackages =
-        if cfg.kernel.realtime then
+        (if cfg.kernel.realtime then
           pkgs.nvidia-jetpack.rtkernelPackages
         else
-          pkgs.nvidia-jetpack.kernelPackages;
+          pkgs.nvidia-jetpack.kernelPackages).extend pkgs.nvidia-jetpack.kernelPackagesOverlay;
 
       boot.kernelParams = [
         # Needed on Orin at least, but upstream has it for both
@@ -285,9 +285,7 @@ in
           [ config.boot.kernelPackages.nvidia-display-driver ]
         ++
         lib.optionals (jetpackAtLeast "6") [
-          (pkgs.nvidia-jetpack.kernelPackages.nvidia-oot-modules.overrideAttrs {
-            inherit (config.boot.kernelPackages) kernel;
-          })
+          config.boot.kernelPackages.nvidia-oot-modules
         ];
 
       hardware.firmware = with pkgs.nvidia-jetpack; [
@@ -486,7 +484,7 @@ in
     }
     (lib.mkIf (jetpackAtLeast "6")
       {
-        hardware.deviceTree.dtbSource = pkgs.nvidia-jetpack.kernelPackages.devicetree;
+        hardware.deviceTree.dtbSource = config.boot.kernelPackages.devicetree;
 
         # Nvidia's jammy kernel has downstream apparmor patches which require "apparmor"
         # to appear sufficiently early in the `lsm=<list of security modules>` kernel argument


### PR DESCRIPTION
###### Description of changes

At the moment, a mixture of `config.boot.kernelPackages` and `pkgs.nvidia-jetpack.kernelPackages` is used throughout the NixOS module. This can lead to duplicate kernels being built when the former fixed point is modified separately to the latter (e.g. with the `boot.kernelPatches` option).

This PR moves everything to use `config.boot.kernelPackages` only, fixing this issue.

In order to keep allowing custom kernel package sets to be used ("Bring Your Own Kernel"), the `kernelPackagesOverlay` is no longer pre-applied in the overlay itself. This allows any package set (from `pkgs.nvidia-jetpack` or otherwise) to be combined with the overlay when being passed to `config.boot.kernelPackages`.

A fix for the `devicetree` `callPackage` like in #271 is also included.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

- [x] Instantiated