### PR TITLE
l4t-oot-modules: ignore PREEMPT_RT check

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     "KERNEL_HEADERS=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/source"
     "KERNEL_OUTPUT=${finalAttrs.kernel.dev}/lib/modules/${finalAttrs.kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
+    "IGNORE_PREEMPT_RT_PRESENCE=1"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Description of changes

Fix Jetpack 6 build of oot-modules when `hardware.nvidia-jetpack.kernel.realtime = true;`.

Fixes https://github.com/anduril/jetpack-nixos/issues/363

###### Testing

Booted an Orin AGX devkit and ran samples test.
