### PR TITLE
Revert "Apply the kernelPackagesOverlay in the NixOS module"

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,32 +245,6 @@ format. By default, there will be a single device setup of the kind
 
 If you are using Podman, it is recommended to add a dependency to any systemd services that run podman to specify `After=nvidia-container-toolkit-cdi-generator.service`. Due to Podman's daemonless nature, this ensures that the CDI configuration files are generated prior to container start.
 
-### Using the kernel package sets
-
-There are two predefined kernel package sets in the overlay. They use sources
-from Jetson Linux.
-
-- `pkgs.nvidia-jetpack.kernelPackages`
-- `pkgs.nvidia-jetpack.rtkernelPackages`
-
-The NixOS module uses these sets by default.
-
-On JetPack 6+, however, you may use a mainline package set instead.
-Consult the [Bring Your Own Kernel](https://docs.nvidia.com/jetson/archives/r36.4.4/DeveloperGuide/SD/Kernel/BringYourOwnKernel.html) documentation for more details.
-
-When using a custom package set in the NixOS configuration, the out-of-tree
-modules must be added using the provided overlay.
-
-e.g. (using the `pkgs.nvidia-jetpack.kernelPackages` set)
-
-```nix
-{ pkgs, ... }:
-
-{
-  config.boot.kernelPackages = pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay
-}
-```
-
 ## Configuring CUDA for Nixpkgs
 
 > [!NOTE]

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -144,10 +144,10 @@ makeScope final.newScope (self: {
     };
 
   kernel = self.callPackage ./pkgs/kernels/r${l4tMajorVersion} { kernelPatches = [ ]; };
-  kernelPackages = final.linuxPackagesFor self.kernel;
+  kernelPackages = (final.linuxPackagesFor self.kernel).extend self.kernelPackagesOverlay;
 
   rtkernel = self.callPackage ./pkgs/kernels/r${l4tMajorVersion} { kernelPatches = [ ]; realtime = true; };
-  rtkernelPackages = final.linuxPackagesFor self.rtkernel;
+  rtkernelPackages = (final.linuxPackagesFor self.rtkernel).extend self.kernelPackagesOverlay;
 
   nxJetsonBenchmarks = self.callPackage ./pkgs/jetson-benchmarks {
     targetSom = "nx";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -236,10 +236,10 @@ in
       });
 
       boot.kernelPackages =
-        (if cfg.kernel.realtime then
+        if cfg.kernel.realtime then
           pkgs.nvidia-jetpack.rtkernelPackages
         else
-          pkgs.nvidia-jetpack.kernelPackages).extend pkgs.nvidia-jetpack.kernelPackagesOverlay;
+          pkgs.nvidia-jetpack.kernelPackages;
 
       boot.kernelParams = [
         # Needed on Orin at least, but upstream has it for both
@@ -285,7 +285,9 @@ in
           [ config.boot.kernelPackages.nvidia-display-driver ]
         ++
         lib.optionals (jetpackAtLeast "6") [
-          config.boot.kernelPackages.nvidia-oot-modules
+          (pkgs.nvidia-jetpack.kernelPackages.nvidia-oot-modules.overrideAttrs {
+            inherit (config.boot.kernelPackages) kernel;
+          })
         ];
 
       hardware.firmware = with pkgs.nvidia-jetpack; [
@@ -484,7 +486,7 @@ in
     }
     (lib.mkIf (jetpackAtLeast "6")
       {
-        hardware.deviceTree.dtbSource = config.boot.kernelPackages.devicetree;
+        hardware.deviceTree.dtbSource = pkgs.nvidia-jetpack.kernelPackages.devicetree;
 
         # Nvidia's jammy kernel has downstream apparmor patches which require "apparmor"
         # to appear sufficiently early in the `lsm=<list of security modules>` kernel argument


### PR DESCRIPTION
This commit breaks downstream consumers of jetpack-nixos containing overlays modifying `pkgs.nvidia-jetpack.kernelPackages.devicetree` and `pkgs.nvidia-jetpack.kernelPackages.nvidia-oot-modules`.

It's a bit unclear if this commit needs to be reworked or if downstream usages need to apply their devicetree modifications in a different manner.  If downstream changes are necessary, we should provide migration documentation. For now, I believe reverting this change is the best course.