### PR TITLE
jetpack6: add nvidia-smi package

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -478,7 +478,9 @@ in
       environment.systemPackages = with pkgs.nvidia-jetpack; [
         l4t-tools
         otaUtils # Tools for UEFI capsule updates
-      ] ++ lib.optional cfg.firmware.optee.xtest pkgs.nvidia-jetpack.opteeXtest;
+      ] ++ lib.optional cfg.firmware.optee.xtest pkgs.nvidia-jetpack.opteeXtest
+      # Tool to view GPU utilization.
+      ++ lib.optional (l4tAtLeast "36") nvidia-smi;
 
       # Used by libEGL_nvidia.so.0
       environment.etc."egl/egl_external_platform.d".source =

--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -430,6 +430,15 @@ let
     autoPatchelf = false;
     meta.platforms = [ "aarch64-linux" "x86_64-linux" ];
   };
+
+  nvidia-smi = buildFromDeb {
+    name = "nvidia-smi";
+    src = debs.t234.nvidia-l4t-nvml.src;
+    version = debs.t234.nvidia-l4t-nvml.version;
+    buildInputs = [ l4t-core ];
+    # nvidia-smi will dlopen libnvidia-ml.so.1
+    appendRunpaths = [ "${placeholder "out"}/lib" ];
+  };
 in
 {
   inherit
@@ -453,5 +462,6 @@ in
     l4t-xusb-firmware;
 } // lib.optionalAttrs (l4tAtLeast "36") {
   inherit
-    l4t-dla-compiler;
+    l4t-dla-compiler
+    nvidia-smi;
 }


### PR DESCRIPTION
# Description
Enable the `nvidia-smi` program to assist with monitoring and management of the GPU processors. It's unclear what functionality works on Jetson vs the x86 build.

# Testing
Programs builds and runs while running JP6 on orin-agx-devkit.
```
> ./nvidia-smi -L
GPU 0: Orin (nvgpu) (UUID: [removed])

>./nvidia-smi
Thu Oct  9 01:42:44 2025
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 540.4.0                Driver Version: 540.4.0      CUDA Version: N/A      |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Orin (nvgpu)                  N/A  | N/A              N/A |                  N/A |
| N/A   N/A  N/A               N/A /  N/A | Not Supported        |     N/A          N/A |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```
