### PR TITLE
cudaPackages.cuda_nvcc: fix propagation of setupCudaHook and compiler

### DIFF
--- a/pkgs/cuda-packages/cuda_nvcc/fixup.nix
+++ b/pkgs/cuda-packages/cuda_nvcc/fixup.nix
@@ -148,7 +148,7 @@ finalAttrs: prevAttrs: {
   # NOTE: mkDerivation's setup.sh clobbers all dependency files in fixupPhase, so we must register the paths in postFixup.
   postFixup =
     prevAttrs.postFixup or ""
-    + lib.optionalString (cudaOlder "12") (''
+    + ''
       echo "adding setupCudaHook to propagatedBuildInputs of ''${!outputBin:?}"
       printWords "${setupCudaHook}" >> "''${!outputBin:?}/nix-support/propagated-build-inputs"
     ''
@@ -157,7 +157,7 @@ finalAttrs: prevAttrs: {
     + ''
       echo "adding backendStdenv.cc to propagatedNativeBuildInputs of ''${!outputBin:?}"
       printWords "${backendStdenv.cc}" >> "''${!outputBin:?}/nix-support/propagated-native-build-inputs"
-    '');
+    '';
 
   meta = prevAttrs.meta or { } // {
     mainProgram = "nvcc";


### PR DESCRIPTION
###### Description of changes

Fixes build of `magma` with CUDA 12.

Previously it would error during `configurePhase` with something like

```console
  In file included from
  /nix/store/8b42ia8y7brbsg8w91dpr43mhmjhr8x7-cuda_cudart-12.6.68-include/include/cuda_runtime.h:82,


                   from <command-line>:

  
  /nix/store/n9cs16hr62zvpjsly9sz6gjambgckms0-cuda_nvcc-12.6.68/include/crt/host_config.h:143:2:
  error: #error -- unsupported GNU version! gcc versions later than 13 are
  not supported! The nvcc flag '-allow-unsupported-compiler' can be used to
  override this version check; however, using an unsupported host compiler
  may cause compilation failure or incorrect run time execution.  Use at your
  own risk.

    143 | #error -- unsupported GNU version! gcc versions later than 13 are not supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation fa>
        |  ^~~~~

  # --error 0x1 --
```

because `gfortran` is listed before `cudaPackages.cuda_nvcc` in the `magma` derivation and so would have precedence on `PATH`:

https://github.com/NixOS/nixpkgs/blob/848c3a9fbba628987c98256fa34c6e2927ee1bde/pkgs/development/libraries/science/math/magma/generic.nix#L124-L128

It's a wonder any CUDA 12 packages worked without the CUDA setup hook.

###### Testing

- [x] Manual verification: ran `nix build -L .#legacyPackages.aarch64-linux.cudaPackages_12.pkgs.magma-cuda-static` internally
- [x] CI
