### PR TITLE
fix(overlay): override cudaPackages scope instead of replacing it

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -89,7 +89,7 @@ in
   cudaPackages_11_4 =
     if redistSystem == "linux-aarch64" then
       assert final.nvidia-jetpack5.cudaPackages.cudaMajorMinorVersion == "11.4";
-      final.nvidia-jetpack5.cudaPackages
+      prev.cudaPackages_11_4.overrideScope (_: _: final.nvidia-jetpack5.cudaPackages)
     else
       prev.cudaPackages_11_4;
   cudaPackages_11 =
@@ -101,7 +101,7 @@ in
   cudaPackages_12_6 =
     if redistSystem == "linux-aarch64" then
       assert final.nvidia-jetpack6.cudaPackages.cudaMajorMinorVersion == "12.6";
-      final.nvidia-jetpack6.cudaPackages
+      prev.cudaPackages_12_6.overrideScope (_: _: final.nvidia-jetpack6.cudaPackages)
     else
       prev.cudaPackages_12_6;
   cudaPackages_12 =


### PR DESCRIPTION
###### Description of changes

I'd like to be able to use some of the packages that are still coming from the normal nixpkgs' cudaPackages, like cudnn-frontend, which doesn't seem to be available in the nvidia-jetpack*.cudaPackages, but do seem to compile on aarch64 and jetson nonetheless.

Just replacing the whole cudaPackages attribute set with that of the jetpack provided one feels like it might be removing packages it shouldn't. Instead, I overrideScope the original cudaPackages, and only overlay the packages that nvidia-jetpack actually provides.

I am unsure if the is the right approach, or if there's maybe a better solution. But this seems to be working?

###### Testing

Built `.legacyPackages.aarch64-linux.cudaPackages.cudnn-frontend` after overlaying it on top of the nixpkgs' nixos-25.05 branch.
