### PR TITLE
module: Set default initrd cryptoModules for luks

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -300,6 +300,20 @@ in
         "nvethernet"
       ];
 
+      # See upstream default for this option, removes any modules that aren't enabled in JetPack kernel
+      boot.initrd.luks.cryptoModules = lib.mkDefault [
+        "aes"
+        "aes_generic"
+        "twofish"
+        "cbc"
+        "xts"
+        "sha1"
+        "sha256"
+        "sha512"
+        "af_alg"
+        "algif_skcipher"
+      ];
+
       boot.kernelModules =
         [ "nvgpu" ]
         ++ lib.optionals (cfg.modesetting.enable && checkValidSoms [ "xavier" ]) [ "tegra-udrm" ]


### PR DESCRIPTION
###### Description of changes

The default value for boot.initrd.luks.cryptoModules includes blowflish, serpent, and lrw modules. None of these modules are enabled in the JetPack kernel. Remove these modules from the list.

###### Testing

- [x] Build JetPack with luks enabled.
