### PR TITLE
Use treefmt for nix flake check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,9 +135,13 @@
       };
 
       checks = forAllSystems ({ pkgs, system, ... }: {
-        formatting = pkgs.runCommand "repo-formatting" { nativeBuildInputs = with pkgs; [ nixpkgs-fmt ]; } ''
-          nixpkgs-fmt --check ${self} && touch $out
-        '';
+        formatting = pkgs.stdenv.mkDerivation {
+          name = "repo-formatting";
+          src = self;
+          buildPhase = ''
+            ${lib.getExe self.formatter.${system}} --fail-on-change --no-cache && touch $out
+          '';
+        };
         jetpackSelectionDependsOnCudaVersion = import ./check-jetpack-selection.nix {
           inherit lib nixpkgs pkgs system;
           overlay = self.overlays.default;


### PR DESCRIPTION
###### Description of changes

I keep accidently committing unformatted code because the flake check isn't checking non-nix files. Use treefmt in the flake check.

###### Testing

- [x] nix flake check on the repo today (passes)
- [x] nix flake check with deliberately unformatted code (fails as expected)
