### PR TITLE
uefi: Pin JetPack 5 python version to 3.12

### DIFF
--- a/pkgs/uefi-firmware/r35/default.nix
+++ b/pkgs/uefi-firmware/r35/default.nix
@@ -158,7 +158,7 @@ let
     depsBuildBuild = prev.depsBuildBuild ++ [ libuuid ];
   });
 
-  pythonEnv = buildPackages.python3.withPackages (ps: [ ps.tkinter ]);
+  pythonEnv = buildPackages.python312.withPackages (ps: [ ps.tkinter ]);
   targetArch =
     if stdenv.isi686 then
       "IA32"


### PR DESCRIPTION
###### Description of changes

UEFI depends on xdrlib, which is removed in 3.13.

###### Testing

- [x] It builds!
