### PR TITLE
modules: nvidia-container-toolkit: Guard JetPack CDI generation

### DIFF
--- a/modules/nvidia-container-toolkit.nix
+++ b/modules/nvidia-container-toolkit.nix
@@ -16,12 +16,12 @@ in
     (mkRenamedOptionModule [ "hardware" "nvidia-jetpack" "container-toolkit" "enable" ] [ "hardware" "nvidia-container-toolkit" "enable" ])
   ];
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = mkIf cfg.enable (mkMerge [
+    {
       hardware.nvidia-container-toolkit.enable = mkDefault (
         with config.virtualisation; docker.enable && docker.enableNvidia || podman.enable && podman.enableNvidia
       );
-    })
+    }
     (mkIf config.hardware.nvidia-container-toolkit.enable {
       systemd.services.nvidia-container-toolkit-cdi-generator = {
         # TODO: Upstream waits on `system-udev-settle.service`:
@@ -119,5 +119,5 @@ in
           );
       };
     })
-  ];
+  ]);
 }


### PR DESCRIPTION
###### Description of changes

Setting up JetPack-specific CDI generation should be guarded by hardware.nvidia-jetpack.enable = true. This was accidentally enabled unconditionally when the nvidia-container-toolkit was enabled and importing the JetPack NixOS modules.

Fixes: ce35a81ccb70 ("Move nvidia-container-toolkit config into its own module")

###### Testing

- [x] Verify JetPack configuration not being pulled in when `hardware.nvidia-jetpack.enable == false` and `hardware.nvidia-container-toolkit.enable == true`
