### PR TITLE
overlay: JetPack CUDA extensions should only apply when using JetPack

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -146,7 +146,8 @@ in
       prev.opencv;
 
   _cuda = prev._cuda.extend (_: prev: recursiveUpdate prev {
-    extensions = prev.extensions ++ [ (final.callPackage ./pkgs/cuda-extensions { }) ];
+    extensions = prev.extensions
+      ++ final.lib.optional useJetPackCudaPackageSet (final.callPackage ./pkgs/cuda-extensions { });
 
     # Update _cuda's database with an entry allowing Orin on CUDA 11.4.
     # NOTE: This can be removed when the minimum supported Nixpkgs version is 25.11,


### PR DESCRIPTION
###### Description of changes

The CUDA extension was erroneously applied unconditionally. It should only apply when using the JetPack CUDA package sets.

Fixes: d4efffc357e0 ("cuda: Introduce L4T cuda-extensions")

###### Testing

- [x] `vpi` attribute should not exist unless on a JetPack CUDA system.