### PR TITLE
Add nv_tcu_demuxer package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,8 @@
               board-automation python-jetson;
             inherit (self.legacyPackages.x86_64-linux.cudaPackages)
               nsight_systems_host nsight_compute_host;
+            inherit (self.legacyPackages.x86_64-linux.nvidia-jetpack7)
+              nv_tcu_demuxer;
           }
           # Flashing and board automation scripts _only_ work on x86_64-linux
           // flashScripts;

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -319,7 +319,9 @@ makeScope final.newScope (self: {
 
   # TODO(jared): deprecate this
   devicePkgsFromNixosConfig = config: config.system.build.jetsonDevicePkgs;
-}
+} // (optionalAttrs (versionAtLeast jetpackMajorMinorPatchVersion "6") {
+  nv_tcu_demuxer = final.callPackage ./pkgs/nv_tcu_demuxer { inherit (self) bspSrc; };
+})
   # Add the L4T packages
   # NOTE: Since this is adding packages to the top-level, and callPackage's auto args functionality draws from that
   # attribute set, we cannot use self.callPackages because we would end up with infinite recursion.

--- a/pkgs/nv_tcu_demuxer/default.nix
+++ b/pkgs/nv_tcu_demuxer/default.nix
@@ -1,0 +1,6 @@
+{ bspSrc, runCommand }:
+
+runCommand "nv_tcu_demuxer" { }
+  ''
+    install -Dm0755 ${bspSrc}/tools/demuxer/nv_tcu_demuxer $out/bin/nv_tcu_demuxer
+  ''


### PR DESCRIPTION
Add `nv_tcu_demuxer` package to the flake packages to demux the [Tegra Combined UART](https://docs.nvidia.com/jetson/archives/r38.2/DeveloperGuide/AT/JetsonLinuxDevelopmentTools/TegraCombinedUART.html#nv-tcu-demuxer-utility) device on Orin and Thor platforms.
