### PR TITLE
docs: Cuda support for JetPack 7 depends on 25.11 release, not 25.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package supports JetPack 5, 6, and 7. It works with NVIDIA's developer kits
 
 The Jetson Nano, TX2, and TX1 devices are _not_ supported, since support for them was dropped upstream in JetPack 5.
 
-__NOTE__: CUDA is not currently supported in JetPack 7 (Thor AGX) due to dependencies on upstream nixpkgs. CUDA 13 support will be added after the release of NixOS/nixpkgs 25.05.
+__NOTE__: CUDA is not currently supported in JetPack 7 (Thor AGX) due to dependencies on upstream nixpkgs. CUDA 13 support will be added after the release of NixOS/nixpkgs 25.11.
 
 ## Getting started
 


### PR DESCRIPTION
###### Description of changes

Unless i have misunderstood it, cuda 13 depends on 25.11 release, not 25.05 as the docs currently says.
Relevant pr:
https://github.com/anduril/jetpack-nixos/pull/391


###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
