### PR TITLE
system: fix the new property tree for system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,14 +30,14 @@
       };
       aarch64_config = {
         nixpkgs = {
-          buildPlatform = "aarch64-linux";
-          hostPlatform = "aarch64-linux";
+          buildPlatform.system = "aarch64-linux";
+          hostPlatform.system = "aarch64-linux";
         };
       };
       aarch64_cross_config = {
         nixpkgs = {
-          buildPlatform = "x86_64-linux";
-          hostPlatform = "aarch64-linux";
+          buildPlatform.system = "x86_64-linux";
+          hostPlatform.system = "aarch64-linux";
         };
       };
       jetpack5_config = {


### PR DESCRIPTION
buildPlatform and hostPlatform no longer act as the system definition. They now contain a system property that has been enforced to be used by nixpkgs and system will be set through `nixpkgs.{host,build}Platform.system`.

###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
