### PR TITLE
mk-overlay.nix: fix usage of CUDA implementation details post 25.11

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -178,6 +178,11 @@ makeScope final.newScope (self: {
         inherit (self) debs buildFromDebs; # NOTE: The presence of debs is used as a condition in construciton of pkgs'.
         debsForSourcePackage = srcPackageName: filter (pkg: (pkg.source or "") == srcPackageName) (attrValues finalCudaPackages.debs.common);
 
+        # The manifests attribute is required to avoid breakages caused by going from a JetPack-provided CUDA package
+        # set to one of upstream Nixpkgs' CUDA package sets, since upstream compares against the manifests attribute.
+        # See: https://github.com/NixOS/nixpkgs/pull/462761.
+        manifests.cuda.release_label = cudaMajorMinorPatchVersion;
+
         pkgs = pkgs';
 
         # Use backendStdenv from upstream


### PR DESCRIPTION
###### Description of changes

Fix usage of implementation details since https://github.com/NixOS/nixpkgs/pull/462761.

###### Testing

Verified the `backendStdenv.nix` error is fixed by ensuring

```console
nix eval .#legacyPackages.aarch64-linux.nvidia-jetpack5.cudaPackages.saxpy.drvPath --override-input nixpkgs github:nixos/nixpkgs/nixos-25.05
```

and

```console
nix eval .#legacyPackages.aarch64-linux.nvidia-jetpack5.cudaPackages.saxpy.drvPath --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11
```

evaluate.

Verified the missing `manifests` attribute error is fixed by ensuring

```console
nix eval .#legacyPackages.aarch64-linux.nvidia-jetpack6.cudaPackages.pkgs.cudaPackages_11_6.pkgs.nvidia-jetpack.cudaPackages.saxpy.drvPath --override-input nixpkgs github:nixos/nixpkgs/nixos-25.05
```

and

```console
nix eval .#legacyPackages.aarch64-linux.nvidia-jetpack6.cudaPackages.pkgs.cudaPackages_11_6.pkgs.nvidia-jetpack.cudaPackages.saxpy.drvPath --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11
```

evaluate.