### PR TITLE
ci: add nix flake check for NixOS 25.11

### DIFF
--- a/.github/workflows/ci-25.11.yaml
+++ b/.github/workflows/ci-25.11.yaml
@@ -1,0 +1,15 @@
+name: ci-25.11
+on:
+  workflow_dispatch: # allows manual triggering
+  pull_request:
+    branches:
+      - master
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - run: nix flake check --print-build-logs --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11 --no-build


### PR DESCRIPTION
###### Description of changes

Adds a Nix flake check CI step for NixOS 25.11. We're not yet requiring this to pass for merges, but to keep an eye on it for when we (hopefully soon) support 25.11.

###### Testing

CI Only