### PR TITLE
Include vpi-firmware for pre-JP7

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -288,8 +288,9 @@ in
 
       hardware.firmware = with pkgs.nvidia-jetpack; [
         l4t-firmware
-      ] ++ lib.optionals pkgs.config.cudaSupport [
-        cudaPackages.vpi-firmware # Optional, but needed for pva_auth_allowlist firmware file used by VPI2
+      ] ++ lib.optionals (lib.versionOlder "7" cfg.majorVersion) [
+        # Optional, but needed for pva_auth_allowlist firmware file used by VPI2
+        cudaPackages.vpi-firmware
       ] ++ lib.optionals (l4tOlder "38") [
         l4t-xusb-firmware # usb firmware also present in linux-firmware package, but that package is huge and has much more than needed
       ] ++ lib.optionals (l4tAtLeast "38") (


### PR DESCRIPTION
###### Description of changes

This "firmware" needed for the needed for pva_auth_allowlist firmware file used by VPI, is in a different package under JP7 (libnvvpi4). This resolves the eval error for JP7 currently so that nix flake check passes

###### Testing

CI Only