### PR TITLE
Fix building nvidia samples app

### DIFF
--- a/pkgs/dlopen-override/default.nix
+++ b/pkgs/dlopen-override/default.nix
@@ -15,6 +15,11 @@
 # To use this pass rewrites which is an attribute set of the form
 # { oldPath = newPath; }
 # And a file which is just a string to the exact path of the lib
+#
+# Also, we have to clear the dlopen symbol version because when we rename the
+# symbol it holds onto the original dlopen's symbol version (GLIBC_x.yy).
+# This version likely does not match the GLIBC version used to compile
+# dlopenoverride (stdenv.mkDerivation above)
 rewrites: file:
 let
   oldPaths = builtins.attrNames rewrites;
@@ -63,6 +68,7 @@ in
     remapFile=$(mktemp)
     echo dlopen ${dlopenUnique} > $remapFile
     ${lib.getExe buildPackages.patchelfUnstable} ${file} \
+      --clear-symbol-version dlopen \
       --rename-dynamic-symbols "$remapFile" \
       --add-needed ${dlopen}/lib/dlopen-override.so \
       --add-rpath ${dlopen}/lib


### PR DESCRIPTION
###### Description of changes

#405 introduced a build failure in the Nvidia samples app.
This was caused by re-linking the library that had it's dlopen shimmed.
The shimmed dlopen retained the glibc version even after overriding the symbol name.
This might seem like it can cause issues since the underlying dlopens might not line up but these symbols always need to be backwards compatible so as long as we use the newest version of dlopen inside of dlopenoverride we don't run into any issues. 

fixes: #418 

###### Testing

Nvidia samples app builds and runs successfully on jetpack 5 and jetpack 6. Tested on a orin-agx-devkit
