### PR TITLE
Fix including vpi-firmware for pre-JP7

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -297,7 +297,7 @@ in
 
       hardware.firmware = with pkgs.nvidia-jetpack; [
         l4t-firmware
-      ] ++ lib.optionals (lib.versionOlder "7" cfg.majorVersion) [
+      ] ++ lib.optionals (lib.versionOlder cfg.majorVersion "7") [
         # Optional, but needed for pva_auth_allowlist firmware file used by VPI2
         cudaPackages.vpi-firmware
       ] ++ lib.optionals (l4tOlder "38") [


### PR DESCRIPTION
###### Description of changes

In a [previous PR](https://github.com/anduril/jetpack-nixos/pull/417)  I had the order reversed...

###### Testing

Ran samples test on xavier-agx-devkit