### PR TITLE
l4t-oot-modules: Include all generated conftest headers

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation {
     cat **/Module.symvers > $dev/Module.symvers
 
     mkdir -p $dev/include/nvidia
-    install -m 0644 out/nvidia-conftest/nvidia/conftest.h $dev/include/nvidia/
+    cp -r out/nvidia-conftest/nvidia/* $dev/include/nvidia/
   '';
 
   outputs = [


### PR DESCRIPTION
###### Description of changes

The conftest header actually includes quite a few other headers now:
```
#include "conftest/headers.h"
#include "conftest/functions.h"
#include "conftest/generic.h"
#include "conftest/macros.h"
#include "conftest/symbols.h"
#include "conftest/types.h"
```

lets make sure we don't miss anything and include everything that is generated.

###### Testing

Derivation now includes all generated headers.
