### PR TITLE
R36 and "bring our own kernel"-feature related conftests fixes.

### DIFF
--- a/pkgs/kernels/r36/0001-Add-of_property_for_each_u32_removed_internal_args-c.patch
+++ b/pkgs/kernels/r36/0001-Add-of_property_for_each_u32_removed_internal_args-c.patch
@@ -1,0 +1,93 @@
+From ccea708ddb09b64c83a7b08452e0c81365a49db6 Mon Sep 17 00:00:00 2001
+From: Tanel Dettenborn <tanel.dettenborn@tii.ae>
+Date: Thu, 4 Dec 2025 16:06:45 +0200
+Subject: [PATCH] Add "of_property_for_each_u32_removed_internal_args"-conftest
+
+Compiling fails against 6.6.76 and onward kernels, because internal
+arguments are removed from "of_property_for_each_u32"-macro.
+
+Note: Conftest is ported from "nvidia-oot"-repository.
+
+Signed-off-by: Tanel Dettenborn <tanel.dettenborn@tii.ae>
+---
+ kernel-open/conftest.sh                       | 23 +++++++++++++++++++
+ kernel-open/nvidia/nv-dsi-parse-panel-props.c |  6 +++++
+ kernel-open/nvidia/nvidia.Kbuild              |  1 +
+ 3 files changed, 30 insertions(+)
+
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
+index 391374f..7bdd5cb 100644
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
+@@ -434,6 +434,29 @@ check_for_ib_peer_memory_symbols() {
+ 
+ compile_test() {
+     case "$1" in
++        of_property_for_each_u32_removed_internal_args)
++            #
++            # Determine if the internal arguments for the macro
++            # of_property_for_each_u32() have been removed.
++            #
++            # Commit 9722c3b66e21 ("of: remove internal arguments from
++            # of_property_for_each_u32()") removes two arguments from
++            # of_property_for_each_u32() which are used internally within
++            # the macro and so do not need to be passed. This change was
++            # made for Linux v6.11.
++            #
++            CODE="
++            #include <linux/of.h>
++            void conftest_of_property_for_each_u32(struct device_node *np,
++                                                   char *propname) {
++                u32 val;
++
++                of_property_for_each_u32(np, propname, val);
++            }"
++
++            compile_check_conftest "$CODE" "NV_OF_PROPERTY_FOR_EACH_REMOVED_INTERNAL_ARGS" "" "types"
++        ;;
++
+         set_memory_uc)
+             #
+             # Determine if the set_memory_uc() function is present.
+diff --git a/kernel-open/nvidia/nv-dsi-parse-panel-props.c b/kernel-open/nvidia/nv-dsi-parse-panel-props.c
+index 9ac5866..5ae1e1c 100644
+--- a/kernel-open/nvidia/nv-dsi-parse-panel-props.c
++++ b/kernel-open/nvidia/nv-dsi-parse-panel-props.c
+@@ -290,8 +290,10 @@ static int parse_dsi_properties(const struct device_node *np_dsi, DSI_PANEL_INFO
+ {
+     u32 temp;
+     int ret = 0;
++#if !defined(NV_OF_PROPERTY_FOR_EACH_REMOVED_INTERNAL_ARGS) /* Linux v6.11 */
+     const __be32 *p;
+     struct property *prop;
++#endif
+     struct device_node *np_dsi_panel;
+ 
+     // Get Panel Node from active-panel phandle
+@@ -493,7 +495,11 @@ static int parse_dsi_properties(const struct device_node *np_dsi, DSI_PANEL_INFO
+         "nvidia,dsi-lvds-bridge", &temp))
+         dsi->dsi2lvds_bridge_enable = (bool)temp;
+ 
++#if defined(NV_OF_PROPERTY_FOR_EACH_REMOVED_INTERNAL_ARGS) /* Linux v6.11 */
++    of_property_for_each_u32(np_dsi_panel, "nvidia,dsi-dpd-pads", temp)
++#else
+     of_property_for_each_u32(np_dsi_panel, "nvidia,dsi-dpd-pads", prop, p, temp)
++#endif
+         dsi->dpd_dsi_pads |= (u32)temp;
+ 
+     if (!of_property_read_u32(np_dsi_panel,
+diff --git a/kernel-open/nvidia/nvidia.Kbuild b/kernel-open/nvidia/nvidia.Kbuild
+index c87daf3..295ee86 100644
+--- a/kernel-open/nvidia/nvidia.Kbuild
++++ b/kernel-open/nvidia/nvidia.Kbuild
+@@ -112,6 +112,7 @@ $(obj)/$(NVIDIA_INTERFACE): $(addprefix $(obj)/,$(NVIDIA_OBJECTS))
+ 
+ NV_OBJECTS_DEPEND_ON_CONFTEST += $(NVIDIA_OBJECTS)
+ 
++NV_CONFTEST_FUNCTION_COMPILE_TESTS += of_property_for_each_u32_removed_internal_args
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += hash__remap_4k_pfn
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += set_pages_uc
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += list_is_first
+-- 
+2.50.1
+

--- a/pkgs/kernels/r36/0001-Fix-register_shrinker_has_fmt_arg-conftest.patch
+++ b/pkgs/kernels/r36/0001-Fix-register_shrinker_has_fmt_arg-conftest.patch
@@ -1,0 +1,30 @@
+From dccd00f3b73ab66d3090cf8279b1137f31059407 Mon Sep 17 00:00:00 2001
+From: Tanel Dettenborn <tanel.dettenborn@tii.ae>
+Date: Wed, 17 Dec 2025 11:54:27 +0200
+Subject: [PATCH] Fix "register_shrinker_has_fmt_arg"-conftest
+
+Aforesaid conftest error erroneously from kernel 6.0.x to 6.6.x. Error is
+caused by Nix added GCC compiler flag "-Werror=format-security". Commit
+fixes conftest, but other fix could be disabling "format-security"-flag.
+
+Signed-off-by: Tanel Dettenborn <tanel.dettenborn@tii.ae>
+---
+ scripts/conftest/conftest.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/conftest/conftest.sh b/scripts/conftest/conftest.sh
+index 2346a86e..fa4cc077 100755
+--- a/scripts/conftest/conftest.sh
++++ b/scripts/conftest/conftest.sh
+@@ -7568,7 +7568,7 @@ compile_test() {
+             #include <linux/compiler_attributes.h>
+             #include <linux/shrinker.h>
+             int conftest_register_shrinker_has_fmt_arg(struct shrinker *s, const char *name) {
+-                    return register_shrinker(s, name);
++                    return register_shrinker(s, \"%s\", name);
+             }"
+ 
+             compile_check_conftest "$CODE" "NV_REGISTER_SHRINKER_HAS_FMT_ARG" "" "types"
+-- 
+2.50.1
+

--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -31,6 +31,9 @@ let
       patches = [
         ./0001-rtl8822ce-Fix-Werror-address.patch
         ./0002-sound-Fix-include-path-for-tegra-virt-alt-include.patch
+
+        # "Bring our own kernel" related fix (details in commit msg).
+        ./0001-Fix-register_shrinker_has_fmt_arg-conftest.patch
       ];
     })
     (gitRepos.nvgpu.overrideAttrs { name = "nvgpu"; })
@@ -42,6 +45,11 @@ let
         ./0002-ANDURIL-Add-some-missing-BASE_CFLAGS.patch
         ./0003-ANDURIL-Update-drm_gem_object_vmap_has_map_arg-test.patch
         ./0004-ANDURIL-override-KERNEL_SOURCES-and-KERNEL_OUTPUT-if.patch
+
+        # "Bring our own kernel" related fix (details in commit msg).
+        # Assuming the conftest will be added to subsequent Jetson releases,
+        # but for now 36.4.4. does not contain it.
+        ./0001-Add-of_property_for_each_u32_removed_internal_args-c.patch
       ];
     })
     (applyPatches {


### PR DESCRIPTION
Jetson R36 introduces "[bring your own kernel](https://docs.nvidia.com/jetson/archives/r36.4.4/DeveloperGuide/SD/Kernel/BringYourOwnKernel.html)"-feature. Nvidia-oot requires a couple of fixes to work against upstream kernel. Note: Tested with kernel 6.6.118. Later kernel might require more adjusting of nvidia-oot.

###### Description of changes
* Nix adds "format-security" GCC flag and therefore one of the NVIDIA's "conftest"-test error erroneously.
* Display driver is missing "of_property_for_each_u32_removed_internal_args"-conftest



<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing
`nix build .#flash-orin-nx-debug && nix build .#iso_minimal` evaluates and compile (and boots on NX device). Targets has been tested with default BSP 5.15.x kernel and upstream 6.6.118 kernel.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
