### PR TITLE
github: Update runner to use custom nix flake check implementation

### DIFF
--- a/.github/nix-flake-check-ci.sh
+++ b/.github/nix-flake-check-ci.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+enumerateAttrs() {
+  local -r flakeURI=$1
+
+  nix eval --json --apply "builtins.attrNames" "$flakeURI" | jq -cr ".[] | \"$flakeURI.\" + ."
+}
+
+currentSystem=$(nix eval --impure --raw --expr "builtins.currentSystem")
+checks=$(enumerateAttrs ".#checks.${currentSystem}")
+
+set -x
+# Evaluate all nixosConfigurations' toplevel derivation
+nix-eval-jobs --flake . --select 'flake: builtins.mapAttrs (f: v: v.config.system.build.toplevel) flake.outputs.nixosConfigurations' "$@"
+
+# Evaluate all packages (impure for builtins.currentSystem)
+nix-eval-jobs --flake . --impure --select 'flake: builtins.getAttr builtins.currentSystem flake.outputs.packages' "$@"
+# Build all checks
+for check in $checks; do
+  nix build "$check" "$@"
+done

--- a/.github/workflows/ci-25.11.yaml
+++ b/.github/workflows/ci-25.11.yaml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - run: nix flake check --print-build-logs --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11 --no-build
+      - run: nix shell nixpkgs#nix-eval-jobs nixpkgs#jq --command ./.github/nix-flake-check-ci.sh --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11

--- a/.github/workflows/ci-unstable.yaml
+++ b/.github/workflows/ci-unstable.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - run: nix flake check --print-build-logs --override-input nixpkgs github:nixos/nixpkgs --no-build
+      - run: nix shell nixpkgs#nix-eval-jobs nixpkgs#jq --command ./.github/nix-flake-check-ci.sh --override-input nixpkgs github:nixos/nixpkgs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - run: nix flake check --print-build-logs
+      - run: nix shell nixpkgs#nix-eval-jobs nixpkgs#jq --command ./.github/nix-flake-check-ci.sh


### PR DESCRIPTION
###### Description of changes

"nix flake check" is not currently optimized to reduce memory consumption and the GitHub runner does not have large amount of memory. If "nix flake check" OOMs, then CI fails. Split out the nix eval using nix-eval-jobs, which helps reduce required memory consumption.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
