### PR TITLE
l4t-3d-core: Fix the appendRunpaths attribute

### DIFF
--- a/pkgs/l4t/l4t-3d-core.nix
+++ b/pkgs/l4t/l4t-3d-core.nix
@@ -52,5 +52,5 @@ buildFromDebs {
     done
   '';
 
-  appendRunpaths = [ "${placeholder "out"}/lib" libglvnd xorg.libX11 xorg.libXext xorg.libxcb ];
+  appendRunpaths = [ "${placeholder "out"}/lib" ] ++ builtins.map (p: (lib.getLib p) + "/lib") [ libglvnd xorg.libX11 xorg.libXext xorg.libxcb ];
 }


### PR DESCRIPTION
###### Description of changes

appendRunpaths expects the full path you want to append, and doesn't do any further manipulation. We intended to add the library path of libglvnd and others, but ended up only adding the base $out output.

Fixes: 4dfea63a39e3 ("l4t-3d-core: Use appendRunpaths")

###### Testing

- [x] run vulkaninfo
