### PR TITLE
module: Remove twofish from boot.initrd.luks.cryptoModules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -273,7 +273,6 @@ in
       boot.initrd.luks.cryptoModules = lib.mkDefault [
         "aes"
         "aes_generic"
-        "twofish"
         "cbc"
         "xts"
         "sha1"


### PR DESCRIPTION
###### Description of changes

JetPack 6 does not ship this module.

###### Testing

- [x] Build initrd with luks enabled
