### PR TITLE
Clear uefi_variables in initrdflash on AGX Xavier

### DIFF
--- a/pkgs/flash-from-device/flash-from-device.sh
+++ b/pkgs/flash-from-device/flash-from-device.sh
@@ -217,6 +217,13 @@ write_partitions() {
     instnum=$(echo "$partloc" | cut -d':' -f 2)
     partname=$(echo "$partloc" | cut -d':' -f 3)
 
+    # Hack for AGX Xavier, which places uefi_variables on sdmmc_user device. sdmmc_user is not zero'd when flashing,
+    # but is zero'd on all other Jetsons because it lives on QSPI, which is zero'd. Let's keep consistent behavior
+    if [[ "$partname" == "uefi_variables" ]] && [[ "$partfile" == "" ]] && [[ "$devnum" -eq 1 && "$instnum" -eq 3 ]]; then
+      dd if=/dev/zero of=/dev/mmcblk0 bs=4096 seek="$start_location" count="$partsize" oflag=seek_bytes iflag=count_bytes
+      continue
+    fi
+
     if [[ "$partfile" == "" ]]; then
       report_step "Skipping flash.idx entry:$partname (devnum=$devnum, instnum=$instnum) (offset=$start_location)"
       continue


### PR DESCRIPTION
###### Description of changes

Hack for AGX Xavier, which places uefi_variables on sdmmc_user device. sdmmc_user is not zero'd when flashing, but is zero'd on all other Jetsons because it lives on QSPI, which is zero'd. Let's keep consistent behavior

###### Testing

- [x] Run uefi capsule update test on AGX Xavier
