### PR TITLE
fix: change nv-tegra git to gitlab

### DIFF
--- a/pkgs/l4t/l4t-multimedia.nix
+++ b/pkgs/l4t/l4t-multimedia.nix
@@ -22,7 +22,7 @@ let
   # Nvidia's included libv4l has very minimal changes against the upstream
   # version. We need to rebuild it from source to ensure it can find nvidia's
   # v4l plugins in the right location. Nvidia's version has the path hardcoded.
-  # See https://nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git
+  # See https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/v4l2_libs.git
   _l4t-multimedia-v4l = libv4l.overrideAttrs ({ nativeBuildInputs ? [ ], patches ? [ ], postPatch ? "", ... }: {
     nativeBuildInputs = nativeBuildInputs ++ [ dpkg ];
     patches = patches ++ lib.singleton (fetchurl {

--- a/sourceinfo/r35.6.2-gitrepos.json
+++ b/sourceinfo/r35.6.2-gitrepos.json
@@ -9,7 +9,7 @@
     "path": "/nix/store/djry5289lvz2gp1s0kav7vmyia14bp3m-3.5.0",
     "rev": "d33bb80cc249fcb5591b93f390a87e4f92274ce8",
     "sha256": "02xj519xxpmfdyw3ymaj93605gm646w1ra77531xh4b5ld359ckx",
-    "url": "https://nv-tegra.nvidia.com/3rdparty/libnl/3.5.0.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/3rdparty/libnl/3.5.0.git"
   },
   "hardware/nvidia/platform/t19x/common": {
     "date": "2023-05-28T22:52:08-07:00",
@@ -21,7 +21,7 @@
     "path": "/nix/store/9509cfg3sbzzmm766qj59m9qzhj1m4k9-common",
     "rev": "cab72a3f1109d333c5e164079e92e20e32f7ceb1",
     "sha256": "18zivxawny9lzja2w818rvml9vqpmv4awda1h9h1lm0xz6fbmiyg",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t19x/common.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t19x/common.git"
   },
   "hardware/nvidia/platform/t19x/galen-industrial/kernel-dts": {
     "date": "2023-01-04T23:36:30-08:00",
@@ -33,7 +33,7 @@
     "path": "/nix/store/ndm7hwxi99zw3nairawlzr0h2k55rb8n-galen-industrial-dts",
     "rev": "67826e84bc0f78b2b47f4142233370c1c2919236",
     "sha256": "12xmmdjx85c9mpa23b46kp896hikrjl2m9bl2n4bcjq5gl8cppjm",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t19x/galen-industrial-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t19x/galen-industrial-dts.git"
   },
   "hardware/nvidia/platform/t19x/galen/kernel-dts": {
     "date": "2023-08-29T23:52:30-07:00",
@@ -45,7 +45,7 @@
     "path": "/nix/store/wsahdgfqxpb8540b80466lvkv7x5gmp9-stardust-dts",
     "rev": "7df2f4ff0149dab335145088b1027b404b4b3df3",
     "sha256": "1r82h5yym5nbr94l8w97bvrwlpvlamjcvq7vj7xz8yvn07sx6gba",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t19x/stardust-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t19x/stardust-dts.git"
   },
   "hardware/nvidia/platform/t19x/jakku/kernel-dts": {
     "date": "2023-11-24T02:04:24-08:00",
@@ -57,7 +57,7 @@
     "path": "/nix/store/ryidr4vh2f4fwsdbcxizrw0h23b2f8p3-jakku-dts",
     "rev": "3d08e2b53acd7a87f1760489c15e0575bf1009c9",
     "sha256": "15i0219kv0ndf0k825ks6394pnvcgz4l10wn29v6sqx8djqbqs1h",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t19x/jakku-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t19x/jakku-dts.git"
   },
   "hardware/nvidia/platform/t19x/mccoy/kernel-dts": {
     "date": "2022-12-16T03:36:34-08:00",
@@ -69,7 +69,7 @@
     "path": "/nix/store/ylcif39m1ycrcvi25d4k57kk3nafg8r3-mccoy-dts",
     "rev": "ef34f875294270e94d713abd456ad39efffb9f30",
     "sha256": "0d9irsz2phq5wbqnqcnnp5v5piq742ibh0fbb712wa1pw7xfr4y8",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t19x/mccoy-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t19x/mccoy-dts.git"
   },
   "hardware/nvidia/platform/t23x/common/kernel-dts": {
     "date": "2023-09-12T03:49:19-07:00",
@@ -81,7 +81,7 @@
     "path": "/nix/store/wpbqm52dc4y5bqkkqrx1lyr6bk9h43wx-common-dts",
     "rev": "62b3069d6529865fc0229692c1dd28525fc0f650",
     "sha256": "1sn87dplx8gv772lj53h9071xsrplr7b7pyx55322cckjl3xhgsq",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t23x/common-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t23x/common-dts.git"
   },
   "hardware/nvidia/platform/t23x/concord/kernel-dts": {
     "date": "2024-06-10T22:49:06-07:00",
@@ -93,7 +93,7 @@
     "path": "/nix/store/nrg23xmhrrc9ippj62ph3xlvgz5fgz25-concord-dts",
     "rev": "0ae413c18b67c50a18ea1c23c99f377dfa0e6c3b",
     "sha256": "0ph204g1r23s1g559bpca50d7fznb339ndanjdszpnzx5ab5ll44",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t23x/concord-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t23x/concord-dts.git"
   },
   "hardware/nvidia/platform/t23x/p3768/kernel-dts": {
     "date": "2025-02-07T10:27:50-08:00",
@@ -105,7 +105,7 @@
     "path": "/nix/store/a8ql6wnwl19i342p11zdp01w44x7dbal-p3768-dts",
     "rev": "9c243042e7feca16d6c1bf8d2492f79e4aa4bb04",
     "sha256": "1apj1i08spaijmf8qwvlkx6r7wxavg5167f84s7iziqssinm5snq",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t23x/p3768-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t23x/p3768-dts.git"
   },
   "hardware/nvidia/platform/t23x/prometheus/kernel-dts": {
     "date": "2023-06-21T02:07:27-07:00",
@@ -117,7 +117,7 @@
     "path": "/nix/store/yamwx5p3yapgrp50c8njk3h0wf88gzjv-prometheus-dts",
     "rev": "d8885a822406d36abd36b0d959ef5b721a15e63c",
     "sha256": "1xa8haiv5wnpbs18z0nqrq2lpyvrz9ni166pw4ay21gmkl763vxr",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/t23x/prometheus-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/t23x/prometheus-dts.git"
   },
   "hardware/nvidia/platform/tegra/common": {
     "date": "2023-01-31T12:22:24-08:00",
@@ -129,7 +129,7 @@
     "path": "/nix/store/cf04fr825189dvx51wp1a4y4cmsbf2wf-common",
     "rev": "bd5a8c9a96e77b071c4aba5ee4c1562bfd631d58",
     "sha256": "1p2z0rycmcgl3n182xccjafb23qkgmr7sjkcw3wijzzqjqsm1vs4",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/platform/tegra/common.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/platform/tegra/common.git"
   },
   "hardware/nvidia/soc/t19x": {
     "date": "2023-08-06T20:51:42-07:00",
@@ -141,7 +141,7 @@
     "path": "/nix/store/amd5mzjbprblvv490irflysbd5a5syyj-t19x",
     "rev": "45b205ae566c3ce45a184f1ff4ed69477dddb7ad",
     "sha256": "1kib4fwf2m49fg7cymaf5xnwkjicphh7mwl0z0vsg9n6dqi8c779",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/soc/t19x.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/soc/t19x.git"
   },
   "hardware/nvidia/soc/t23x": {
     "date": "2024-05-15T07:05:27-07:00",
@@ -153,7 +153,7 @@
     "path": "/nix/store/fv9j56j317db0dzv0xpg29b0qlgjg2fg-t23x",
     "rev": "4946e3cf631a8f92d7ac01940c227f9cd2647af2",
     "sha256": "1j2hk0gbjjfycmwjx4jybvbrhv5d3vwvlxhq5yr1civwyyr7x8pk",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/soc/t23x.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/soc/t23x.git"
   },
   "hardware/nvidia/soc/tegra": {
     "date": "2025-02-12T10:56:16-08:00",
@@ -165,7 +165,7 @@
     "path": "/nix/store/ya5kx02gl1ljmxs7igssdgl1pamd79lc-tegra",
     "rev": "8cd785702998e37aa1a815509e5da28e7dbeb10f",
     "sha256": "1mmlm5i1ailx5flykxzx81grlsswblfw1n5ppbl7x0wa6wrjqgjz",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/soc/tegra.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/soc/tegra.git"
   },
   "kernel/kernel-5.10": {
     "date": "2025-02-24T20:21:55-08:00",
@@ -177,7 +177,7 @@
     "path": "/nix/store/w05sz1lbspqpm1p7mdg76kh067m291x8-linux-5.10",
     "rev": "8133aa889de64069251195ad151a876cd0482896",
     "sha256": "0lq8xlmhs33fhp86c24bd7xcxgdlb5xfpbaqm4y810hcf780lfzy",
-    "url": "https://nv-tegra.nvidia.com/linux-5.10.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-5.10.git"
   },
   "kernel/nvgpu": {
     "date": "2024-08-14T10:04:10-07:00",
@@ -189,7 +189,7 @@
     "path": "/nix/store/bbz9zwzxmvz664z79ifpl6ydv2lhl7fy-linux-nvgpu",
     "rev": "3de579438edaaf8fa62510ea0d20ff25bf9f56d4",
     "sha256": "1m3wc3l633g9j935wxfcmyz568v1jlc3ii21ij5119k8n6cs5h6q",
-    "url": "https://nv-tegra.nvidia.com/linux-nvgpu.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nvgpu.git"
   },
   "kernel/nvidia": {
     "date": "2025-02-12T10:51:04-08:00",
@@ -201,7 +201,7 @@
     "path": "/nix/store/vwnmxqdzsvq9jix2d02k6c047jj53dix-linux-nvidia",
     "rev": "ab7f1b97939d308d70276c228ec893cca62e02f6",
     "sha256": "1nh13rwhsa10x3b87n1j89wixr7b7lpxrmys5jyfhlf3w04hh5di",
-    "url": "https://nv-tegra.nvidia.com/linux-nvidia.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nvidia.git"
   },
   "kernel/nvidia/drivers/net/ethernet/nvidia/nvethernet/nvethernetrm": {
     "date": "2024-02-26T12:34:40-08:00",
@@ -213,7 +213,7 @@
     "path": "/nix/store/y8bv507r2m989ly6fcdbrjpj8gqsx4kx-nvethernetrm",
     "rev": "606235ffb27196a6cb71e33d0dca263e7273b2a0",
     "sha256": "1x34nd0f940gd84w3qysc9d7h9cwhavqcyrmpll4mdn1h1p77wcd",
-    "url": "https://nv-tegra.nvidia.com/kernel/nvethernetrm.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/kernel/nvethernetrm.git"
   },
   "tegra/argus-cam-libav/argus_cam_libavencoder": {
     "date": "2025-07-01T06:51:16-07:00",
@@ -225,7 +225,7 @@
     "path": "/nix/store/4d3iz4lhp68i3s72qx9wpcfga8z7w2g0-argus_cam_libavencoder",
     "rev": "3770b1f3687939a0053384ddad85ec03c4e26edb",
     "sha256": "09k727hmn2i86d1sfjyc5h709v05w1cdwi23iay2dad13hyxa287",
-    "url": "https://nv-tegra.nvidia.com/tegra/argus-cam-libav/argus_cam_libavencoder.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/argus-cam-libav/argus_cam_libavencoder.git"
   },
   "tegra/cuda-src/nvsample_cudaprocess": {
     "date": "2025-07-01T06:51:30-07:00",
@@ -237,7 +237,7 @@
     "path": "/nix/store/lrnzy3xwdhqyp8n5fhmy847q77s3xyn9-nvsample_cudaprocess",
     "rev": "358ab9b14c91b74cf965c4847cd232fed9aeb5d5",
     "sha256": "0xcgck5k8ax1jv8xl6mpjwcyd8q30283lvs55ncrmmvz3k9qx0cl",
-    "url": "https://nv-tegra.nvidia.com/tegra/cuda-src/nvsample_cudaprocess.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/cuda-src/nvsample_cudaprocess.git"
   },
   "tegra/gfx-src/nv-xconfig": {
     "date": "2025-07-01T06:51:17-07:00",
@@ -249,7 +249,7 @@
     "path": "/nix/store/iwssxqmwjrly31zpy9x25qbpnmdxdwqh-nv-xconfig",
     "rev": "4ece7a7e4876a21264c9f4a313fa4285af71a6ba",
     "sha256": "17lhzznfdh9zhc54cg7yj6zv0n1mmsq4zvfvv2qy1m1rkv9qg35z",
-    "url": "https://nv-tegra.nvidia.com/tegra/gfx-src/nv-xconfig.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gfx-src/nv-xconfig.git"
   },
   "tegra/gst-src/gst-egl": {
     "date": "2025-07-01T06:51:20-07:00",
@@ -261,7 +261,7 @@
     "path": "/nix/store/g4fsqn2firhbqcly2j9wkqsjy5g7zk0m-gst-egl",
     "rev": "a68fa1c01985daee67514721eb1c23d1c110b9c6",
     "sha256": "0gq3igf3bf400s42q0i7dzxy00cv7nl01fj1za4cq0kah5hl3940",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-egl.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-egl.git"
   },
   "tegra/gst-src/gst-jpeg": {
     "date": "2025-07-01T06:51:18-07:00",
@@ -273,7 +273,7 @@
     "path": "/nix/store/y9nlx9q3plphzmnd21dv7igk900kbchd-gst-jpeg",
     "rev": "d76c50967ee0362149484eec31c82ca7e9aa0ae1",
     "sha256": "07gnr36dvjlkw7ky070h7rnlb2yridkafzd1356bj9hc87y78xld",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-jpeg.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-jpeg.git"
   },
   "tegra/gst-src/gst-nvarguscamera": {
     "date": "2025-07-01T06:51:30-07:00",
@@ -285,7 +285,7 @@
     "path": "/nix/store/nxww374wwr79w8hsqx50gawrji37gpv4-gst-nvarguscamera",
     "rev": "2c1ab817dbe8368ab88319e40dc171653fb488aa",
     "sha256": "0rqsxl20kfrnnc7848jlj03hcdxspcfaz0cr63s3r6gi2py4k3pf",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvarguscamera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvarguscamera.git"
   },
   "tegra/gst-src/gst-nvcompositor": {
     "date": "2025-07-01T06:51:38-07:00",
@@ -297,7 +297,7 @@
     "path": "/nix/store/f92fzasin2vf0zrphq87p8g7gzq9ngvl-gst-nvcompositor",
     "rev": "fce947f948d8edfab7b112c07135fe66281a0f77",
     "sha256": "1l95aga2rqqkzamkqivw0bgd8y1mbaykgnm6b7csq1mbb8bw9mj4",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvcompositor.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvcompositor.git"
   },
   "tegra/gst-src/gst-nvtee": {
     "date": "2025-07-01T06:51:12-07:00",
@@ -309,7 +309,7 @@
     "path": "/nix/store/s594li28ac6s5y5mddqisn08ak3ir0q1-gst-nvtee",
     "rev": "1a80822e9573f2b6190a153709481814d95b92ed",
     "sha256": "0czsfwh6hl1vwb0bc9pr0sg5fyy262rzl9af95mh0162xr61j4qh",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvtee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvtee.git"
   },
   "tegra/gst-src/gst-nvv4l2camera": {
     "date": "2025-07-01T06:51:31-07:00",
@@ -321,7 +321,7 @@
     "path": "/nix/store/3ibj06mjniafds9yiv9sqda19wj0gs6q-gst-nvv4l2camera",
     "rev": "4757f10ace8d1711fee4ff18cade6d473d250268",
     "sha256": "0g33g580qi8blhqg4mla2fyz9jhc1q6062x9kls5cr4j13qdr35r",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvv4l2camera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvv4l2camera.git"
   },
   "tegra/gst-src/gst-nvvidconv": {
     "date": "2025-07-01T06:51:40-07:00",
@@ -333,7 +333,7 @@
     "path": "/nix/store/jx4w9rpfss3vfrzn71a1xqh58vi56i8v-gst-nvvidconv",
     "rev": "61c21f10836a2604c6c609060233dcdb1f496362",
     "sha256": "0fwd8bl6nzx481xlkkia5pp511pdkk5vinvsdivwrman0x1psk4f",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvidconv.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvidconv.git"
   },
   "tegra/gst-src/gst-nvvideo4linux2": {
     "date": "2025-07-01T06:51:14-07:00",
@@ -345,7 +345,7 @@
     "path": "/nix/store/y4sbxb654x1as52lq7isqy74cx0kaazg-gst-nvvideo4linux2",
     "rev": "b119b2b41b6973efe2119faf2f2085858409619f",
     "sha256": "1ara86wdpl53pgqkgbhqnla1bfl6c0qlzincw19ks7m56w59fvz9",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvideo4linux2.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvideo4linux2.git"
   },
   "tegra/gst-src/libgstnvcustomhelper": {
     "date": "2025-07-01T06:51:15-07:00",
@@ -357,7 +357,7 @@
     "path": "/nix/store/ghg7r91slwwznhclygj82iihc55sxz3r-libgstnvcustomhelper",
     "rev": "798df2cd1d7b14979d97c9db4a9ff76c9af4c173",
     "sha256": "00fgdqc2nd21px9pkb9d8vcrqdlzn7akz51pag01j8zz600wm3d3",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvcustomhelper.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvcustomhelper.git"
   },
   "tegra/gst-src/libgstnvdrmvideosink": {
     "date": "2025-07-01T06:51:15-07:00",
@@ -369,7 +369,7 @@
     "path": "/nix/store/mzjhhqilmasagqysidwg502dljbqwg2g-libgstnvdrmvideosink",
     "rev": "9c3eba7e2c4de7ce200eb3f5e30e369acebee036",
     "sha256": "1s3b54daxs8hn8kbrldma50q1afg082zifl376l633mm7v1dnckp",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvdrmvideosink.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvdrmvideosink.git"
   },
   "tegra/gst-src/libgstnvvideosinks": {
     "date": "2025-07-01T06:51:44-07:00",
@@ -381,7 +381,7 @@
     "path": "/nix/store/lhbyrkgb21pdlsa6jn53yvazdqfv3m3q-libgstnvvideosinks",
     "rev": "e9563c482b9083c2718cf59cc1967e16ac4b59d3",
     "sha256": "1y0lfsi9l9h2d1ki6qjivl8d8qss1hgwgz3k8g6kgb6k9fkx9674",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvvideosinks.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvvideosinks.git"
   },
   "tegra/gst-src/nvgstapps": {
     "date": "2025-07-01T06:51:44-07:00",
@@ -393,7 +393,7 @@
     "path": "/nix/store/4ckn0jqan2ld1jg0ky2wxhc54jvxkcaj-nvgstapps",
     "rev": "0e2a7f1eadd98f4a38a26e0ab4f746ea87431b32",
     "sha256": "00abrjw90zjcssqi8wgg03rwxbpcp7r74i3hqvigcc8lcllf2s78",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/nvgstapps.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/nvgstapps.git"
   },
   "tegra/kernel-src/nv-kernel-display-driver": {
     "date": "2025-07-01T06:51:43-07:00",
@@ -405,7 +405,7 @@
     "path": "/nix/store/g11a6lsdlxhh2gqai9dy84nb636d1cpi-nv-kernel-display-driver",
     "rev": "0508373a21f6c7ce01633466639c5fa0e91a314a",
     "sha256": "14kbpy2lh5plxi56j5m5xd8akdp0566js06jdmn645qpja9v58k0",
-    "url": "https://nv-tegra.nvidia.com/tegra/kernel-src/nv-kernel-display-driver.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-kernel-display-driver.git"
   },
   "tegra/nv-sci-src/nvsci_headers": {
     "date": "2025-07-01T06:51:39-07:00",
@@ -417,7 +417,7 @@
     "path": "/nix/store/wkq5qii3m3nrf90nv050g0ypx3sz8rmd-nvsci_headers",
     "rev": "7086bf184b763bb2819714611860551aa5c5f2c0",
     "sha256": "0n2yfm0xncf1kf0i65f8k03cmzx91ymmh6z1vp4zh7q2f8zfjhb3",
-    "url": "https://nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_headers.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/nv-sci-src/nvsci_headers.git"
   },
   "tegra/optee-src/atf": {
     "date": "2025-07-01T06:51:37-07:00",
@@ -429,7 +429,7 @@
     "path": "/nix/store/7jmhvpwz8zy9a5lacx56aiz3pqnmrqwd-atf",
     "rev": "9d6c289e24ce6eb3e199bd1e2b9521ae60715d4f",
     "sha256": "0ch7966i57zrgwdzn6n6l9s7pdc83l1m1zvd31gx18p7gd9gmn7q",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/atf.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/atf.git"
   },
   "tegra/optee-src/nv-optee": {
     "date": "2025-07-01T06:51:27-07:00",
@@ -441,7 +441,7 @@
     "path": "/nix/store/y9an1hymzamyscszyqqs7y4vw9k62lw4-nv-optee",
     "rev": "b67bc49a359a5c5c6413aeb06a49e0f30087e09c",
     "sha256": "0x5jzjfy81lqn86d2aj6vnnhd3wr37cxkm04bn07lj4dyg7dh531",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/nv-optee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/nv-optee.git"
   },
   "tegra/v4l2-src/libv4l2_nvargus": {
     "date": "2025-07-01T06:51:28-07:00",
@@ -453,7 +453,7 @@
     "path": "/nix/store/8pbbn0ka40my49kja8j08b16z7ksxrvb-libv4l2_nvargus",
     "rev": "c8d706dbf8b4dfa39fc9bc02b827ee6bcb399dda",
     "sha256": "15r4yq876wdcamihcvnvj5qf1i5ng9zl5j1n9yqq0khvwwylv1kf",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/libv4l2_nvargus.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/libv4l2_nvargus.git"
   },
   "tegra/v4l2-src/v4l2_libs": {
     "date": "2025-07-01T06:51:29-07:00",
@@ -465,6 +465,6 @@
     "path": "/nix/store/6kkqa3l9xsi64ijml2wd7nlidh0wm1pb-v4l2_libs",
     "rev": "b16006fd7a4a5058b844dfbe349674c522fa5fd8",
     "sha256": "1j8rg9jqrwi0qdbvxihislbs4xdrgpcmizx10rxiypys1bjdsspa",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/v4l2_libs.git"
   }
 }

--- a/sourceinfo/r36.4.4-gitrepos.json
+++ b/sourceinfo/r36.4.4-gitrepos.json
@@ -10,7 +10,7 @@
     "path": "/nix/store/85cxx2q86p7l3vw7kxv4hrm68rxf8awb-1.4.5",
     "rev": "8ca3c104dd178c98bcd02a8eb0c9404de0a99358",
     "sha256": "0k11fm8ypsyggcii4qz4fb05wd6nbndkn4lwbj467mrxjb620k46",
-    "url": "https://nv-tegra.nvidia.com/3rdparty/dtc-src/1.4.5.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/3rdparty/dtc-src/1.4.5.git"
   },
   "hardware/nvidia/t23x/nv-public": {
     "date": "2024-12-25T10:18:53-08:00",
@@ -23,7 +23,7 @@
     "path": "/nix/store/cr3qyqf2mw91m9z3kipwh18cydfwdf25-t23x-public-dts",
     "rev": "85ce314b25a2f112ee4411dca63ecb72cbe508ff",
     "sha256": "0wryp44iqrz0kx6p8sywdqv3c0iy4zbhsg0qnpwyv1gwy7420pk0",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/t23x-public-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-public-dts.git"
   },
   "hardware/nvidia/tegra/nv-public": {
     "date": "2023-06-28T02:06:21-07:00",
@@ -36,7 +36,7 @@
     "path": "/nix/store/18pwc2x6sl43b6a1i895x58v3ag3dx2k-tegra-public-dts",
     "rev": "8ba5d53ef1e1753f9f2a5b1f7b7b5fc5039de68e",
     "sha256": "1nw979gr3pbzqky1qbn4dafjzfa8jhq57aqlfjfpv50fim8ppjil",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/tegra-public-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/tegra-public-dts.git"
   },
   "hwpm": {
     "date": "2024-08-01T10:24:36-07:00",
@@ -49,7 +49,7 @@
     "path": "/nix/store/19n1mf5knlz7wrh8xf0g5an9kiqn5i95-linux-hwpm",
     "rev": "d47dc62f4011ffbb0353ba43df5cfb42b967bef2",
     "sha256": "0w4k5cw5vkvq1gaqkh6xi2z1f1axvha4s5v38n775wbyw4arblx2",
-    "url": "https://nv-tegra.nvidia.com/linux-hwpm.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-hwpm.git"
   },
   "kernel-devicetree": {
     "date": "2024-05-29T18:53:06Z",
@@ -62,7 +62,7 @@
     "path": "/nix/store/hcnjzmavdp7wx4bslpr40rrjcm99q4vz-kernel-devicetree",
     "rev": "19952c8e25702e9de23500c3b1fb351bf4380446",
     "sha256": "1xhlp2h6r8k3bk97gh955sjwpmbk4xa0r1xgc2kkbm70p8xv2ncq",
-    "url": "https://nv-tegra.nvidia.com/linux/kernel-devicetree.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux/kernel-devicetree.git"
   },
   "kernel/kernel-jammy-src": {
     "date": "2025-04-29T21:07:59-07:00",
@@ -75,7 +75,7 @@
     "path": "/nix/store/chpmakyxql65ncva9k6a5p3a4jqzzrhr-linux-jammy",
     "rev": "1a9075adac170fa159a97ded84cd2a482de31e8f",
     "sha256": "0bl93xl3dkjhlr63kk24fdc9n2bgsnkvxcgc6sjz3shcgz4325ir",
-    "url": "https://nv-tegra.nvidia.com/3rdparty/canonical/linux-jammy.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/3rdparty/canonical/linux-jammy.git"
   },
   "nvdisplay": {
     "date": "2025-06-30T15:46:53-07:00",
@@ -88,7 +88,7 @@
     "path": "/nix/store/8zbm9xrbm1an8abp2hzp4m9q82nd035f-nv-kernel-display-driver",
     "rev": "2c448bfbebf4314293fd432d2a0b33f66e5a4815",
     "sha256": "0adq1wvnv36z2dpl39ixban7wjbzy623s9v0crdyaj3s1f4fi642",
-    "url": "https://nv-tegra.nvidia.com/tegra/kernel-src/nv-kernel-display-driver.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-kernel-display-driver.git"
   },
   "nvethernetrm": {
     "date": "2023-06-06T02:05:11-07:00",
@@ -101,7 +101,7 @@
     "path": "/nix/store/ryzmhzxifq2rxhjin3d4a7a0c561qzxh-nvethernetrm",
     "rev": "1150fc9b2976463a6d839c3515d012b5a27a367b",
     "sha256": "11fm3rhw20gwcb9ymq7llh8gy5gfzacq279xg6s82kdvqf0mlcki",
-    "url": "https://nv-tegra.nvidia.com/kernel/nvethernetrm.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/kernel/nvethernetrm.git"
   },
   "nvgpu": {
     "date": "2024-12-17T15:54:04-08:00",
@@ -114,7 +114,7 @@
     "path": "/nix/store/gvnsifv7wy7nl27fgwvi3v7fhrxgq4r8-linux-nvgpu",
     "rev": "8a0a5345705e069e398a79dbcba96c5db54a37f1",
     "sha256": "15hnivy0fzv3qd9v472jd5qb024s1d5zl540dw1p3gf8sd2xi3x8",
-    "url": "https://nv-tegra.nvidia.com/linux-nvgpu.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nvgpu.git"
   },
   "nvidia-oot": {
     "date": "2025-03-20T09:43:41-07:00",
@@ -127,7 +127,7 @@
     "path": "/nix/store/b4zxb9mrk2m7wfrasxv0ql9kxi0vzb2k-linux-nv-oot",
     "rev": "efa698bed82f27e403537b7ecf82743e696d17ef",
     "sha256": "1x5czgiclfkgi999rld7dg57qffw1qjhawvyj1hjkmqrdr2r4nb3",
-    "url": "https://nv-tegra.nvidia.com/linux-nv-oot.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nv-oot.git"
   },
   "tegra/argus-cam-libav/argus_cam_libavencoder": {
     "date": "2025-06-30T15:46:31-07:00",
@@ -140,7 +140,7 @@
     "path": "/nix/store/l6rgrscn9jrwwlb14s33khazgcm7hl5i-argus_cam_libavencoder",
     "rev": "4953aa235fe517912a0cb1172273e1265ca80249",
     "sha256": "1p490z0lg9c9l7srqdj4hjzx7bzz8vw8ywp5w1jjagsmbgz7fqx5",
-    "url": "https://nv-tegra.nvidia.com/tegra/argus-cam-libav/argus_cam_libavencoder.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/argus-cam-libav/argus_cam_libavencoder.git"
   },
   "tegra/cuda-src/nvsample_cudaprocess": {
     "date": "2025-06-30T15:46:50-07:00",
@@ -153,7 +153,7 @@
     "path": "/nix/store/93kpx4a9r0kpjfq9kxvgzdv59kparfig-nvsample_cudaprocess",
     "rev": "2bd4ec482b4f07c4913ac395b0d1a7802a20e206",
     "sha256": "0mhg88ksqlpaf3c2z7rsfrr7yaqgjcca4ir8y7i7x5qfvrxsxrgn",
-    "url": "https://nv-tegra.nvidia.com/tegra/cuda-src/nvsample_cudaprocess.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/cuda-src/nvsample_cudaprocess.git"
   },
   "tegra/gfx-src/nv-xconfig": {
     "date": "2025-06-30T15:46:32-07:00",
@@ -166,7 +166,7 @@
     "path": "/nix/store/qm1ljz1c1c4nvqqdyxj892i70zjlczb0-nv-xconfig",
     "rev": "c1a63744a2308345cc7b5591cb9bf93653d414d4",
     "sha256": "0af6h9bcaakihl0nzjmmkz6a2lxvpzsd6kp1cgj79hay96yd5bxl",
-    "url": "https://nv-tegra.nvidia.com/tegra/gfx-src/nv-xconfig.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gfx-src/nv-xconfig.git"
   },
   "tegra/gst-src/gst-egl": {
     "date": "2025-06-30T15:46:34-07:00",
@@ -179,7 +179,7 @@
     "path": "/nix/store/f30xf3467kfa3z787zc7p3rqflc17hvq-gst-egl",
     "rev": "007ef9feb8746cb52cbc858c12a5e75b4dd78316",
     "sha256": "1940gnnw7hscly2346a731bwk3j0bq5w4brb5yarwnmh36aywlmz",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-egl.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-egl.git"
   },
   "tegra/gst-src/gst-jpeg": {
     "date": "2025-06-30T15:46:33-07:00",
@@ -192,7 +192,7 @@
     "path": "/nix/store/m7pd64wdrali41pd9mch53q33sk0z887-gst-jpeg",
     "rev": "ced2f1bd2c590604825c45279a049837a071f64f",
     "sha256": "07kd4l2kg7805xpi76603i7znixmvkyslfzvaz2h3pwpqkpakcrm",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-jpeg.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-jpeg.git"
   },
   "tegra/gst-src/gst-nvarguscamera": {
     "date": "2025-06-30T15:46:47-07:00",
@@ -205,7 +205,7 @@
     "path": "/nix/store/26kl804sjz1i47j5g9f96m26m0yccvah-gst-nvarguscamera",
     "rev": "5f4debc5ce5f439a1650c6d64933d48bf8ab7b38",
     "sha256": "0gcb2lgja5lna1q36rvmvh45h6psdxxjdxi4vbs8six40dp2350j",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvarguscamera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvarguscamera.git"
   },
   "tegra/gst-src/gst-nvcompositor": {
     "date": "2025-06-30T15:47:02-07:00",
@@ -218,7 +218,7 @@
     "path": "/nix/store/vg29ssb35782v5ds25cn52d2v2iqfsd9-gst-nvcompositor",
     "rev": "8cf96a5aa2ad943cccfed280055e35d22cf36627",
     "sha256": "09jv8dpnjlarxvw9aymb52kqf31nr7rvns3afq3s459x0z8q44md",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvcompositor.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvcompositor.git"
   },
   "tegra/gst-src/gst-nvtee": {
     "date": "2025-06-30T15:46:28-07:00",
@@ -231,7 +231,7 @@
     "path": "/nix/store/g9lvgsn2387iqcnlzmjcgdnk4wk221yg-gst-nvtee",
     "rev": "25b52bfa61aae6257579aa20ea12f130f629d9a4",
     "sha256": "19dkn0sacq1zq58nkknpz1n6z2pqwk4fly0nc6qn7rsv2d55pl7m",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvtee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvtee.git"
   },
   "tegra/gst-src/gst-nvv4l2camera": {
     "date": "2025-06-30T15:46:54-07:00",
@@ -244,7 +244,7 @@
     "path": "/nix/store/cg7zxaqn75kv64vk222fl96nb3ah41jx-gst-nvv4l2camera",
     "rev": "6482819d08adc271f5ef15f88565586742908272",
     "sha256": "0xdm4wf95w810q0b9q52hrpg0h4gg91vascmc4ks782d98sar10b",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvv4l2camera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvv4l2camera.git"
   },
   "tegra/gst-src/gst-nvvidconv": {
     "date": "2025-06-30T15:47:04-07:00",
@@ -257,7 +257,7 @@
     "path": "/nix/store/3bab575rskmb29gycdy3di4pazbnp9qm-gst-nvvidconv",
     "rev": "3cb4207ab2af9892e98cb1479b9468502f316000",
     "sha256": "1d92h7c06nbzn34na4xya6pfsibhlrxx71xnrask7vr0wp4csbqa",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvidconv.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvidconv.git"
   },
   "tegra/gst-src/gst-nvvideo4linux2": {
     "date": "2025-06-30T15:46:29-07:00",
@@ -270,7 +270,7 @@
     "path": "/nix/store/0vzp94zjbxd3977jsgcs784515jxdpac-gst-nvvideo4linux2",
     "rev": "36656046cb49c1430b0149df98bc241f27f8f388",
     "sha256": "10qnrr4kpbps7cbypzhn9ckkckraqd2g8chvsr7v22n062h7p9qf",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvideo4linux2.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvideo4linux2.git"
   },
   "tegra/gst-src/libgstnvcustomhelper": {
     "date": "2025-06-30T15:46:30-07:00",
@@ -283,7 +283,7 @@
     "path": "/nix/store/abdaszrrxl7prcljzq0gs22fpld9s4ck-libgstnvcustomhelper",
     "rev": "5d6575c144009aed33f9af5264ec0e0c5aa7e9d3",
     "sha256": "19g24f47mi8z41ym5l653p97x30p4klfh852fsxd6mr2hb3lkkxc",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvcustomhelper.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvcustomhelper.git"
   },
   "tegra/gst-src/libgstnvdrmvideosink": {
     "date": "2025-06-30T15:46:30-07:00",
@@ -296,7 +296,7 @@
     "path": "/nix/store/v7aysidjfzsjgbryz1n3fbfpx5mwqkss-libgstnvdrmvideosink",
     "rev": "7a196e55502ecbece5038582e498fb8335b92c44",
     "sha256": "138gcr8hssj6is2si8mhnprcmiqy40p3f4cjmanb7np3kgi5bj2r",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvdrmvideosink.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvdrmvideosink.git"
   },
   "tegra/gst-src/libgstnvvideosinks": {
     "date": "2025-06-30T15:47:05-07:00",
@@ -309,7 +309,7 @@
     "path": "/nix/store/pb8qcxnmc84xiy59jq1j6gyjj1s133ia-libgstnvvideosinks",
     "rev": "60683d560efcb163d7c9c79a4f20d88b25f6e803",
     "sha256": "02930z3f92fwx5skx0cwq97hlsiwq0k33kprc85rhmbdpaw6blzv",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvvideosinks.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvvideosinks.git"
   },
   "tegra/gst-src/nvgstapps": {
     "date": "2025-06-30T15:47:05-07:00",
@@ -322,7 +322,7 @@
     "path": "/nix/store/9m2gdb8vvq7sdscn6ffdlim8dj0yidbw-nvgstapps",
     "rev": "e6a6fcf23b41c2aacbc1f3c9f59c555be42506dc",
     "sha256": "1srf4d7fww68fhs034d5mzp0q87q9129sajgprrbimj3ggj342p1",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/nvgstapps.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/nvgstapps.git"
   },
   "tegra/gst-src/opencv_gst_samples": {
     "date": "2025-06-30T15:46:48-07:00",
@@ -335,7 +335,7 @@
     "path": "/nix/store/n53vyd7wga1qlj0qwrqxfawwk2w0nvai-opencv_gst_samples",
     "rev": "5ec2d13862fd2ff06dd05f8de82b7453185216a1",
     "sha256": "067yq2g3vz2v36i9aihx60whskbzyxsi3msp3mkjipjypx34g5vq",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/opencv_gst_samples.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/opencv_gst_samples.git"
   },
   "tegra/nv-sci-src/nvsci_headers": {
     "date": "2025-06-30T15:47:03-07:00",
@@ -348,7 +348,7 @@
     "path": "/nix/store/9n9klb5vi316398avzfmyjvxl04q8d3h-nvsci_headers",
     "rev": "8b26a735c2d0209f966163b471e3c6884b2497d5",
     "sha256": "1b2w1dgmymrkkmpkyg3lscc5rsihbs8h8z4bkfr0nhpxq5mvwzl5",
-    "url": "https://nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_headers.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/nv-sci-src/nvsci_headers.git"
   },
   "tegra/nv-sci-src/nvsci_samples": {
     "date": "2025-06-30T15:47:06-07:00",
@@ -361,7 +361,7 @@
     "path": "/nix/store/s747w6hsjk9jqc7zbn5a4apwa95gaijx-nvsci_samples",
     "rev": "04b61f06d11b30c5c76dcf9004bfbb5990f8223a",
     "sha256": "1sii92f9rcmp9nx105f1mrs6429ab60m1n3y626m73f563ppn1az",
-    "url": "https://nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_samples.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/nv-sci-src/nvsci_samples.git"
   },
   "tegra/openwfd-src/openwfd_headers": {
     "date": "2025-06-30T15:46:42-07:00",
@@ -374,7 +374,7 @@
     "path": "/nix/store/9wppdwwh0xai11rxcap79jc9i3d27gn7-openwfd_headers",
     "rev": "608179895ff5e84c183bee547e5a3097d39ca8ad",
     "sha256": "0i0i7p6rhq88hv8bfb5zpxmhkp2mhgd49hy5dzg0bz65xvzwjqc7",
-    "url": "https://nv-tegra.nvidia.com/tegra/openwfd-src/openwfd_headers.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/openwfd-src/openwfd_headers.git"
   },
   "tegra/optee-src/atf": {
     "date": "2025-06-30T15:47:01-07:00",
@@ -387,7 +387,7 @@
     "path": "/nix/store/5540kqac0xi09a8p6w0bhx08nfxhkgjs-atf",
     "rev": "8a001c6fb7debe467d6ffb544b8fe8e4af1ad9d7",
     "sha256": "1bghk69m8b1j3z8gzi5vcpkyfrhx6z87cxc4d211av4iigp720zb",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/atf.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/atf.git"
   },
   "tegra/optee-src/nv-optee": {
     "date": "2025-06-30T15:46:41-07:00",
@@ -400,7 +400,7 @@
     "path": "/nix/store/q6380wri6zvz88r6scjbhafmx7q8d71q-nv-optee",
     "rev": "7e454f370a7b4893fe55a9acc029065ba8417bfc",
     "sha256": "181avcsh6ly4v0zjlgi0amz0dz2hkcrikssimpl2fxd7vbfsjhn1",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/nv-optee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/nv-optee.git"
   },
   "tegra/spe-src/spe-freertos-bsp": {
     "date": "2025-06-30T15:46:45-07:00",
@@ -413,7 +413,7 @@
     "path": "/nix/store/j14x7j18s4gyfc0b0qh5sm8yk4b2gjy2-spe-freertos-bsp",
     "rev": "284a3454cca70561069c10855a967038447007ad",
     "sha256": "0ldmlram66czq0d7g5p6fs5jhv7nqj9wpfjjb7r3lr7nrqfapmrs",
-    "url": "https://nv-tegra.nvidia.com/tegra/spe-src/spe-freertos-bsp.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/spe-src/spe-freertos-bsp.git"
   },
   "tegra/v4l2-src/libv4l2_nvargus": {
     "date": "2025-06-30T15:46:42-07:00",
@@ -426,7 +426,7 @@
     "path": "/nix/store/xfkz0cywr81majxilsgxsw469rxnxjl7-libv4l2_nvargus",
     "rev": "6e80819a6d2f080cb090b7312e879111b57c9037",
     "sha256": "0kl2lhqs2zdbql061m8rzczfdx6k2kvdkd5kkhnj8p2hn5xqasga",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/libv4l2_nvargus.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/libv4l2_nvargus.git"
   },
   "tegra/v4l2-src/v4l2_libs": {
     "date": "2025-06-30T15:46:46-07:00",
@@ -439,6 +439,6 @@
     "path": "/nix/store/gxll1vcij3jldd5f175p8fkddbdqhy36-v4l2_libs",
     "rev": "958a5b80a77b227458c2a3be7bd4378927fac1e1",
     "sha256": "1r0hbn038pn754df4ibdaq62lgmi8qfczmk9qavg8ipjjrdy25sk",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/v4l2_libs.git"
   }
 }

--- a/sourceinfo/r38.2.1-gitrepos.json
+++ b/sourceinfo/r38.2.1-gitrepos.json
@@ -11,7 +11,7 @@
     "rev": "b71c05658d76e99a5441a21f5380cc3d87fff67b",
     "rootDir": "",
     "sha256": "1xnjb4g4fd5sgvhwrhfb59ill16hvv23xfdx90j3q1prsjnwcnz5",
-    "url": "https://nv-tegra.nvidia.com/3rdparty/dtc-src/1.4.5.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/3rdparty/dtc-src/1.4.5.git"
   },
   "hardware/nvidia/t23x/nv-public": {
     "date": "2025-05-23T11:56:42-07:00",
@@ -25,7 +25,7 @@
     "rev": "f1c9521e5d3ad13bb3a573de09bcc71eec352e95",
     "rootDir": "",
     "sha256": "1d46q4a7dvvfp0mh34clz6k8lz55sg4rnx25rj9la0cjhlgz0qkr",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/t23x-public-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-public-dts.git"
   },
   "hardware/nvidia/t264/nv-public": {
     "date": "2025-08-08T03:57:53-07:00",
@@ -39,7 +39,7 @@
     "rev": "33278109a5314ed27d0e69dbc6eccffecccd54fb",
     "rootDir": "",
     "sha256": "14ff8s03mc5knw2xw4jh87zf7i37h190cx0y0fpv5i1iznwslkq1",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/t264-public-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t264-public-dts.git"
   },
   "hardware/nvidia/tegra/nv-public": {
     "date": "2024-07-16T02:20:15-07:00",
@@ -53,7 +53,7 @@
     "rev": "2101ccc1b1ef8267e63286332aed34891943c7c7",
     "rootDir": "",
     "sha256": "1pdf49p736vag6nr90q67nxj90q60ka5fnphrr9iirs28y449imk",
-    "url": "https://nv-tegra.nvidia.com/device/hardware/nvidia/tegra-public-dts.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/tegra-public-dts.git"
   },
   "hwpm": {
     "date": "2025-05-26T12:42:11-07:00",
@@ -67,7 +67,7 @@
     "rev": "927a33af1caac3deb42b7406dcd31eee5296b761",
     "rootDir": "",
     "sha256": "0wvg39j2pa7wwraz3qa5w98w4qfnkjbj4ad44y2dpxc5r0gnr4g1",
-    "url": "https://nv-tegra.nvidia.com/linux-hwpm.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-hwpm.git"
   },
   "kernel-devicetree": {
     "date": "2025-05-06T17:55:11-07:00",
@@ -81,7 +81,7 @@
     "rev": "da22d336b5aa156616babe039dc2132e433304a5",
     "rootDir": "",
     "sha256": "1k8jigzj3prk05940pgr263nv3jfi9p6lm4s8cf4r7n6im7rdac6",
-    "url": "https://nv-tegra.nvidia.com/linux/kernel-devicetree.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux/kernel-devicetree.git"
   },
   "kernel/kernel-noble": {
     "date": "2025-09-10T11:31:55-07:00",
@@ -95,7 +95,7 @@
     "rev": "2a4430812eecde8f7bf7a72b882db29dff8c66bf",
     "rootDir": "",
     "sha256": "02r8dcv62pp4rmpcvkip401zyhghvfms9fr2gp05m5732v62n96l",
-    "url": "https://nv-tegra.nvidia.com/3rdparty/canonical/linux-noble.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/3rdparty/canonical/linux-noble.git"
   },
   "nvdisplay": {
     "date": "2025-09-19T10:10:04-07:00",
@@ -109,7 +109,7 @@
     "rev": "d6333983830005298d4e6b53c1a51dc2e69fc1ba",
     "rootDir": "",
     "sha256": "0rf4zxw7gl0j22qvzpps6w9g9j1qrh96jh022wyylfpdalhal16y",
-    "url": "https://nv-tegra.nvidia.com/tegra/kernel-src/nv-kernel-display-driver.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-kernel-display-driver.git"
   },
   "nvethernetrm": {
     "date": "2025-07-14T16:57:35-07:00",
@@ -123,7 +123,7 @@
     "rev": "b704cd863afe8c0aa9c53f1d60c9be1931ca3672",
     "rootDir": "",
     "sha256": "1q7q0ps5mxyzk153hpzb2b3rf67a09gwswcgfzw2sjqzh6j8hvhh",
-    "url": "https://nv-tegra.nvidia.com/kernel/nvethernetrm.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/kernel/nvethernetrm.git"
   },
   "nvgpu": {
     "date": "2025-09-19T10:09:55-07:00",
@@ -137,7 +137,7 @@
     "rev": "3705257bb29b3ca0efde0391ef04fa03ea8f6afd",
     "rootDir": "",
     "sha256": "0b1wf1cxx4lbb1illc9dyprjp7957zisscr66qs7vr2cp4y5ss3v",
-    "url": "https://nv-tegra.nvidia.com/tegra/kernel-src/linux-nvgpu.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/linux-nvgpu.git"
   },
   "nvidia-oot": {
     "date": "2025-09-05T08:26:18-07:00",
@@ -151,7 +151,7 @@
     "rev": "de95a4c5bbe08cb5a75ae77f769d3ba5a1087198",
     "rootDir": "",
     "sha256": "1byfizs1bkl50mjbba41ngvyphmw0a2c9vqd334vim4ngqy18aw3",
-    "url": "https://nv-tegra.nvidia.com/linux-nv-oot.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nv-oot.git"
   },
   "tegra/ada-src/adaruntime": {
     "date": "2025-09-19T10:09:38-07:00",
@@ -165,7 +165,7 @@
     "rev": "6ee604e5ae8b45700257a6b155d3e0552af2a26c",
     "rootDir": "",
     "sha256": "04i8dixlnb62xy96m576v8mwd4jqyngysrcs76ss5mmwlxnci340",
-    "url": "https://nv-tegra.nvidia.com/tegra/ada-src/adaruntime.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/ada-src/adaruntime.git"
   },
   "tegra/argus-cam-libav/argus_cam_libavencoder": {
     "date": "2025-09-19T10:09:40-07:00",
@@ -179,7 +179,7 @@
     "rev": "4f53b57161dd007fa2a7d4fb81dc38c97a846151",
     "rootDir": "",
     "sha256": "13z5rz3wmb0a4m6608jm46j1gz5ksn4y6cll7igzjalmkrvzax9b",
-    "url": "https://nv-tegra.nvidia.com/tegra/argus-cam-libav/argus_cam_libavencoder.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/argus-cam-libav/argus_cam_libavencoder.git"
   },
   "tegra/cuda-src/nvsample_cudaprocess": {
     "date": "2025-09-19T10:10:01-07:00",
@@ -193,7 +193,7 @@
     "rev": "7193df6903e99029959b2d867a76c2e99dfa1270",
     "rootDir": "",
     "sha256": "1n6zprmzvxxvzrmnay269fr8g549g88j2ivsg1fx59ml67zbp80d",
-    "url": "https://nv-tegra.nvidia.com/tegra/cuda-src/nvsample_cudaprocess.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/cuda-src/nvsample_cudaprocess.git"
   },
   "tegra/gfx-src/nv-xconfig": {
     "date": "2025-09-19T10:09:40-07:00",
@@ -207,7 +207,7 @@
     "rev": "86b65e68249c87412738e9e1a1e5a53b72b9c5e2",
     "rootDir": "",
     "sha256": "0drhaqdsalwk34rdpfndi0l0c87by59kw7p8j6458yshra039czy",
-    "url": "https://nv-tegra.nvidia.com/tegra/gfx-src/nv-xconfig.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gfx-src/nv-xconfig.git"
   },
   "tegra/gst-src/gst-egl": {
     "date": "2025-09-19T10:09:42-07:00",
@@ -221,7 +221,7 @@
     "rev": "3069e4b80c2ff05f32faa75b192aaee78e726ac8",
     "rootDir": "",
     "sha256": "15i58c6s5kfmiwcsrjza5hal06xbz61pq6iij7c2s4nw2gymjsny",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-egl.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-egl.git"
   },
   "tegra/gst-src/gst-jpeg": {
     "date": "2025-09-19T10:09:41-07:00",
@@ -235,7 +235,7 @@
     "rev": "d8fad2045b5088d125a78a85d9926f7b7e9737f2",
     "rootDir": "",
     "sha256": "02kif4nxp2gi248z4c89x7hv1bvp1p1n2py6yck9wqw88sizkmqw",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-jpeg.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-jpeg.git"
   },
   "tegra/gst-src/gst-nvarguscamera": {
     "date": "2025-09-19T10:09:58-07:00",
@@ -249,7 +249,7 @@
     "rev": "d8adec09c0d0187e68ae650d7bc9135d4913b562",
     "rootDir": "",
     "sha256": "1fmgx5kk4ngv82a24d8bgy68wibs28g4wxix14vi4d34fxzvhy1g",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvarguscamera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvarguscamera.git"
   },
   "tegra/gst-src/gst-nvcompositor": {
     "date": "2025-09-19T10:10:06-07:00",
@@ -263,7 +263,7 @@
     "rev": "9456ee592464fe737a5a401451d227a311c0667d",
     "rootDir": "",
     "sha256": "1kppa6jnb7gv1ga4c2w8dkib2aiy3y4kkx1sdqpidz54fd3myaan",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvcompositor.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvcompositor.git"
   },
   "tegra/gst-src/gst-nvipcpipeline": {
     "date": "2025-09-19T10:09:05-07:00",
@@ -277,7 +277,7 @@
     "rev": "4099d70dbe4db06b815f32bf24980980849dbb14",
     "rootDir": "",
     "sha256": "05idhzvvkva86f16kjac140pa6g5zwl4xjkls8llp1qmlky091ds",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvipcpipeline.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvipcpipeline.git"
   },
   "tegra/gst-src/gst-nvtee": {
     "date": "2025-09-19T10:09:06-07:00",
@@ -291,7 +291,7 @@
     "rev": "47de8825b4db6caaa18ad7257787451cfb16eda0",
     "rootDir": "",
     "sha256": "0y369bcydksvzxxr7i4nk7jzsrphy4l4l66qgfkc9nypkpljn290",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvtee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvtee.git"
   },
   "tegra/gst-src/gst-nvunixfd": {
     "date": "2025-09-19T10:10:47-07:00",
@@ -305,7 +305,7 @@
     "rev": "1b33fc2e5ceba4821b743d1e2744bb1ccc2197c0",
     "rootDir": "",
     "sha256": "0yq2x0jlszyifij4iga4vfd6cyq4951yfg4crpmqgmba9dzzxbx7",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvunixfd.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvunixfd.git"
   },
   "tegra/gst-src/gst-nvv4l2camera": {
     "date": "2025-09-19T10:10:06-07:00",
@@ -319,7 +319,7 @@
     "rev": "aa4859da4c571ec31ffa8a7fb5e47424e1a8835b",
     "rootDir": "",
     "sha256": "0kwnc8y5cvg9dqil5y002kpnginxw3z29b3jayjvb5qkwpzygrg1",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvv4l2camera.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvv4l2camera.git"
   },
   "tegra/gst-src/gst-nvvidconv": {
     "date": "2025-09-19T10:10:42-07:00",
@@ -333,7 +333,7 @@
     "rev": "434bd5f56c39901df17a8d0659be4b463cceeb9b",
     "rootDir": "",
     "sha256": "18c5038721jsznim3xkwk419zifjwm3qvw6xfk5znkcfgjyn8ian",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvidconv.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvidconv.git"
   },
   "tegra/gst-src/gst-nvvideo4linux2": {
     "date": "2025-09-19T10:09:24-07:00",
@@ -347,7 +347,7 @@
     "rev": "373bf1a53af1147116727215931ab1aa489c9071",
     "rootDir": "",
     "sha256": "1j70fb38ny67jf3ylf7lbdbp9gr9fqvnl0azxqrrwz3wpd5mmkds",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/gst-nvvideo4linux2.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/gst-nvvideo4linux2.git"
   },
   "tegra/gst-src/libgstnvcustomhelper": {
     "date": "2025-09-19T10:09:25-07:00",
@@ -361,7 +361,7 @@
     "rev": "5b4e14b24329388fd2e1026707ef61c3837a6b7b",
     "rootDir": "",
     "sha256": "0x5s4nlw3hbiydxfrd0pnjmfz0995wpng6sm299wwbc1a8qmhsh3",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvcustomhelper.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvcustomhelper.git"
   },
   "tegra/gst-src/libgstnvdrmvideosink": {
     "date": "2025-09-19T10:09:25-07:00",
@@ -375,7 +375,7 @@
     "rev": "4dae5492fbafbd47f4d7ad8300efa95230de6ce9",
     "rootDir": "",
     "sha256": "1lqv8vh929y08x77ciribgq4xv5h95x7v9c18l4lq24m5s840jz5",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvdrmvideosink.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvdrmvideosink.git"
   },
   "tegra/gst-src/libgstnvvideosinks": {
     "date": "2025-09-19T10:10:48-07:00",
@@ -389,7 +389,7 @@
     "rev": "524a5450ee9904ff91858932662208ad490d2f10",
     "rootDir": "",
     "sha256": "019adlgys8p459kqavah47hrqxjb9qfx5z8fzhn71gibd1gyy1w2",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/libgstnvvideosinks.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/libgstnvvideosinks.git"
   },
   "tegra/gst-src/nvgstapps": {
     "date": "2025-09-19T10:10:44-07:00",
@@ -403,7 +403,7 @@
     "rev": "bfee9b105e2e89382594748cbc6aa63c5fa05e7c",
     "rootDir": "",
     "sha256": "0n3bc2lz8kvjcc3l3173cfzpnrfjibpcw4nq4qjd44qsn9mdm1s8",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/nvgstapps.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/nvgstapps.git"
   },
   "tegra/gst-src/opencv_gst_samples": {
     "date": "2025-09-19T10:09:59-07:00",
@@ -417,7 +417,7 @@
     "rev": "1cc0c590dd60a8ca844209050a825b6c924ca050",
     "rootDir": "",
     "sha256": "03d4ylgdcxlb918hy2ks1qcxs4fk8r3mdmqw62j2782z03dldjw4",
-    "url": "https://nv-tegra.nvidia.com/tegra/gst-src/opencv_gst_samples.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/gst-src/opencv_gst_samples.git"
   },
   "tegra/hafnium-src/hafnium": {
     "date": "2025-09-19T10:10:46-07:00",
@@ -431,7 +431,7 @@
     "rev": "d5928923bc3cb64cebe3ec0ee4511f7e85caac42",
     "rootDir": "",
     "sha256": "0ilm37gbqikz67ig7g0max5qfxhvdnpq324s4q37lbjj07z5av70",
-    "url": "https://nv-tegra.nvidia.com/tegra/hafnium-src/hafnium.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/hafnium-src/hafnium.git"
   },
   "tegra/nv-sci-src/nvsci_headers": {
     "date": "2025-09-19T10:10:08-07:00",
@@ -445,7 +445,7 @@
     "rev": "c4b0ffbec7f1b44834719fdf8220a7574ef2c86d",
     "rootDir": "",
     "sha256": "0bjd3mac2dcyrnz89mnnxrqb5cxn4wmwfckqlmcgbxpvd181qrr1",
-    "url": "https://nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_headers.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/nv-sci-src/nvsci_headers.git"
   },
   "tegra/nv-sci-src/nvsci_samples": {
     "date": "2025-09-19T10:10:49-07:00",
@@ -459,7 +459,7 @@
     "rev": "a3f1b7ea3396b05883518ef262da7d5e77d803f9",
     "rootDir": "",
     "sha256": "133p2mxyn52bk41afq8byqssyxngxq8yhiqda3w0d4rvc7z3zq35",
-    "url": "https://nv-tegra.nvidia.com/tegra/nv-sci-src/nvsci_samples.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/nv-sci-src/nvsci_samples.git"
   },
   "tegra/openwfd-src/openwfd_headers": {
     "date": "2025-09-19T10:09:57-07:00",
@@ -473,7 +473,7 @@
     "rev": "a075470ae4cfc5a4708e863c9c5119be81192a68",
     "rootDir": "",
     "sha256": "0izrz5y7lkcz4jjsvpzc63w79jwypgvpak377kjgqfpqxd6hmfva",
-    "url": "https://nv-tegra.nvidia.com/tegra/openwfd-src/openwfd_headers.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/openwfd-src/openwfd_headers.git"
   },
   "tegra/optee-src/atf": {
     "date": "2025-09-19T10:09:22-07:00",
@@ -487,7 +487,7 @@
     "rev": "2b69e3103dc7913d9286259e086bbfc8f194bae1",
     "rootDir": "",
     "sha256": "0m6ssz2w0j6x6swy242czwzhq5i9872kr50w1wambx5naava5q1x",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/atf.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/atf.git"
   },
   "tegra/optee-src/atf_t264": {
     "date": "2025-09-19T10:09:12-07:00",
@@ -501,7 +501,7 @@
     "rev": "a5b0e0a94b01e222ddb9a18e95fbc5f46ad0ab29",
     "rootDir": "",
     "sha256": "1wpmg58x8kj1r62lwqgikkp3l7mxpa6dzisdpn00m8y248nd1vgb",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/atf_t264.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/atf_t264.git"
   },
   "tegra/optee-src/nv-optee": {
     "date": "2025-09-19T10:09:49-07:00",
@@ -515,7 +515,7 @@
     "rev": "064a5169e80afcc89258f82be2a07a7d54e737fc",
     "rootDir": "",
     "sha256": "0s107k6vsf9crdrhmyxw6kh3lg87svmvcnbw6y683lhg258q6j7x",
-    "url": "https://nv-tegra.nvidia.com/tegra/optee-src/nv-optee.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/optee-src/nv-optee.git"
   },
   "tegra/v4l2-src/libv4l2_nvargus": {
     "date": "2025-09-19T10:09:51-07:00",
@@ -529,7 +529,7 @@
     "rev": "d1e58f9cd6b84cb12fdb0229f1d3f42ebaf1c333",
     "rootDir": "",
     "sha256": "19pcd5chimbfm9lxq6ygvs0vvrxsgbqhl85312kyr51rsa0x0fl1",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/libv4l2_nvargus.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/libv4l2_nvargus.git"
   },
   "tegra/v4l2-src/v4l2_libs": {
     "date": "2025-09-19T10:09:57-07:00",
@@ -543,7 +543,7 @@
     "rev": "74b0ee4b0a453bf6a603d7699e4c15b83217a42f",
     "rootDir": "",
     "sha256": "00ppq1xji2xdkaiw94hcwmvvl0ghrhlffa9qcr8k17afvad6x8ns",
-    "url": "https://nv-tegra.nvidia.com/tegra/v4l2-src/v4l2_libs.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/v4l2-src/v4l2_libs.git"
   },
   "tegra/webrtc-app-src/argus-camera-app": {
     "date": "2025-09-19T10:10:34-07:00",
@@ -557,7 +557,7 @@
     "rev": "0db98ee507c29c1f5cfb4f4c05edecb06a575ca2",
     "rootDir": "",
     "sha256": "1dzldkl3wxvm9gh50lx97a28nwskpf09zcsz5lksfgi2x9xn69w3",
-    "url": "https://nv-tegra.nvidia.com/tegra/webrtc-app-src/argus-camera-app.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/webrtc-app-src/argus-camera-app.git"
   },
   "unifiedgpudisp": {
     "date": "2025-09-19T10:09:32-07:00",
@@ -571,6 +571,6 @@
     "rev": "943a608e59bc1133f01c8228ad5c03e2a3369dec",
     "rootDir": "",
     "sha256": "1pbilmmqkqdsc6w843472ndgzmca164h3xmi6pq1kimidrjpz87h",
-    "url": "https://nv-tegra.nvidia.com/tegra/kernel-src/nv-unified-gpu-display-driver.git"
+    "url": "https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-unified-gpu-display-driver.git"
   }
 }


### PR DESCRIPTION
###### Description of changes
Changing all mentions of https://nv-tegra.nvidia.com to https://gitlab.com/nvidia/nv-tegra/ because of issues with downtime/deprecation (https://forums.developer.nvidia.com/t/unable-to-connect-to-nv-tegra-nvidia-com-git-servers-16-01-2026/357713)

###### Testing
Building the image/install-script for my xaviar agx devkit works, im currently installing nixos on it, will update this pr when its done.

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
