### PR TITLE
xavier-nx-devkit: Ensure TBCDTB_FILE is set to match DTB_FILE

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -158,11 +158,13 @@ in
         (mkIf (cfg.som == "xavier-nx") {
           targetBoard = mkDefault "jetson-xavier-nx-devkit";
           partitionTemplate = mkDefault (filterPartitions defaultPartitionsToRemove "${pkgs.nvidia-jetpack.bspSrc}/bootloader/${partitionTemplateDirectory}/cfg/flash_l4t_t194_spi_sd_p3668.xml");
+          patches = [ ../pkgs/r35-bsp.patch ]; # See: https://github.com/anduril/jetpack-nixos/pull/436
         })
 
         (mkIf (cfg.som == "xavier-nx-emmc") {
           targetBoard = mkDefault "jetson-xavier-nx-devkit-emmc";
           partitionTemplate = mkDefault (filterPartitions defaultPartitionsToRemove "${pkgs.nvidia-jetpack.bspSrc}/bootloader/${partitionTemplateDirectory}/cfg/flash_l4t_t194_spi_emmc_p3668.xml");
+          patches = [ ../pkgs/r35-bsp.patch ]; # See: https://github.com/anduril/jetpack-nixos/pull/436
         })
       ];
   }

--- a/pkgs/r35-bsp.patch
+++ b/pkgs/r35-bsp.patch
@@ -1,0 +1,35 @@
+diff --git a/p3509-0000+p3668-0000-qspi-sd.conf b/p3509-0000+p3668-0000-qspi-sd.conf
+index e327f03..2c5a96a 100644
+--- a/p3509-0000+p3668-0000-qspi-sd.conf
++++ b/p3509-0000+p3668-0000-qspi-sd.conf
+@@ -38,6 +38,7 @@ source "${LDK_DIR}/p3668.conf.common";
+ BLBlockSize=1048576;
+ EMMC_CFG=flash_l4t_t194_spi_sd_p3668.xml;
+ DTB_FILE=tegra194-p3668-0000-p3509-0000.dtb;
++TBCDTB_FILE=tegra194-p3668-0000-p3509-0000.dtb
+ RECROOTFSSIZE=100MiB
+ MISC_COLD_BOOT_CONFIG="tegra194-mb1-bct-misc-sd-l4t.cfg";
+ 
+diff --git a/p3509-0000+p3668-0000-qspi.conf b/p3509-0000+p3668-0000-qspi.conf
+index 69ab6f9..1320546 100644
+--- a/p3509-0000+p3668-0000-qspi.conf
++++ b/p3509-0000+p3668-0000-qspi.conf
+@@ -36,5 +36,6 @@
+ source "${LDK_DIR}/p3668.conf.common";
+ EMMC_CFG=flash_l4t_t194_qspi_p3668.xml;
+ DTB_FILE=tegra194-p3668-0000-p3509-0000.dtb;
++TBCDTB_FILE=tegra194-p3668-0000-p3509-0000.dtb;
+ NO_ROOTFS=${NO_ROOTFS:-1};
+ MISC_COLD_BOOT_CONFIG="tegra194-mb1-bct-misc-sd-l4t.cfg";
+diff --git a/p3509-0000+p3668-0001-qspi-emmc.conf b/p3509-0000+p3668-0001-qspi-emmc.conf
+index 2555474..7c12f9a 100644
+--- a/p3509-0000+p3668-0001-qspi-emmc.conf
++++ b/p3509-0000+p3668-0001-qspi-emmc.conf
+@@ -36,6 +36,7 @@
+ source "${LDK_DIR}/p3668.conf.common";
+ EMMC_CFG=flash_l4t_t194_spi_emmc_p3668.xml;
+ DTB_FILE=tegra194-p3668-0001-p3509-0000.dtb;
++TBCDTB_FILE=tegra194-p3668-0001-p3509-0000.dtb;
+ EMMCSIZE=17179869184;
+ RECROOTFSSIZE=100MiB;
+ 


### PR DESCRIPTION
###### Description of changes

For the Xavier NX, the `initrd` flash script was failing to correctly write platform firmware because it assumed the target SD card would be at `/dev/mmcblk0`. However, the device tree was configured to probe an unused eMMC controller (`sdhci@3460000`) first, which resulted in the actual SD card being assigned to `/dev/mmcblk1`. This discrepancy caused the flash script to write to a non-existent device. The problem went unnoticed for some time because SD cards retained data from previous, functional flashing methods.

To resolve this, the `TBCDTB_FILE` is now set to match the `DTB_FILE`. As a result, the SD card controller (`sdhci@3440000`) is correctly identified, and the SD card is properly assigned to `/dev/mmcblk0`, which the `initrd` flash script expects.

I've updated xavier-nx-emmc as well, which removes the SD card controller as well.

###### Testing

- [x] Flash xavier-nx-devkit
