### PR TITLE
initrd-flash: Disable autosuspend for USB port

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -133,6 +133,10 @@ final: prev: (
 
               ln -s $gadget/functions/acm.usb0 $gadget/configs/c.1/
 
+              if [ -w /sys/bus/usb/devices/usb2/power/control ] ; then
+                echo on >/sys/bus/usb/devices/usb2/power/control
+              fi
+
               echo "$(ls /sys/class/udc | head -n 1)" >$gadget/UDC
 
               # force into device mode if OTG and something is up with automatic detection


### PR DESCRIPTION
###### Description of changes

Found that this improves reliability for the USB gadget to enumerate
properly.

###### Testing

- [x] initrd flash all the devices
