### PR TITLE
Fix flash initrd modules closure for cross builds

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -170,7 +170,7 @@ final: prev: (
         (prev.makeInitrd {
           contents = [
             { object = jetpack-init; symlink = "/init"; }
-            { object = "${modulesClosure}/lib"; symlink = "/lib"; }
+            { object = modulesClosure; symlink = "/lib"; suffix = "/lib"; }
           ];
         }).overrideAttrs (prev: {
           passthru = prev.passthru // {


### PR DESCRIPTION
###### Description of changes
 Summary:

  - Build flash initrd using the modules closure root and set suffix = "/lib" for the /lib symlink.
  - Prevents invalid store subpaths in initrd contents during cross builds.

  Why:

  - object = "${modulesClosure}/lib" embeds a subpath in the store path, which breaks closure export and causes path .../modules-shrunk/lib is not in the Nix store during x86_64 flash-script builds.



