### PR TITLE
initrdFlash: Wait for USB device controller to probe

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -133,9 +133,16 @@ final: prev: (
 
               ln -s $gadget/functions/acm.usb0 $gadget/configs/c.1/
 
+              # Disable autosuspend
               if [ -w /sys/bus/usb/devices/usb2/power/control ] ; then
                 echo on >/sys/bus/usb/devices/usb2/power/control
               fi
+
+              # Wait for udc to finish probing, if not done already
+              while [[ -z "$(ls /sys/class/udc | head -n 1)" ]] ; do
+                echo "Waiting for /sys/class/udc/*"
+                sleep 1
+              done
 
               echo "$(ls /sys/class/udc | head -n 1)" >$gadget/UDC
 


### PR DESCRIPTION
###### Description of changes

Our script to set up the USB gadget may run before the USB device controller finishes probing. Since we are in simple busybox shell, just spin until it exists.

###### Testing

- [x] initrdFlash orin-agx-devkit
