### PR TITLE
l4t-opencv: Patch pkgconfig to update $out path

### DIFF
--- a/pkgs/l4t/l4t-opencv.nix
+++ b/pkgs/l4t/l4t-opencv.nix
@@ -23,6 +23,10 @@ buildFromDebs {
     debs.common.nvidia-opencv-dev.src
   ];
 
+  postPatch = ''
+    substituteInPlace lib/pkgconfig/opencv4.pc --replace-fail "prefix=/usr/local" "prefix=${placeholder "out"}"
+  '';
+
   buildInputs = [
     glib
     gtk2


### PR DESCRIPTION
###### Description of changes

The pkgconfig for l4t-opencv uses prefix=/usr/local. Update it to the output path.

###### Testing

- [x] build l4t-opencv and observe correct pkgconfig file
