### PR TITLE
fix: cross-compile of dlopen

### DIFF
--- a/pkgs/dlopen-override/default.nix
+++ b/pkgs/dlopen-override/default.nix
@@ -49,7 +49,7 @@ let
     buildPhase = ''
       runHook preBuild
 
-      cc -shared -fPIC -o dlopen-override.so dlopenoverride.c -ldl
+      $CC -shared -fPIC -o dlopen-override.so dlopenoverride.c -ldl
 
       runHook postBuild
     '';


### PR DESCRIPTION
after the merge of buildFromDebs with normalizeDebs the scope changed and now the strictDeps misses the compiler here.

 > Running phase: unpackPhase
       > unpacking source archive /nix/store/3y5rmqix8dwp293kqfbf1axq3cp5vn4v-dlopen-override
       > source root is dlopen-override
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > /nix/store/bjrzd5xzzdzf8344979jiba4viz61rq8-stdenv-linux/setup: line 1767: cc: command not found
       For full logs, run:
         nix log
       > /nix/store/fx1wxs0x743zj6whb3h42v6ain2bncw6-dlopen-override-aarch64-unknown-linux-gnu-1.0.drv

###### Description of changes

fixing the native build dependencies

###### Testing
applied to a local fork
https://github.com/anduril/jetpack-nixos/commit/8597553b9623e17928b8d183ee626a200adee963

and tested in the project scope in this PR
https://github.com/tiiuae/ghaf/pull/1714