### PR TITLE
nixos: graphics: Add l4t-video-codec-openrm to hardware.graphics.extraPackages

### DIFF
--- a/modules/graphics.nix
+++ b/modules/graphics.nix
@@ -67,6 +67,7 @@ in
                 "l4t-nvml" # JP6+
                 "l4t-nvsci"
                 "l4t-pva"
+                "l4t-video-codec-openrm" # JP7+
                 "l4t-wayland"
               ]
                 (lib.const null))


### PR DESCRIPTION
###### Description of changes

Provides libs necessary for encoding and decoding video.

###### Testing

- [x] Run multimedia samples
