### PR TITLE
Optee xtest regression test passing

### DIFF
--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -111,7 +111,10 @@ in
   config = mkIf config.hardware.nvidia-jetpack.enable {
     hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
       lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
-      ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
+      ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.tas;
+
+    hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
+      lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
 
     systemd.services.tee-supplicant =
       let

--- a/pkgs/optee/0003-Add-pre-sign-hook.patch
+++ b/pkgs/optee/0003-Add-pre-sign-hook.patch
@@ -1,0 +1,55 @@
+--- a/optee/optee_os/ta/link.mk
++++ b/optee/optee_os/ta/link.mk
+@@ -22,6 +22,7 @@ all: $(link-out-dir$(sm))/$(user-ta-uuid).dmp \
+ cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).elf
+ cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).dmp
+ cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).map
++cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).stripped.unneeded.elf
+ cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf
+ cleanfiles += $(link-out-dir$(sm))/$(user-ta-uuid).ta
+ cleanfiles += $(link-script-pp$(sm)) $(link-script-dep$(sm))
+@@ -96,11 +97,16 @@ $(link-out-dir$(sm))/$(user-ta-uuid).dmp: \
+ 	@$(cmd-echo-silent) '  OBJDUMP $$@'
+ 	$(q)$(OBJDUMP$(sm)) -l -x -d $$< > $$@
+ 
+-$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf: \
++$(link-out-dir$(sm))/$(user-ta-uuid).stripped.unneeded.elf: \
+ 			$(link-out-dir$(sm))/$(user-ta-uuid).elf
+ 	@$(cmd-echo-silent) '  OBJCOPY $$@'
+ 	$(q)$(OBJCOPY$(sm)) --strip-unneeded $$< $$@
+ 
++$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf: \
++		$(link-out-dir$(sm))/$(user-ta-uuid).stripped.unneeded.elf
++	@$(cmd-echo-silent) '  PRESIGN $$@'
++	$(q)$(if $(NIX_TA_PRE_SIGN_HOOK),$(NIX_TA_PRE_SIGN_HOOK),cp) $$< $$@
++
+ cmd-echo$(user-ta-uuid) := SIGN   #
+ ifeq ($(CFG_ENCRYPT_TA),y)
+ crypt-args$(user-ta-uuid) := --enc-key $(TA_ENC_KEY)
+--- a/optee/optee_os/ta/link_shlib.mk
++++ b/optee/optee_os/ta/link_shlib.mk
+@@ -13,6 +13,7 @@ all: $(link-out-dir)/$(shlibname).so $(link-out-dir)/$(shlibname).dmp \
+ 
+ cleanfiles += $(link-out-dir)/$(shlibname).so
+ cleanfiles += $(link-out-dir)/$(shlibname).dmp
++cleanfiles += $(link-out-dir)/$(shlibname).stripped.unneeded.so
+ cleanfiles += $(link-out-dir)/$(shlibname).stripped.so
+ cleanfiles += $(link-out-dir)/$(shlibuuid).elf
+ cleanfiles += $(link-out-dir)/$(shlibuuid).ta
+@@ -39,10 +40,15 @@ $(link-out-dir)/$(shlibname).dmp: $(link-out-dir)/$(shlibname).so
+ 	@$(cmd-echo-silent) '  OBJDUMP $@'
+ 	$(q)$(OBJDUMP$(sm)) -l -x -d $< > $@
+ 
+-$(link-out-dir)/$(shlibname).stripped.so: $(link-out-dir)/$(shlibname).so
++$(link-out-dir)/$(shlibname).stripped.unneeded.so: $(link-out-dir)/$(shlibname).so
+ 	@$(cmd-echo-silent) '  OBJCOPY $@'
+ 	$(q)$(OBJCOPY$(sm)) --strip-unneeded $< $@
+ 
++$(link-out-dir)/$(shlibname).stripped.so: \
++		$(link-out-dir)/$(shlibname).stripped.unneeded.so
++	@$(cmd-echo-silent) '  PRESIGN $@'
++	$(q)$(if $(NIX_TA_PRE_SIGN_HOOK),$(NIX_TA_PRE_SIGN_HOOK),cp) $< $@
++
+ $(link-out-dir)/$(shlibuuid).elf: $(link-out-dir)/$(shlibname).so
+ 	@$(cmd-echo-silent) '  LN      $@'
+ 	$(q)ln -sf $(<F) $@

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -32,7 +32,10 @@ in
   taPublicKeyFile = null;
 
   src = gitRepos."tegra/optee-src/nv-optee";
-  patches = [ ./remove-force-log-level.diff ];
+  patches = [
+    ./remove-force-log-level.diff
+    ./0003-Add-pre-sign-hook.patch
+  ];
 
   nativeBuildInputs = [
     dtc

--- a/pkgs/optee/opteeXtest.nix
+++ b/pkgs/optee/opteeXtest.nix
@@ -9,6 +9,7 @@
 , opteeClient
 , taDevKit
 , l4tAtLeast
+, writeShellApplication
 }:
 stdenv.mkDerivation {
   pname = "optee_xtest";
@@ -27,7 +28,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     (buildPackages.python3.withPackages (p: [ p.cryptography ]))
-    nukeReferences
   ] ++ lib.optionals (l4tOlder "36") [ openssl ];
 
   buildInputs = [ ] ++ lib.optionals (l4tOlder "36") [ openssl ];
@@ -36,16 +36,41 @@ stdenv.mkDerivation {
     patchShebangs --build $(find optee/optee_test -type d -name scripts -printf '%p ')
   '';
 
-  makeFlags = [
-    "-C optee/optee_test"
-    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-    "OPTEE_CLIENT_EXPORT=${opteeClient}"
-    "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
-    "TA_DIR=$(tas)" # xtest needs to manually load corrupt TA for test 1008
-    "O=$(PWD)/out"
-  ] ++ lib.optionals (l4tAtLeast "36") [
-    "WITH_OPENSSL=n"
-  ];
+  makeFlags =
+    let
+      # We need to nuke-refs here because $tas/<uuid>.ta will retain a string
+      # reference to $out/lib (and glibc/lib) on the nix-store. We need to break
+      # this reference in order to split $out and $ta refs since $out/bin/xtest
+      # refers to the $tas location for runtime loading.
+      # The reason why the $out/lib reference is included in the TAs in the first
+      # place is during the linking phase, some TAs can statically link to
+      # eachother. This $out/lib path remains in the RPATH/RUNPATH for library
+      # searching metadata. The existing objcopy --strip-unneeded does not strip
+      # this unformation, despite it not being necessary for our TAs.
+      # We need this to be done during the build phase since we cannot nuke-refs
+      # after signing, as it will make verification of the signed TA fail.
+      taPreSign = writeShellApplication {
+        name = "ta-pre-sign.sh";
+        runtimeInputs = [ nukeReferences ];
+        text = ''
+          input="$1"
+          output="$2"
+          cp "$input" "$output"
+          nuke-refs "$output"
+        '';
+      };
+    in
+    [
+      "-C optee/optee_test"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      "OPTEE_CLIENT_EXPORT=${opteeClient}"
+      "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+      "TA_DIR=$(tas)" # xtest needs to manually load corrupt TA for test 1008
+      "O=$(PWD)/out"
+      "NIX_TA_PRE_SIGN_HOOK=${lib.getExe taPreSign}"
+    ] ++ lib.optionals (l4tAtLeast "36") [
+      "WITH_OPENSSL=n"
+    ];
   installPhase = ''
     runHook preInstall
 
@@ -56,35 +81,4 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
-
-  # We need to nuke-refs here because $tas/<uuid>.ta will retain a string
-  # reference to $out/lib (and glibc/lib) on the nix-store. We need to break
-  # this reference in order to split $out and $ta refs since $out/bin/xtest
-  # refers to the $tas location for runtime loading.
-  # The reason why the $out/lib reference is included in the TAs in the first
-  # place is during the linking phase, some TAs can statically link to
-  # eachother. This $out/lib path remains in the RPATH/RUNPATH for library
-  # searching metadata. The existing objcopy --strip-unneeded does not strip
-  # this unformation, despite it not being necessary for our TAs.
-  preBuild =
-    let
-      taPreSign = ''
-        cp \$input \$output
-        nuke-refs \$output
-      '';
-    in
-    ''
-      cat > ta-pre-sign.sh <<EOF
-      #!/bin/sh
-      set -euo pipefail
-
-      input="\$1"
-      output="\$2"
-
-      ${taPreSign}
-      EOF
-      chmod +x ta-pre-sign.sh
-      makeFlagsArray+=(NIX_TA_PRE_SIGN_HOOK="$PWD/ta-pre-sign.sh")
-    '';
-
 }

--- a/pkgs/optee/opteeXtest.nix
+++ b/pkgs/optee/opteeXtest.nix
@@ -8,8 +8,9 @@
 , opteeClient
 , taDevKit
 , l4tAtLeast
+, symlinkJoin
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "optee_xtest";
   version = l4tMajorMinorPatchVersion;
 
@@ -25,11 +26,28 @@ stdenv.mkDerivation {
   postPatch = ''
     patchShebangs --build $(find optee/optee_test -type d -name scripts -printf '%p ')
   '';
+
+  # Use passthru + symlinkJoin instead of multiple outputs to avoid cyclic
+  # dependencies: xtest binary needs to reference TAs, and TAs contain
+  # references to $out in metadata/symbols (can't strip - they're signed).
+  passthru =
+    let
+      path = dir: "${lib.getOutput "out" finalAttrs.finalPackage }/${dir}";
+      package = name: symlinkJoin {
+        inherit name;
+        paths = [(path name)];
+      };
+    in {
+      tas = package "tas";
+      plugins = package "plugins";
+    };
+
   makeFlags = [
     "-C optee/optee_test"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     "OPTEE_CLIENT_EXPORT=${opteeClient}"
     "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+    "TA_DIR=$(out)/tas" # xtest needs to manually load corrupt TA for test 1008
     "O=$(PWD)/out"
   ] ++ lib.optionals (l4tAtLeast "36") [
     "WITH_OPENSSL=n"
@@ -38,8 +56,10 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm 755 ./out/xtest/xtest $out/bin/xtest
-    find ./out -name "*.ta" -exec cp {} $out \;
+
+    find ./out -name "*.ta" -print0 | xargs -0 install -Dm 755 -t $out/tas
+    find ./out -name "*.plugin" -print0 | xargs -0 install -Dm 755 -t $out/plugins
 
     runHook postInstall
   '';
-}
+})

--- a/pkgs/optee/opteeXtest.nix
+++ b/pkgs/optee/opteeXtest.nix
@@ -1,5 +1,6 @@
 { stdenv
 , gitRepos
+, nukeReferences
 , l4tMajorMinorPatchVersion
 , buildPackages
 , lib
@@ -8,17 +9,25 @@
 , opteeClient
 , taDevKit
 , l4tAtLeast
-, symlinkJoin
 }:
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "optee_xtest";
   version = l4tMajorMinorPatchVersion;
 
   src = gitRepos."tegra/optee-src/nv-optee";
   patches = [ ./0001-GCC-15-compile-fix.patch ];
 
+  # Multiple outputs: xtest binary, TAs, and plugins
+  outputs = [
+    "out"
+    "tas"
+    "plugins"
+  ];
+
+
   nativeBuildInputs = [
     (buildPackages.python3.withPackages (p: [ p.cryptography ]))
+    nukeReferences
   ] ++ lib.optionals (l4tOlder "36") [ openssl ];
 
   buildInputs = [ ] ++ lib.optionals (l4tOlder "36") [ openssl ];
@@ -27,27 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build $(find optee/optee_test -type d -name scripts -printf '%p ')
   '';
 
-  # Use passthru + symlinkJoin instead of multiple outputs to avoid cyclic
-  # dependencies: xtest binary needs to reference TAs, and TAs contain
-  # references to $out in metadata/symbols (can't strip - they're signed).
-  passthru =
-    let
-      path = dir: "${lib.getOutput "out" finalAttrs.finalPackage }/${dir}";
-      package = name: symlinkJoin {
-        inherit name;
-        paths = [(path name)];
-      };
-    in {
-      tas = package "tas";
-      plugins = package "plugins";
-    };
-
   makeFlags = [
     "-C optee/optee_test"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     "OPTEE_CLIENT_EXPORT=${opteeClient}"
     "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
-    "TA_DIR=$(out)/tas" # xtest needs to manually load corrupt TA for test 1008
+    "TA_DIR=$(tas)" # xtest needs to manually load corrupt TA for test 1008
     "O=$(PWD)/out"
   ] ++ lib.optionals (l4tAtLeast "36") [
     "WITH_OPENSSL=n"
@@ -57,9 +51,40 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm 755 ./out/xtest/xtest $out/bin/xtest
 
-    find ./out -name "*.ta" -print0 | xargs -0 install -Dm 755 -t $out/tas
-    find ./out -name "*.plugin" -print0 | xargs -0 install -Dm 755 -t $out/plugins
+    find ./out -name "*.ta" -print0 | xargs -0 install -Dm 755 -t $tas
+    find ./out -name "*.plugin" -print0 | xargs -0 install -Dm 755 -t $plugins
 
     runHook postInstall
   '';
-})
+
+  # We need to nuke-refs here because $tas/<uuid>.ta will retain a string
+  # reference to $out/lib (and glibc/lib) on the nix-store. We need to break
+  # this reference in order to split $out and $ta refs since $out/bin/xtest
+  # refers to the $tas location for runtime loading.
+  # The reason why the $out/lib reference is included in the TAs in the first
+  # place is during the linking phase, some TAs can statically link to
+  # eachother. This $out/lib path remains in the RPATH/RUNPATH for library
+  # searching metadata. The existing objcopy --strip-unneeded does not strip
+  # this unformation, despite it not being necessary for our TAs.
+  preBuild =
+    let
+      taPreSign = ''
+        cp \$input \$output
+        nuke-refs \$output
+      '';
+    in
+    ''
+      cat > ta-pre-sign.sh <<EOF
+      #!/bin/sh
+      set -euo pipefail
+
+      input="\$1"
+      output="\$2"
+
+      ${taPreSign}
+      EOF
+      chmod +x ta-pre-sign.sh
+      makeFlagsArray+=(NIX_TA_PRE_SIGN_HOOK="$PWD/ta-pre-sign.sh")
+    '';
+
+}


### PR DESCRIPTION
###### Description of changes

On orin-agx-devkit, a pair of regression tests were failing.

`xtest -t regression 1008` - Corrupt TA test loading.
`xtest -t regression 1033` - Plugin Test.

The corrupt TA couldn't be found on the path listed by the `TA_DIR=` compilation flag. This change sets the TA_DIR. 
The plugins were missing on the tee-supplicant path. This change adds the plugin.
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing
Ran opteeXtest on an orin-agx-devkit.

`xtest`

```
31062 subtests of which 0 failed
133 test cases of which 0 failed
0 test cases were skipped
```

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
