### PR TITLE
initrdFlash: Use dm-linear to merge mmcblk0boot0 and mmcblk0boot1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,24 +138,28 @@
 
       nixosModules.default = import ./modules/default.nix self.overlays.default;
 
-      overlays.default = final: prev:
-        # We've already applied our overlay and should not apply it again.
-        # TODO(@connorbaker): Create a general "named overlay" mechanism which provides visibility into which overlays
-        # were applied and the order in which they were applied.
-        if prev."jetpack-nixos-overlay-applied-${self.narHash}" or false then
-          { }
-        else
-          nixpkgs.lib.composeManyExtensions [
-            # We apply cuda-legacy here ourselves instead of making users do this becauase
-            # it is unlikely that users directly care about cuda-legacy as it's something
-            # jetpack-nixos has traditionally supplied.
-            # We apply cuda-legacy first because Connor says so.
-            cuda-legacy.overlays.default
-            (import ./overlay.nix)
-            (_: _: { "jetpack-nixos-overlay-applied-${self.narHash}" = true; })
-          ]
-            final
-            prev;
+      overlays.default =
+        let
+          stamp = "jetpack-nixos-overlay-applied-${self.narHash or self.dirtyRev}";
+        in
+        final: prev:
+          # We've already applied our overlay and should not apply it again.
+          # TODO(@connorbaker): Create a general "named overlay" mechanism which provides visibility into which overlays
+          # were applied and the order in which they were applied.
+          if prev.${stamp} or false then
+            { }
+          else
+            nixpkgs.lib.composeManyExtensions [
+              # We apply cuda-legacy here ourselves instead of making users do this becauase
+              # it is unlikely that users directly care about cuda-legacy as it's something
+              # jetpack-nixos has traditionally supplied.
+              # We apply cuda-legacy first because Connor says so.
+              cuda-legacy.overlays.default
+              (import ./overlay.nix)
+              (_: _: { ${stamp} = true; })
+            ]
+              final
+              prev;
 
       packages = {
         x86_64-linux =

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -89,9 +89,10 @@ final: prev: (
 
       flashInitrd =
         let
+          commonModules = [ "dm-mod" ];
           spiModules = if lib.versions.majorMinor config.system.build.kernel.version == "5.10" then [ "qspi_mtd" "spi_tegra210_qspi" "at24" "spi_nor" ] else [ "mtdblock" "spi_tegra210_quad" ];
           usbModules = if lib.versions.majorMinor config.system.build.kernel.version == "5.10" then [ ] else [ "libcomposite" "udc-core" "tegra-xudc" "xhci-tegra" "u_serial" "usb_f_acm" ];
-          modules = spiModules ++ usbModules ++ cfg.flashScriptOverrides.additionalInitrdFlashModules;
+          modules = commonModules ++ spiModules ++ usbModules ++ cfg.flashScriptOverrides.additionalInitrdFlashModules;
           modulesClosure = prev.makeModulesClosure {
             rootModules = modules;
             kernel = config.system.modulesTree;

--- a/pkgs/flash-from-device/default.nix
+++ b/pkgs/flash-from-device/default.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs, pkgsStatic, runCommand, tegra-eeprom-tool-static }:
+{ lib
+, pkgsStatic
+, runCommand
+, tegra-eeprom-tool-static
+}:
 
 let
   mtdutils = pkgsStatic.mtdutils.overrideAttrs ({ version, patches ? [ ], ... }: {
@@ -21,6 +25,7 @@ let
     cp ${mtdutils}/bin/flash_erase $out/bin
     cp ${tegra-eeprom-tool-static}/bin/tegra-boardspec $out/bin
     cp ${lib.getExe pkgsStatic.nvidia-jetpack.patchgpt} $out/bin
+    cp ${lib.getExe' pkgsStatic.lvm2 "dmsetup"} $out/bin
   '';
   name = "flash-from-device";
 in


### PR DESCRIPTION
###### Description of changes

It's better this way. SOMs which have only 8MiB of emmc will fill both
boot0 and boot1. mb2_b happens to cross the boundary: starts at approx.
+3.8MiB and ends at approx. 4.1MiB. This means we must write part of
mb2_b in mmcblk0boot0 and part in mmcblk0boot1. Use dm-linear to
elegantly handle the partial writes to each block device.

###### Testing

- [x] Flash and UEFI capsule updates on AGX Xavier with 16MiB boot partition
- [ ] Flash and UEFI capsule update on AGX Xavier with 8MiB boot partition
