### PR TITLE
nvpmodel: fix mode switching on JP7

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -288,7 +288,7 @@ in
         options nvgpu devfreq_timer="delayed"
       '' + lib.optionalString (jetpackAtLeast "7") ''
         # from L4T-Ubuntu /etc/modprobe.d/nvidia-unifiedgpudisp.conf
-        options nvidia NVreg_RegistryDwords="RMExecuteDevinitOnPmu=0;RMEnableAcr=1;RmCePceMap=0xffffff20;RmCePceMap1=0xffffffff;RmCePceMap2=0xffffffff;RmCePceMap3=0xffffffff;" NVreg_TegraGpuPgMask=512
+        options nvidia NVreg_RegistryDwords="RMExecuteDevinitOnPmu=0;RMEnableAcr=1;RmCePceMap=0xffffff20;RmCePceMap1=0xffffffff;RmCePceMap2=0xffffffff;RmCePceMap3=0xffffffff;"
         softdep nvidia pre: governor_pod_scaling post: nvidia-uvm
       '';
 

--- a/modules/nvpmodel.nix
+++ b/modules/nvpmodel.nix
@@ -43,6 +43,28 @@ in
 
     environment.etc."nvpmodel.conf".source = cfg.configFile;
     environment.etc."nvpmodel".source = "${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel";
+    # Need this hack otherwise setting the mode requires a reboot on JP7 thor
+    #
+    # Per this thread for some reason the new driver they are using for the GPU doesn't expose
+    # a GPU_POWER_GATING sysfs node. And the hack they suggested doesn't work.
+    # https://forums.developer.nvidia.com/t/nvpmodel-conf-for-70w-with-jetson-thor/348826/13
+    #
+    # How nvpmodel now determines the current state of GPU_POWER_GATING is through the /etc/modprobe.d conf files.
+    # You might think wow that seems strange because you can change this file at runtime and set a different gpu_pg_mask
+    # and then change modes without a reboot. This works and seems to break the rules in the note here
+    # https://docs.nvidia.com/jetson/archives/r38.2/DeveloperGuide/SD/PlatformPowerAndPerformance/JetsonThor.html#power-mode-controls
+    #
+    # The reason thor was failing to set a power mode is because nvpmodel ignores symlinks which all of the NixOS kernel module confs are.
+    # Since they symlink back to the nix store.
+    # newfstatat(AT_FDCWD, "/etc/modprobe.d/nixos.conf", {st_mode=S_IFLNK|0777, st_size=33, ...}, AT_SYMLINK_NOFOLLOW) = 0
+    #
+    # To fix this we drop a hardlink for this option at /etc/modprobe.d. Setting the value to -1 allows nvpmodel to overwrite
+    # the conf file on first boot.
+    environment.etc."NVreg_TegraGpuPgMask.conf" = mkIf (config.hardware.nvidia-jetpack.majorVersion == "7") {
+      target = "modprobe.d/NVreg_TegraGpuPgMask.conf";
+      text = "options nvidia NVreg_TegraGpuPgMask=-1";
+      mode = "0644";
+    };
 
     environment.systemPackages = with pkgs.nvidia-jetpack; [ l4t-nvpmodel ];
   };


### PR DESCRIPTION
###### Description of changes

Adds a hard linked file in `/etc/modprobe.d` that sets `options nvidia NVreg_TegraGpuPgMask=${builtins.toString cfg.gpuPgMask}` so nvpmodel can parse the GPU_POWER_GATING value.

Exposes an option to set the gpuPgMask currently this is not necessary as there are only two modes (120W and MAXN) which both use 64 for their MASK option. But, once Nvidia releases more modes this will need to be set if users want to change the mode on bootup.

###### Testing

Thor-agx-devkit is able to set its mode on boot up.
```
nvpmodel -q
NV Power Mode: MAXN
0
```