### PR TITLE
kernels: r36/r38: restore VIDEOBUF2_DMA_CONTIG

### DIFF
--- a/pkgs/kernels/r36/default.nix
+++ b/pkgs/kernels/r36/default.nix
@@ -101,6 +101,15 @@ buildLinux (args // {
 
     # Restore default LSM from security/Kconfig. Undoes Nvidia downstream changes.
     LSM = freeform "landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf";
+
+    # drivers/media/platform/tegra/camera/vi/channel.c from
+    # linux-oot-modules has ifdefs for
+    # CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+    # function.
+    # Otherwise it hits a WARN_ON() and outputs
+    # > tegra-capture-vi: failed to initialize VB2 queue
+    VIDEOBUF2_DMA_CONTIG = yes;
+
   } // (import ../common-arch.nix { inherit lib; })
   // lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix

--- a/pkgs/kernels/r38/default.nix
+++ b/pkgs/kernels/r38/default.nix
@@ -98,6 +98,15 @@ buildLinux (args // {
 
     # Restore default LSM from security/Kconfig. Undoes Nvidia downstream changes.
     LSM = freeform "landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf";
+
+    # drivers/media/platform/tegra/camera/vi/channel.c from
+    # linux-oot-modules has ifdefs for
+    # CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+    # function.
+    # Otherwise it hits a WARN_ON() and outputs
+    # > tegra-capture-vi: failed to initialize VB2 queue
+    VIDEOBUF2_DMA_CONTIG = yes;
+
   } // (import ../common-arch.nix { inherit lib; })
   // lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix


### PR DESCRIPTION
###### Description of changes

The previous change to remove extraneous architecture support led to VIDEOBUF2_DMA_CONTIG being disabled, although it is necessary for a Tegra out-of-tree (OOT) module.  This change is not necessary for r35, since the module is built in-tree (the combined tree) and the Kconfig option VIDEO_TEGRA_VI selects VIDEOBUF2_DMA_CONTIG.

Prior to this change, after booting an Orin AGX devkit, we would see the following:
```
[   30.626714] ------------[ cut here ]------------
[   30.626721] WARNING: CPU: 11 PID: 1231 at drivers/media/common/videobuf2/videobuf2-core.c:2385 vb2_core_queue_init+0x16c/0x1b0 [videobuf2_common]
[   30.626739] Modules linked in: tegra_camera(O+) governor_userspace tegra_drm(O) v4l2_dv_timings nvhost_nvcsi(O) tegra_camera_platform(O) nvhost_pva(O) capture_ivc(O) tegra_camera_rtcpu(O) nvhost_nvdla(O) ivc_bus(O) hsp_mailbox_client(O) ivc_ext(O) videobuf2_v4l2 videobuf2_common v4l2_fwnode v4l2_async videodev mc tegra_wmark(O) nvhost_capture(O) tsecriscv(O) nvhwpm(O) tegra_se(O) host1x_nvhost(O) crypto_engine governor_pod_scaling(O) nvmap(O) nvsciipc(O) host1x(O) mc_utils(O) fuse nfnetlink nvme nvethernet(O) nvme_core nvpps(O) ucsi_ccg typec_ucsi typec phy_tegra194_p2u xhci_tegra pcie_tegra194 tegra_mce(O) nls_iso8859_1 nls_cp437 nfsv4 nfs lockd grace sunrpc
[   30.626787] CPU: 11 PID: 1231 Comm: (udev-worker) Tainted: G           O      5.15.185 #1-NixOS
[   30.626790] Hardware name: NVIDIA NVIDIA Jetson AGX Orin Developer Kit/Jetson, BIOS 36.5.0-a59ebfc0a92a 01/01/1980
[   30.626792] pstate: 60400009 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[   30.626794] pc : vb2_core_queue_init+0x16c/0x1b0 [videobuf2_common]
[   30.626800] lr : vb2_core_queue_init+0x20/0x1b0 [videobuf2_common]
[   30.626805] sp : ffff80000a34b6d0
[   30.626805] x29: ffff80000a34b6d0 x28: 000000000000000c x27: 0000000000000000
[   30.626808] x26: ffff0000815fa080 x25: ffff00008167e800 x24: ffff0007a8de5d88
[   30.626810] x23: 0000000000000001 x22: ffff0000963801f8 x21: ffff0000815fa0a0
[   30.626812] x20: 0000000000000000 x19: ffff000096380680 x18: ffffffffffffffff
[   30.626814] x17: 4255530030616964 x16: ffffc98ab1df16e0 x15: 0000000000000100
[   30.626816] x14: ffffffffffffffff x13: 0000000000000000 x12: 0000000000000028
[   30.626817] x11: 0000000000000018 x10: 0101010101010101 x9 : 0000000000000008
[   30.626819] x8 : 7f7f7f7f7f7f7f7f x7 : 73607371ff666471 x6 : 0000000000000000
[   30.626821] x5 : 0000000000000000 x4 : 0000000000000000 x3 : ffffc98a5bbd9b40
[   30.626823] x2 : ffffc98ab1df1718 x1 : 0000000000000000 x0 : ffffc98a5be0c928
[   30.626825] Call trace:
[   30.626826]  vb2_core_queue_init+0x16c/0x1b0 [videobuf2_common]
[   30.626831]  vb2_queue_init_name+0xc8/0x120 [videobuf2_v4l2]
[   30.626837]  vb2_queue_init+0x2c/0x40 [videobuf2_v4l2]
[   30.626841]  tegra_channel_init+0x2ac/0x3a0 [tegra_camera]
[   30.626879]  tegra_vi_channels_init+0x4c/0x120 [tegra_camera]
[   30.626903]  tegra_vi_media_controller_init_int+0x1e4/0x28c [tegra_camera]
[   30.626925]  tegra_capture_vi_media_controller_init+0x30/0x5c [tegra_camera]
[   30.626947]  capture_vi_probe+0x13c/0x534 [tegra_camera]
[   30.626969]  platform_probe+0x74/0xe4
[   30.626978]  really_probe+0xcc/0x46c
[   30.626980]  __driver_probe_device+0x114/0x170
[   30.626981]  driver_probe_device+0x54/0x130
[   30.626983]  __driver_attach+0xd8/0x200
[   30.626984]  bus_for_each_dev+0x8c/0xf0
[   30.626988]  driver_attach+0x38/0x48
[   30.626989]  bus_add_driver+0x15c/0x260
[   30.626992]  driver_register+0x80/0x140
[   30.626994]  __platform_driver_register+0x3c/0x58
[   30.626996]  capture_vi_init+0x3c/0xfc4 [tegra_camera]
[   30.627018]  do_one_initcall+0x64/0x260
[   30.627023]  do_init_module+0x54/0x240
[   30.627026]  load_module+0x216c/0x26bc
[   30.627028]  __do_sys_init_module+0x1d8/0x2fc
[   30.627029]  __arm64_sys_init_module+0x2c/0x40
[   30.627031]  invoke_syscall+0x5c/0x120
[   30.627034]  el0_svc_common.constprop.0+0xf0/0x110
[   30.627037]  do_el0_svc+0x3c/0x9c
[   30.627039]  el0_svc+0x28/0xa8
[   30.627043]  el0t_64_sync_handler+0x108/0x120
[   30.627045]  el0t_64_sync+0x1a4/0x1a8
[   30.627046] ---[ end trace 687bdb73decdbf3c ]---
[   31.632094] tegra-camrtc-capture-vi tegra-capture-vi: failed to initialize VB2 queue
[   31.632101] tegra-camrtc-capture-vi tegra-capture-vi: channel init failed
```

###### Testing

- [x] Booted an Orin AGX devkit and there are no longer the same kernel dmesg errors