### PR TITLE
kernels: r36/r38: actually restore VIDEOBUF2_DMA_CONTIG

### DIFF
--- a/pkgs/kernels/r36/0001-ipu-Depend-on-x86.patch
+++ b/pkgs/kernels/r36/0001-ipu-Depend-on-x86.patch
@@ -1,7 +1,7 @@
-From 684f238159a15e58b935a9fc861744126f6833df Mon Sep 17 00:00:00 2001
+From 7c7566f1972d38f9d3c7c71010a8b4dc8e0fcb4f Mon Sep 17 00:00:00 2001
 From: Elliot Berman <eberman@anduril.com>
 Date: Mon, 28 Apr 2025 15:28:58 -0700
-Subject: [PATCH] ipu: Depend on x86
+Subject: [PATCH 1/2] ipu: Depend on x86
 
 The ipu6 module makes use of the following x86-specific function:
 clflush_cache_range(). Make the Kconfig reflect this so allmodconfig
@@ -13,7 +13,7 @@ Signed-off-by: Elliot Berman <eberman@anduril.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/media/pci/intel/Kconfig b/drivers/media/pci/intel/Kconfig
-index ee4a77acb66f..5088f1e850c5 100644
+index ee4a77acb66f3..5088f1e850c56 100644
 --- a/drivers/media/pci/intel/Kconfig
 +++ b/drivers/media/pci/intel/Kconfig
 @@ -3,6 +3,7 @@ config VIDEO_INTEL_IPU6
@@ -25,5 +25,5 @@ index ee4a77acb66f..5088f1e850c5 100644
  	select IOMMU_IOVA
  	select X86_DEV_DMA_OPS if X86
 -- 
-2.49.0
+2.50.0
 

--- a/pkgs/kernels/r36/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
+++ b/pkgs/kernels/r36/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
@@ -1,0 +1,37 @@
+From 0e7e514385c43aae07926eb7465222a2a51eba69 Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <dfullmer@anduril.com>
+Date: Sat, 14 Feb 2026 13:43:59 -0800
+Subject: [PATCH 2/2] Hack to select VIDEOBUF2_DMA_CONTIG
+
+drivers/media/platform/tegra/camera/vi/channel.c from linux-oot-modules
+has ifdefs for CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+function. Otherwise it hits a WARN_ON() and outputs
+> tegra-capture-vi: failed to initialize VB2 queue
+
+This option unfortunately can't be set via extraConfig or
+structuredExtraConfig because the config option does not include a
+"prompt" and therefore kconfig sets its visibility to false, and it never
+shows up in "make config",  which prevents generate-config.pl from
+setting it.  Manually adding it to the defconfig doesn't work either.
+
+Here we have a hack to just reuse another option that _is_ already
+enabled and have it select the CONFIG_VIDEOBUF2_DMA_CONTIG
+---
+ drivers/media/common/videobuf2/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/common/videobuf2/Kconfig b/drivers/media/common/videobuf2/Kconfig
+index d2223a12c95fc..a2298bafa0b95 100644
+--- a/drivers/media/common/videobuf2/Kconfig
++++ b/drivers/media/common/videobuf2/Kconfig
+@@ -21,6 +21,7 @@ config VIDEOBUF2_VMALLOC
+ 	select VIDEOBUF2_CORE
+ 	select VIDEOBUF2_MEMOPS
+ 	select DMA_SHARED_BUFFER
++        select VIDEOBUF2_DMA_CONTIG
+ 
+ config VIDEOBUF2_DMA_SG
+ 	tristate
+-- 
+2.50.0
+

--- a/pkgs/kernels/r36/default.nix
+++ b/pkgs/kernels/r36/default.nix
@@ -41,6 +41,10 @@ buildLinux (args // {
       name = "ipu: Depend on x86";
       patch = ./0001-ipu-Depend-on-x86.patch;
     }
+    {
+      name = "Hack-to-select-VIDEOBUF2_DMA_CONTIG";
+      patch = ./0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch;
+    }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {
@@ -101,14 +105,6 @@ buildLinux (args // {
 
     # Restore default LSM from security/Kconfig. Undoes Nvidia downstream changes.
     LSM = freeform "landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf";
-
-    # drivers/media/platform/tegra/camera/vi/channel.c from
-    # linux-oot-modules has ifdefs for
-    # CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
-    # function.
-    # Otherwise it hits a WARN_ON() and outputs
-    # > tegra-capture-vi: failed to initialize VB2 queue
-    VIDEOBUF2_DMA_CONTIG = yes;
 
   } // (import ../common-arch.nix { inherit lib; })
   // lib.optionalAttrs realtime {

--- a/pkgs/kernels/r38/0001-usb-host-Export-xhci_irq.patch
+++ b/pkgs/kernels/r38/0001-usb-host-Export-xhci_irq.patch
@@ -1,7 +1,7 @@
-From 173bf15c5274580a344dae38a29edee51dd449ce Mon Sep 17 00:00:00 2001
+From 4b1552b3861382dcefd0ace133e7d52501499cb3 Mon Sep 17 00:00:00 2001
 From: Elliot Berman <eberman@anduril.com>
 Date: Tue, 26 Aug 2025 10:31:32 -0700
-Subject: [PATCH] usb: host: Export xhci_irq
+Subject: [PATCH 1/2] usb: host: Export xhci_irq
 
 This symbol is used by xhci-tegra, which can be built in a separate
 module from xhci.
@@ -25,5 +25,5 @@ index 7badf91645909..04186add014e4 100644
  irqreturn_t xhci_msi_irq(int irq, void *hcd)
  {
 -- 
-2.50.1
+2.50.0
 

--- a/pkgs/kernels/r38/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
+++ b/pkgs/kernels/r38/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
@@ -1,0 +1,37 @@
+From d122bf9d0678255039dc6e2833dc04f7865c62cc Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <dfullmer@anduril.com>
+Date: Sat, 14 Feb 2026 13:43:59 -0800
+Subject: [PATCH 2/2] Hack to select VIDEOBUF2_DMA_CONTIG
+
+drivers/media/platform/tegra/camera/vi/channel.c from linux-oot-modules
+has ifdefs for CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+function. Otherwise it hits a WARN_ON() and outputs
+> tegra-capture-vi: failed to initialize VB2 queue
+
+This option unfortunately can't be set via extraConfig or
+structuredExtraConfig because the config option does not include a
+"prompt" and therefore kconfig sets its visibility to false, and it never
+shows up in "make config",  which prevents generate-config.pl from
+setting it.  Manually adding it to the defconfig doesn't work either.
+
+Here we have a hack to just reuse another option that _is_ already
+enabled and have it select the CONFIG_VIDEOBUF2_DMA_CONTIG
+---
+ drivers/media/common/videobuf2/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/common/videobuf2/Kconfig b/drivers/media/common/videobuf2/Kconfig
+index d2223a12c95fc..a2298bafa0b95 100644
+--- a/drivers/media/common/videobuf2/Kconfig
++++ b/drivers/media/common/videobuf2/Kconfig
+@@ -21,6 +21,7 @@ config VIDEOBUF2_VMALLOC
+ 	select VIDEOBUF2_CORE
+ 	select VIDEOBUF2_MEMOPS
+ 	select DMA_SHARED_BUFFER
++        select VIDEOBUF2_DMA_CONTIG
+ 
+ config VIDEOBUF2_DMA_SG
+ 	tristate
+-- 
+2.50.0
+

--- a/pkgs/kernels/r38/default.nix
+++ b/pkgs/kernels/r38/default.nix
@@ -38,6 +38,10 @@ buildLinux (args // {
       name = "usb: host: Export xhci_irq";
       patch = ./0001-usb-host-Export-xhci_irq.patch;
     }
+    {
+      name = "Hack-to-select-VIDEOBUF2_DMA_CONTIG";
+      patch = ./0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch;
+    }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes

The previous commit to do this actually didn't function correctly, due to an issue with config option visibility and "make config" described in the included patch.

###### Testing

Verified that the kernel configfile for both r36 and r38 now contain VIDEOBUF2_DMA_CONTIG