### PR TITLE
Initial options for "bring your own kernel"

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,21 +260,9 @@ from Jetson Linux.
 
 The NixOS module uses these sets by default.
 
-On JetPack 6+, however, you may use a mainline package set instead.
+On JetPack 6+, however, you may use a mainline kernel instead.
+You can disable Nvidia's provided vendor kernel by setting `hardware.nvidia-jetpack.kernel.useVendorProvided = false;`.
 Consult the [Bring Your Own Kernel](https://docs.nvidia.com/jetson/archives/r36.4.4/DeveloperGuide/SD/Kernel/BringYourOwnKernel.html) documentation for more details.
-
-When using a custom package set in the NixOS configuration, the out-of-tree
-modules must be added using the provided overlay.
-
-e.g. (using the `pkgs.nvidia-jetpack.kernelPackages` set)
-
-```nix
-{ pkgs, ... }:
-
-{
-  config.boot.kernelPackages = pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay
-}
-```
 
 ## Configuring CUDA for Nixpkgs
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -229,10 +229,10 @@ in
       ];
 
       boot.kernelPackages =
-        (if cfg.kernel.realtime then
+        if cfg.kernel.realtime then
           pkgs.nvidia-jetpack.rtkernelPackages
         else
-          pkgs.nvidia-jetpack.kernelPackages).extend pkgs.nvidia-jetpack.kernelPackagesOverlay;
+          pkgs.nvidia-jetpack.kernelPackages;
 
       boot.kernelParams = [
         # Needed on Orin at least, but upstream has it for both

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -34,6 +34,7 @@ in
     ./devices.nix
     ./flash-script.nix
     ./graphics.nix
+    ./kernel.nix
     ./nvargus-daemon.nix
     ./nvfancontrol.nix
     ./nvidia-container-toolkit.nix
@@ -110,13 +111,6 @@ in
           Jetson carrier board to target. Can be set to "generic" to target a generic jetson carrier board, but some things may not work.
         '';
       };
-
-      kernel.realtime = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Enable PREEMPT_RT patches";
-      };
-
 
       flasherPkgs = mkOption {
         type = options.nixpkgs.pkgs.type;
@@ -228,80 +222,7 @@ in
         ])
       ];
 
-      boot.kernelPackages =
-        if cfg.kernel.realtime then
-          pkgs.nvidia-jetpack.rtkernelPackages
-        else
-          pkgs.nvidia-jetpack.kernelPackages;
-
-      boot.kernelParams = [
-        # Needed on Orin at least, but upstream has it for both
-        "nvidia.rm_firmware_active=all"
-      ]
-      ++ lib.optionals cfg.console.enable cfg.console.args
-      ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "38") [
-        "clk_ignore_unused"
-      ];
-
-      boot.initrd.includeDefaultModules = false; # Avoid a bunch of modules we may not get from tegra_defconfig
-      boot.initrd.availableKernelModules = [ "xhci-tegra" "ucsi_ccg" "typec_ucsi" "typec" ] # Make sure USB firmware makes it into initrd
-        ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "36") [
-        "nvme"
-        "tegra_mce"
-        "phy-tegra-xusb"
-        "i2c-tegra"
-        "fusb301"
-        # PCIe for nvme, ethernet, etc.
-        "phy_tegra194_p2u"
-        "pcie_tegra194"
-        # Ethernet for AGX
-        "nvpps"
-        "nvethernet"
-      ] ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "38") [
-        "pwm-fan"
-        "uas"
-        "r8152"
-        "phy-tegra194-p2u"
-        "nvme-core"
-        "tegra-bpmp-thermal"
-        "pwm-tegra"
-        "tegra_vblk"
-        "tegra_hv_vblk_oops"
-        "ufs-tegra"
-        "nvpps"
-        "pcie-tegra264"
-        "nvethernet"
-        "r8126"
-        "r8168"
-        "tegra_vnet"
-        "rtl8852ce"
-        "oak_pci"
-      ];
-
-      # See upstream default for this option, removes any modules that aren't enabled in JetPack kernel
-      boot.initrd.luks.cryptoModules = lib.mkDefault [
-        "aes"
-        "aes_generic"
-        "cbc"
-        "xts"
-        "sha1"
-        "sha256"
-        "sha512"
-        "af_alg"
-        "algif_skcipher"
-      ];
-
-      boot.kernelModules = if (jetpackAtLeast "7") then [ "nvidia-uvm" ] else [ "nvgpu" ];
-
-      boot.extraModprobeConfig = lib.optionalString (jetpackAtLeast "6") ''
-        options nvgpu devfreq_timer="delayed"
-      '' + lib.optionalString (jetpackAtLeast "7") ''
-        # from L4T-Ubuntu /etc/modprobe.d/nvidia-unifiedgpudisp.conf
-        options nvidia NVreg_RegistryDwords="RMExecuteDevinitOnPmu=0;RMEnableAcr=1;RmCePceMap=0xffffff20;RmCePceMap1=0xffffffff;RmCePceMap2=0xffffffff;RmCePceMap3=0xffffffff;"
-        softdep nvidia pre: governor_pod_scaling post: nvidia-uvm
-      '';
-
-      boot.extraModulePackages = lib.optional (jetpackAtLeast "6") config.boot.kernelPackages.nvidia-oot-modules;
+      boot.kernelParams = lib.optionals cfg.console.enable cfg.console.args;
 
       hardware.firmware = with pkgs.nvidia-jetpack; [
         l4t-firmware
@@ -317,8 +238,6 @@ in
         in
         nvidiaDriverFirmwareDebs ++ [ l4t-firmware-openrm ]
       );
-
-      boot.blacklistedKernelModules = [ "nouveau" ];
 
       hardware.deviceTree.enable = true;
       hardware.deviceTree.dtboBuildExtraIncludePaths = {
@@ -414,7 +333,7 @@ in
 
       # Nvidia's jammy kernel has downstream apparmor patches which require "apparmor"
       # to appear sufficiently early in the `lsm=<list of security modules>` kernel argument
-      security.lsm = lib.mkIf config.security.apparmor.enable (mkBefore [ "apparmor" ]);
+      security.lsm = lib.mkIf (cfg.kernel.useVendorProvided && config.security.apparmor.enable) (mkBefore [ "apparmor" ]);
     })
   ]);
 }

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.hardware.nvidia-jetpack;
+
+  jetpackAtLeast = lib.versionAtLeast cfg.majorVersion;
+in
+{
+  options = {
+    hardware.nvidia-jetpack.kernel = {
+      useVendorProvided = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Use kernel provided by Nvidia's Jetson Linux";
+      };
+
+      realtime = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Enable PREEMPT_RT patches. Only has effect if useVendorProvided = true";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot = {
+      kernelPackages = lib.mkIf cfg.kernel.useVendorProvided
+        (if cfg.kernel.realtime then
+          pkgs.nvidia-jetpack.rtkernelPackages
+        else
+          pkgs.nvidia-jetpack.kernelPackages);
+
+      extraModulePackages = lib.optional (jetpackAtLeast "6") config.boot.kernelPackages.nvidia-oot-modules;
+
+      blacklistedKernelModules = [ "nouveau" ];
+
+      kernelModules = if (jetpackAtLeast "7") then [ "nvidia-uvm" ] else [ "nvgpu" ];
+
+      kernelParams = [
+        # Needed on Orin at least, but upstream has it for both
+        "nvidia.rm_firmware_active=all"
+      ] ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "38") [
+        "clk_ignore_unused"
+      ];
+
+      extraModprobeConfig = lib.optionalString (jetpackAtLeast "6") ''
+        options nvgpu devfreq_timer="delayed"
+      '' + lib.optionalString (jetpackAtLeast "7") ''
+        # from L4T-Ubuntu /etc/modprobe.d/nvidia-unifiedgpudisp.conf
+        options nvidia NVreg_RegistryDwords="RMExecuteDevinitOnPmu=0;RMEnableAcr=1;RmCePceMap=0xffffff20;RmCePceMap1=0xffffffff;RmCePceMap2=0xffffffff;RmCePceMap3=0xffffffff;"
+        softdep nvidia pre: governor_pod_scaling post: nvidia-uvm
+      '';
+
+      initrd.includeDefaultModules = false; # Avoid a bunch of modules we may not get from tegra_defconfig
+      initrd.availableKernelModules = [ "xhci-tegra" "ucsi_ccg" "typec_ucsi" "typec" ] # Make sure USB firmware makes it into initrd
+        ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "36") [
+        "nvme"
+        "tegra_mce"
+        "phy-tegra-xusb"
+        "i2c-tegra"
+        "fusb301"
+        # PCIe for nvme, ethernet, etc.
+        "phy_tegra194_p2u"
+        "pcie_tegra194"
+        # Ethernet for AGX
+        "nvpps"
+        "nvethernet"
+      ] ++ lib.optionals (pkgs.nvidia-jetpack.l4tAtLeast "38") [
+        "pwm-fan"
+        "uas"
+        "r8152"
+        "phy-tegra194-p2u"
+        "nvme-core"
+        "tegra-bpmp-thermal"
+        "pwm-tegra"
+        "tegra_vblk"
+        "tegra_hv_vblk_oops"
+        "ufs-tegra"
+        "nvpps"
+        "pcie-tegra264"
+        "nvethernet"
+        "r8126"
+        "r8168"
+        "tegra_vnet"
+        "rtl8852ce"
+        "oak_pci"
+      ];
+
+      # See upstream default for this option, removes any modules that aren't enabled in JetPack kernel
+      initrd.luks.cryptoModules = lib.mkDefault [
+        "aes"
+        "aes_generic"
+        "cbc"
+        "xts"
+        "sha1"
+        "sha256"
+        "sha512"
+        "af_alg"
+        "algif_skcipher"
+      ];
+    };
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -99,6 +99,9 @@ in
     else
       final.nvidia-jetpack7;
 
+  # Add nvidia's custom modules to kernel package sets
+  kernelPackagesExtensions = (prev.kernelPackagesExtensions or []) ++ [ final.nvidia-jetpack.kernelPackagesOverlay ];
+
   # Set cudaPackage package sets to our JetPack-constructed package sets if we are on aarch64-linux. This is strictly
   # worse than conditioning on Jetson capabilities, but allows us to avoid infinite recursion when depending on the
   # version of the default CUDA package set. Since non-Jetson ARM platforms aren't supported by the CUDA 11.4 release,


### PR DESCRIPTION
###### Description of changes

This PR adds a `hardware.nvidia-jetpack.kernel.useVendorProvided` option that defaults to true, with the aim to allow users to more easily "bring their own kernel".  Users could have done this themselves in the past by overriding `boot.kernelPackages` with a higher priority setting, but adding this option makes it slightly easier to use and allows us to easily condition other settings on whether we're using the vendor kernel or not.

Additionally, this applies the additional out-of-tree kernel modules via via the [kernelPackageExtensions](https://github.com/NixOS/nixpkgs/pull/448069) option introduced in NixOS 25.11. Finally, we move most kernel-related configs/options into a new file for better separation.

###### Testing

In progress