### PR TITLE
fix(nvpmodel): select correct nvpmodel config for Orin Nano Super (p3767_0005)

### DIFF
--- a/modules/nvpmodel.nix
+++ b/modules/nvpmodel.nix
@@ -31,7 +31,11 @@ let
 
       # If there are no files that match the compat node use the default nvpower.sh uses
       if [ ! -f ${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/nvpmodel/nvpmodel_"$device_som".conf ]; then
-        if [[ "$device_som" == 'p3767_0005' ]]; then
+        if [[ "$device_som" == 'p3767_0005_super' ]]; then
+          # The nvpower script maps p3767_0005 -> p3767_0003 so doing the same here
+          # for the super variant.
+          device_som="p3767_0003_super"
+        elif [[ "$device_som" == 'p3767_0005' ]]; then
           # The nvpower script maps p3767_0005 -> p3767_0003 so doing the same here
           # looks to be difference between jp5 and jp6.
           device_som="p3767_0003"


### PR DESCRIPTION
Orin Nano Super modules reporting p3767_0005_super in the device tree compatible string fall through to the AGX Orin config (p3701_0000) because there is no matching nvpmodel conf file. Add the same p3767_0005 -> p3767_0003 remap that nvpower.sh uses for the super variant.

Resolves issue #478