### PR TITLE
uefi-firmware: Incremental rebuild optimizations

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -125,6 +125,7 @@ makeScope final.newScope (self: {
   tegra-eeprom-tool-static = final.pkgsStatic.callPackage ./pkgs/tegra-eeprom-tool { };
 
   patchgpt = self.callPackage ./pkgs/patchgpt { };
+  patchfv = self.callPackage ./pkgs/patchfv { };
 
   samples = makeScope self.newScope (finalSamples: {
     callPackages = callPackagesWith (self // finalSamples);

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -108,7 +108,7 @@ makeScope final.newScope (self: {
 
   dlopenOverride = final.callPackage ./pkgs/dlopen-override { };
 
-  inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion; })
+  inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion patchfv; })
     uefi-firmware;
 
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -109,7 +109,7 @@ makeScope final.newScope (self: {
   dlopenOverride = final.callPackage ./pkgs/dlopen-override { };
 
   inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion; })
-    uefi-firmware;
+    uefi-firmware jetsonStandaloneMMOptee;
 
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };
 

--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -108,7 +108,7 @@ makeScope final.newScope (self: {
 
   dlopenOverride = final.callPackage ./pkgs/dlopen-override { };
 
-  inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion; })
+  inherit (final.callPackages ./pkgs/uefi-firmware/r${l4tMajorVersion} { inherit (self) l4tMajorMinorPatchVersion patchfv; })
     uefi-firmware jetsonStandaloneMMOptee;
 
   genEkb = self.callPackage ./pkgs/optee/gen-ekb.nix { };

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -68,6 +68,14 @@ final: prev: (
         inherit (cfg.firmware.uefi.capsuleAuthentication) trustedPublicCertPemFile;
       });
 
+      jetsonStandaloneMMOptee = prevJetpack.jetsonStandaloneMMOptee.override {
+        debugMode = cfg.firmware.uefi.debugMode;
+        errorLevelInfo = cfg.firmware.uefi.errorLevelInfo;
+        edk2NvidiaPatches = cfg.firmware.uefi.edk2NvidiaPatches;
+        edk2UefiPatches = cfg.firmware.uefi.edk2UefiPatches;
+        inherit (finalJetpack) socFamily;
+      };
+
       flash-tools = prevJetpack.flash-tools.overrideAttrs ({ patches ? [ ], postPatch ? "", ... }: {
         patches = patches ++ cfg.flashScriptOverrides.patches;
         postPatch = postPatch + cfg.flashScriptOverrides.postPatch;

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -4,7 +4,7 @@
 , l4tMajorMinorPatchVersion
 , lib
 , stdenv
-, uefi-firmware ? null
+, jetsonStandaloneMMOptee ? null
 }:
 stdenv.mkDerivation (finalAttrs:
 let
@@ -65,9 +65,9 @@ in
     "CFG_TEE_CORE_LOG_LEVEL=${toString finalAttrs.coreLogLevel}"
     "CFG_TEE_TA_LOG_LEVEL=${toString finalAttrs.taLogLevel}"
   ]
-  ++ (lib.optionals ((finalAttrs.socType == "t194" || finalAttrs.socType == "t234") && uefi-firmware != null) [
+  ++ (lib.optionals ((finalAttrs.socType == "t194" || finalAttrs.socType == "t234") && jetsonStandaloneMMOptee != null) [
     "CFG_WITH_STMM_SP=y"
-    "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin"
+    "CFG_STMM_PATH=${jetsonStandaloneMMOptee}/standalonemm_optee.bin"
   ])
   ++ (lib.optional (finalAttrs.taPublicKeyFile != null) "TA_PUBLIC_KEY=${finalAttrs.taPublicKeyFile}")
   ;

--- a/pkgs/patchfv/default.nix
+++ b/pkgs/patchfv/default.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  python3,
+  python3Packages,
+  fetchFromGitHub,
+  lib,
+}:
+
+let
+  # TODO: converge back to upstream uefi-firmware-parser once theopolis/uefi-firmware-parser#146 is available in nixpkgs
+  uefi-firmware-parser = python3Packages.buildPythonPackage {
+    pname = "uefi-firmware-parser";
+    version = "1.13-unstable-08-04-2026";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "elliotberman";
+      repo = "uefi-firmware-parser";
+      rev = "aaf71c5d2268b67dc64e1315201b2d90c844eaee";
+      hash = "sha256-jQB/ZD4fjclaAeuSt0zjZDrpwGh+8ASAqeCtG4VnnmM=";
+    };
+
+    build-system = [
+      python3Packages.setuptools
+      python3Packages.wheel
+    ];
+
+    pythonRemoveDeps = [ "future" ];
+
+    pythonImportsCheck = [ "uefi_firmware" ];
+
+    meta = {
+      description = "Tool for parsing, extracting, and recreating UEFI firmware volumes";
+      homepage = "https://github.com/theopolis/uefi-firmware-parser";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      mainProgram = "uefi-firmware-parser";
+    };
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "patchfv";
+  version = "0.1.0";
+
+  src = ./.;
+
+  dontBuild = true;
+
+  buildInputs = [
+    (python3.withPackages (p: [
+      uefi-firmware-parser
+    ]))
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D patchfv.py $out/bin/patchfv
+    patchShebangs --host $out/bin/patchfv
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tool to patch UEFI firmware volumes, replacing version strings";
+    mainProgram = "patchfv";
+  };
+}

--- a/pkgs/patchfv/default.nix
+++ b/pkgs/patchfv/default.nix
@@ -1,0 +1,47 @@
+{ writers
+, python3Packages
+, fetchFromGitHub
+, lib
+,
+}:
+
+let
+  # TODO: converge back to upstream uefi-firmware-parser once theopolis/uefi-firmware-parser#146 is available in nixpkgs
+  uefi-firmware-parser = python3Packages.buildPythonPackage {
+    pname = "uefi-firmware-parser";
+    version = "1.14";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "theopolis";
+      repo = "uefi-firmware-parser";
+      tag = "v1.14";
+      hash = "sha256-flBnYDVc0ZAG0wW613XUjAdCuHSn7uw2VDMLRFIgaNY=";
+    };
+
+    build-system = [
+      python3Packages.setuptools
+      python3Packages.wheel
+    ];
+
+    pythonRemoveDeps = [ "future" ];
+
+    pythonImportsCheck = [ "uefi_firmware" ];
+
+    meta = {
+      description = "Tool for parsing, extracting, and recreating UEFI firmware volumes";
+      homepage = "https://github.com/theopolis/uefi-firmware-parser";
+      license = lib.licenses.mit;
+      mainProgram = "uefi-firmware-parser";
+      platforms = lib.platforms.unix;
+    };
+  };
+in
+
+writers.writePython3Bin "patchfv"
+{
+  libraries = [ uefi-firmware-parser ];
+  # E501: ignore line length
+  flakeIgnore = [ "E501" ];
+}
+  (builtins.readFile ./patchfv.py)

--- a/pkgs/patchfv/patchfv.py
+++ b/pkgs/patchfv/patchfv.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import logging
+from pathlib import Path
+import sys
+import traceback
+
+import uefi_firmware
+
+logging.basicConfig(level=logging.DEBUG)
+
+def find_and_replace_in_data(data, old_string, new_string, old_string_utf16, new_string_utf16):
+    original_len = len(data)
+    replacements = 0
+
+    utf8_count = data.count(old_string)
+    if utf8_count > 0:
+        data = data.replace(old_string, new_string)
+        replacements += utf8_count
+        print(f"  Found and replaced {utf8_count} UTF-8 occurrence(s)")
+
+    utf16_count = data.count(old_string_utf16)
+    if utf16_count > 0:
+        data = data.replace(old_string_utf16, new_string_utf16)
+        replacements += utf16_count
+        print(f"  Found and replaced {utf16_count} UTF-16LE occurrence(s)")
+
+    assert len(data) == original_len, "Replacement strings must be same length as original!"
+
+    return data, replacements
+
+def _patch_firmware_object(object, old_string, new_string, old_string_utf16, new_string_utf16):
+    count = 0
+
+    if hasattr(object, "objects") and any(object.objects):
+        for subobject in object.objects:
+            count += _patch_firmware_object(subobject, old_string, new_string, old_string_utf16, new_string_utf16)
+    elif hasattr(object, "data"):
+        new_data, count = find_and_replace_in_data(object.data, old_string, new_string, old_string_utf16, new_string_utf16)
+        object.data = new_data
+
+    return count
+
+
+def _patch_firmware_volume(fv_data, old_string, new_string, old_string_utf16, new_string_utf16):
+    parser = uefi_firmware.AutoParser(fv_data)
+    if not parser.type():
+        raise Exception("Error: could not detect firmware volume type")
+
+    print(f"Detected firwmare type: {parser.type()}")
+    firmware = parser.parse()
+
+    count = _patch_firmware_object(firmware, old_string, new_string, old_string_utf16, new_string_utf16)
+
+    if count > 0:
+        if not hasattr(firmware, "build"):
+            raise Exception("Error: cannot rebuild firmware volume")
+        fv_data = firmware.build(generate_checksum=True, debug=True)
+
+    return fv_data, count
+
+
+def patch_firmware_volume(input_path, output_path, old_string, new_string):
+    # Convert strings to bytes if needed and create UTF-16LE versions
+    if isinstance(old_string, str):
+        old_string = old_string.encode('ascii')
+    if isinstance(new_string, str):
+        new_string = new_string.encode('ascii')
+
+    old_string_utf16 = old_string.decode('ascii').encode('utf-16-le')
+    new_string_utf16 = new_string.decode('ascii').encode('utf-16-le')
+
+    print(f"Reading firmware volume from: {input_path}")
+
+    # Read the entire firmware volume
+    with open(input_path, 'rb') as f:
+        fv_data = f.read()
+
+    print(f"Firmware volume size: {len(fv_data)} bytes")
+
+    total_replacements = 0
+    fv_data, total_replacements = _patch_firmware_volume(fv_data, old_string, new_string, old_string_utf16, new_string_utf16)
+    print(f"Replaced {total_replacements} via UEFI parsing")
+
+    print("\n=== Final pass on raw firmware data ===")
+    modified_data, direct_count = find_and_replace_in_data(fv_data, old_string, new_string, old_string_utf16, new_string_utf16)
+    total_replacements += direct_count
+
+    if total_replacements > 0:
+        print(f"\n{'='*60}")
+        print(f"Total replacements made: {total_replacements}")
+        print(f"{'='*60}")
+
+        with open(output_path, 'wb') as f:
+            f.write(modified_data)
+
+        print(f"\nPatched firmware written to: {output_path}")
+    else:
+        with open(output_path, 'wb') as f:
+            f.write(fv_data)
+        print("\nNo occurrences of the target string found")
+
+def main():
+    if len(sys.argv) != 5:
+        print("Usage: patchfv <input_fv> <output_fv> <old_string> <new_string>")
+        print()
+        print("Example: patchfv UEFI_NS.Fv UEFI_NS_patched.Fv '36.5.0-123456789012' '36.5.0-abcdefghijkl'")
+        print()
+        print("Note: old_string and new_string must be the same length to maintain firmware structure")
+        sys.exit(1)
+
+    input_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+    old_string = sys.argv[3]
+    new_string = sys.argv[4]
+
+    if not input_path.exists():
+        print(f"Error: Input file not found: {input_path}")
+        sys.exit(1)
+
+    if len(old_string) != len(new_string):
+        print(f"Error: old_string and new_string must be the same length")
+        print(f"  old_string: '{old_string}' ({len(old_string)} chars)")
+        print(f"  new_string: '{new_string}' ({len(new_string)} chars)")
+        sys.exit(1)
+
+    print(f"Old string: {old_string}")
+    print(f"New string: {new_string}")
+    print()
+
+    success = patch_firmware_volume(input_path, output_path, old_string, new_string)
+
+    if input_path.stat().st_size == output_path.stat().st_size:
+        print("\n✓ Success: Output file size matches input (in-place replacement)")
+    else:
+        print(f"\n⚠ Warning: File size changed (input: {input_path.stat().st_size}, "
+                f"output: {output_path.stat().st_size})")
+
+if __name__ == '__main__':
+    main()

--- a/pkgs/patchfv/patchfv.py
+++ b/pkgs/patchfv/patchfv.py
@@ -1,0 +1,165 @@
+import logging
+from pathlib import Path
+import sys
+
+import uefi_firmware
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def find_and_replace_in_data(
+    data, old_string, new_string, old_string_utf16, new_string_utf16
+):
+    original_len = len(data)
+    replacements = 0
+
+    utf8_count = data.count(old_string)
+    if utf8_count > 0:
+        data = data.replace(old_string, new_string)
+        replacements += utf8_count
+        print(f"  Found and replaced {utf8_count} UTF-8 occurrence(s)")
+
+    utf16_count = data.count(old_string_utf16)
+    if utf16_count > 0:
+        data = data.replace(old_string_utf16, new_string_utf16)
+        replacements += utf16_count
+        print(f"  Found and replaced {utf16_count} UTF-16LE occurrence(s)")
+
+    assert (
+        len(data) == original_len
+    ), "Replacement strings must be same length as original!"
+
+    return data, replacements
+
+
+def _patch_firmware_object(
+    object, old_string, new_string, old_string_utf16, new_string_utf16
+):
+    count = 0
+
+    if hasattr(object, "objects") and any(object.objects):
+        for subobject in object.objects:
+            count += _patch_firmware_object(
+                subobject, old_string, new_string, old_string_utf16, new_string_utf16
+            )
+    elif hasattr(object, "data"):
+        new_data, count = find_and_replace_in_data(
+            object.data, old_string, new_string, old_string_utf16, new_string_utf16
+        )
+        object.data = new_data
+
+    return count
+
+
+def _patch_firmware_volume(
+    fv_data, old_string, new_string, old_string_utf16, new_string_utf16
+):
+    parser = uefi_firmware.AutoParser(fv_data)
+    if not parser.type():
+        raise Exception("Error: could not detect firmware volume type")
+
+    print(f"Detected firwmare type: {parser.type()}")
+    firmware = parser.parse()
+
+    count = _patch_firmware_object(
+        firmware, old_string, new_string, old_string_utf16, new_string_utf16
+    )
+
+    if count > 0:
+        if not hasattr(firmware, "build"):
+            raise Exception("Error: cannot rebuild firmware volume")
+        fv_data = firmware.build(generate_checksum=True, debug=True)
+
+    return fv_data, count
+
+
+def patch_firmware_volume(input_path, output_path, old_string, new_string):
+    # Convert strings to bytes if needed and create UTF-16LE versions
+    if isinstance(old_string, str):
+        old_string = old_string.encode("ascii")
+    if isinstance(new_string, str):
+        new_string = new_string.encode("ascii")
+
+    old_string_utf16 = old_string.decode("ascii").encode("utf-16-le")
+    new_string_utf16 = new_string.decode("ascii").encode("utf-16-le")
+
+    print(f"Reading firmware volume from: {input_path}")
+
+    # Read the entire firmware volume
+    with open(input_path, "rb") as f:
+        fv_data = f.read()
+
+    print(f"Firmware volume size: {len(fv_data)} bytes")
+
+    total_replacements = 0
+    fv_data, total_replacements = _patch_firmware_volume(
+        fv_data, old_string, new_string, old_string_utf16, new_string_utf16
+    )
+    print(f"Replaced {total_replacements} via UEFI parsing")
+
+    print("\n=== Final pass on raw firmware data ===")
+    modified_data, direct_count = find_and_replace_in_data(
+        fv_data, old_string, new_string, old_string_utf16, new_string_utf16
+    )
+    total_replacements += direct_count
+
+    if total_replacements > 0:
+        print(f"\n{'=' * 60}")
+        print(f"Total replacements made: {total_replacements}")
+        print(f"{'=' * 60}")
+
+        with open(output_path, "wb") as f:
+            f.write(modified_data)
+
+        print(f"\nPatched firmware written to: {output_path}")
+    else:
+        with open(output_path, "wb") as f:
+            f.write(fv_data)
+        print("\nNo occurrences of the target string found")
+
+
+def main():
+    if len(sys.argv) != 5:
+        print("Usage: patchfv <input_fv> <output_fv> <old_string> <new_string>")
+        print()
+        print(
+            "Example: patchfv UEFI_NS.Fv UEFI_NS_patched.Fv '36.5.0-123456789012' '36.5.0-abcdefghijkl'"
+        )
+        print()
+        print(
+            "Note: old_string and new_string must be the same length to maintain firmware structure"
+        )
+        sys.exit(1)
+
+    input_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+    old_string = sys.argv[3]
+    new_string = sys.argv[4]
+
+    if not input_path.exists():
+        print(f"Error: Input file not found: {input_path}")
+        sys.exit(1)
+
+    if len(old_string) != len(new_string):
+        print("Error: old_string and new_string must be the same length")
+        print(f"  old_string: '{old_string}' ({len(old_string)} chars)")
+        print(f"  new_string: '{new_string}' ({len(new_string)} chars)")
+        sys.exit(1)
+
+    print(f"Old string: {old_string}")
+    print(f"New string: {new_string}")
+    print()
+
+    patch_firmware_volume(input_path, output_path, old_string, new_string)
+
+    if input_path.stat().st_size == output_path.stat().st_size:
+        print("\n✓ Success: Output file size matches input (in-place replacement)")
+    else:
+        print(
+            f"\n⚠ Warning: File size changed (input: {input_path.stat().st_size}, "
+            f"output: {output_path.stat().st_size})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/uefi-firmware/r35/default.nix
+++ b/pkgs/uefi-firmware/r35/default.nix
@@ -16,6 +16,7 @@
 , applyPatches
 , nukeReferences
 , l4tMajorMinorPatchVersion
+, patchfv
 , uniqueHash ? ""
 , # Optional path to a boot logo that will be converted and cropped into the format required
   bootLogo ? null
@@ -244,13 +245,10 @@ let
           buildPhase = ''
             runHook preBuild
 
-            # Keep in sync with passthru.biosVersion below
-            BUILD_HASH=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
-
             # The BUILDID_STRING and BUILD_DATE_TIME are used
             # just by nvidia, not generic edk2
             build -a ${targetArch} -b ${buildTarget} -t ${buildType} -p Platform/NVIDIA/${platformBuild}/${platformBuild}.dsc -n $NIX_BUILD_CORES \
-              -D BUILDID_STRING="${l4tMajorMinorPatchVersion}-''${BUILD_HASH}" \
+              -D BUILDID_STRING="${fakeVersion}" \
               -D BUILD_DATE_TIME="$(date --utc --iso-8601=seconds --date=@$SOURCE_DATE_EPOCH)" \
               ${lib.optionalString (trustedPublicCertPemFile != null) "-D CUSTOM_CAPSULE_CERT"} \
               $buildFlags
@@ -278,7 +276,7 @@ let
         };
     };
 
-  uefi-firmware = mkJetsonUefi (finalAttrs: {
+  unstamped-firmware = mkJetsonUefi {
     platformBuild = "Jetson";
     outputs = [
       "FV/UEFI_NS.Fv"
@@ -296,9 +294,27 @@ let
         mv $filename $out/dtbs/$(basename "$filename" ".dtb").dtbo
       done
     '';
+  };
 
-    passthru.biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
-  });
+  fakeHash = "123456789012";
+  fakeVersion = "${l4tMajorMinorPatchVersion}-${fakeHash}";
+  biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${unstamped-firmware}");
+
+  uefi-firmware = runCommand "${unstamped-firmware.pname}-${unstamped-firmware.version}-stamped"
+    {
+      nativeBuildInputs = [ python3 buildPackages.nvidia-jetpack.patchfv ];
+      passthru = { inherit biosVersion; };
+    } ''
+    mkdir -p $out
+    cp -r ${unstamped-firmware}/* $out
+
+    rm $out/UEFI_NS.Fv $out/uefi_jetson.bin
+    patchfv ${unstamped-firmware}/UEFI_NS.Fv $out/UEFI_NS.Fv ${fakeVersion} ${biosVersion}
+
+    python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+  '';
 
   jetsonStandaloneMMOptee = mkJetsonUefi (finalAttrs: {
     platformBuild = "StandaloneMmOptee";

--- a/pkgs/uefi-firmware/r35/default.nix
+++ b/pkgs/uefi-firmware/r35/default.nix
@@ -178,100 +178,105 @@ let
   buildTarget = if debugMode then "DEBUG" else "RELEASE";
 
   mkJetsonUefi =
-    { platformBuild
-    , outputs
-    }:
-    let
-      _outputs = builtins.map (s: "Build/*/*/" + s) outputs;
-    in
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "${platformBuild}-edk2-uefi";
-      version = l4tMajorMinorPatchVersion;
+    lib.extendMkDerivation {
+      constructDrv = stdenv.mkDerivation;
+      excludeDrvArgNames = [ "platformBuild" "outputs" ];
+      extendDrvArgs = finalAttrs: { platformBuild, outputs, nativeBuildInputs ? [ ], depsBuildBuild ? [ ], patches ? [ ], meta ? { }, NIX_CFLAGS_COMPILE ? [ ], ... }:
+        let
+          _outputs = builtins.map (s: "Build/*/*/" + s) outputs;
+        in
+        {
+          pname = "${platformBuild}-edk2-uefi";
+          version = l4tMajorMinorPatchVersion;
 
-      # Initialize the build dir with the build tools from edk2
-      src = edk2-src;
+          # Initialize the build dir with the build tools from edk2
+          src = edk2-src;
 
-      depsBuildBuild = [ buildPackages.stdenv.cc ];
-      nativeBuildInputs = [ bc pythonEnv acpica-tools dtc unixtools.whereis ];
-      strictDeps = true;
+          depsBuildBuild = depsBuildBuild ++ [ buildPackages.stdenv.cc ];
+          nativeBuildInputs = nativeBuildInputs ++ [ bc pythonEnv acpica-tools dtc unixtools.whereis nukeReferences ];
+          strictDeps = true;
 
-      NIX_CFLAGS_COMPILE = [
-        "-Wno-error=format-security" # TODO: Fix underlying issue
+          NIX_CFLAGS_COMPILE = NIX_CFLAGS_COMPILE ++ [
+            "-Wno-error=format-security" # TODO: Fix underlying issue
 
-        # Workaround for ../Silicon/NVIDIA/Drivers/EqosDeviceDxe/nvethernetrm/osi/core/osi_hal.c:1428: undefined reference to `__aarch64_ldadd4_sync'
-        "-mno-outline-atomics"
-      ];
+            # Workaround for ../Silicon/NVIDIA/Drivers/EqosDeviceDxe/nvethernetrm/osi/core/osi_hal.c:1428: undefined reference to `__aarch64_ldadd4_sync'
+            "-mno-outline-atomics"
+          ];
 
-      ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+          ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
 
-      # From edk2-nvidia/Silicon/NVIDIA/edk2nv/stuart/settings.py
-      PACKAGES_PATH = lib.concatStringsSep ":" [
-        "${edk2-src}/BaseTools" # TODO: Is this needed?
-        finalAttrs.src
-        edk2-platforms
-        edk2-non-osi
-        edk2-nvidia
-        edk2-nvidia-non-osi
-        "${edk2-platforms}/Features/Intel/OutOfBandManagement"
-      ];
+          # From edk2-nvidia/Silicon/NVIDIA/edk2nv/stuart/settings.py
+          PACKAGES_PATH = lib.concatStringsSep ":" [
+            "${edk2-src}/BaseTools" # TODO: Is this needed?
+            finalAttrs.src
+            edk2-platforms
+            edk2-non-osi
+            edk2-nvidia
+            edk2-nvidia-non-osi
+            "${edk2-platforms}/Features/Intel/OutOfBandManagement"
+          ];
 
-      enableParallelBuilding = true;
+          enableParallelBuilding = true;
 
-      prePatch = ''
-        rm -rf BaseTools
-        cp -r ${edk2-jetson}/BaseTools BaseTools
-        chmod -R u+w BaseTools
-      '';
+          prePatch = ''
+            rm -rf BaseTools
+            cp -r ${edk2-jetson}/BaseTools BaseTools
+            chmod -R u+w BaseTools
+          '';
 
-      patches = edk2UefiPatches;
+          patches = edk2UefiPatches ++ patches;
 
-      configurePhase = ''
-        runHook preConfigure
-        export WORKSPACE="$PWD"
-        source ./edksetup.sh BaseTools
+          configurePhase = ''
+            runHook preConfigure
+            export WORKSPACE="$PWD"
+            source ./edksetup.sh BaseTools
 
-        ${lib.optionalString (trustedPublicCertPemFile != null) ''
-        echo Using ${trustedPublicCertPemFile} as public certificate for capsule verification
-        ${lib.getExe buildPackages.openssl} x509 -outform DER -in ${trustedPublicCertPemFile} -out PublicCapsuleKey.cer
-        python3 BaseTools/Scripts/BinToPcd.py -p gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer -i PublicCapsuleKey.cer -o PublicCapsuleKey.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
-        python3 BaseTools/Scripts/BinToPcd.py -x -p gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr -i PublicCapsuleKey.cer -o PublicCapsuleKey.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
-        ''}
+            ${lib.optionalString (trustedPublicCertPemFile != null) ''
+            echo Using ${trustedPublicCertPemFile} as public certificate for capsule verification
+            ${lib.getExe buildPackages.openssl} x509 -outform DER -in ${trustedPublicCertPemFile} -out PublicCapsuleKey.cer
+            python3 BaseTools/Scripts/BinToPcd.py -p gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer -i PublicCapsuleKey.cer -o PublicCapsuleKey.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
+            python3 BaseTools/Scripts/BinToPcd.py -x -p gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr -i PublicCapsuleKey.cer -o PublicCapsuleKey.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+            ''}
 
-        runHook postConfigure
-      '';
+            runHook postConfigure
+          '';
 
-      buildPhase = ''
-        runHook preBuild
+          buildPhase = ''
+            runHook preBuild
 
-        # Keep in sync with passthru.biosVersion below
-        BUILD_HASH=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
+            # Keep in sync with passthru.biosVersion below
+            BUILD_HASH=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
 
-        # The BUILDID_STRING and BUILD_DATE_TIME are used
-        # just by nvidia, not generic edk2
-        build -a ${targetArch} -b ${buildTarget} -t ${buildType} -p Platform/NVIDIA/${platformBuild}/${platformBuild}.dsc -n $NIX_BUILD_CORES \
-          -D BUILDID_STRING="${l4tMajorMinorPatchVersion}-''${BUILD_HASH}" \
-          -D BUILD_DATE_TIME="$(date --utc --iso-8601=seconds --date=@$SOURCE_DATE_EPOCH)" \
-          ${lib.optionalString (trustedPublicCertPemFile != null) "-D CUSTOM_CAPSULE_CERT"} \
-          $buildFlags
+            # The BUILDID_STRING and BUILD_DATE_TIME are used
+            # just by nvidia, not generic edk2
+            build -a ${targetArch} -b ${buildTarget} -t ${buildType} -p Platform/NVIDIA/${platformBuild}/${platformBuild}.dsc -n $NIX_BUILD_CORES \
+              -D BUILDID_STRING="${l4tMajorMinorPatchVersion}-''${BUILD_HASH}" \
+              -D BUILD_DATE_TIME="$(date --utc --iso-8601=seconds --date=@$SOURCE_DATE_EPOCH)" \
+              ${lib.optionalString (trustedPublicCertPemFile != null) "-D CUSTOM_CAPSULE_CERT"} \
+              $buildFlags
 
-        runHook postBuild
-      '';
+            runHook postBuild
+          '';
 
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out
-        # all-build-outputs and build log are helpful to have on hand when debugging issues
-        find ./Build ./Conf > $out/all-build-outputs
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            # all-build-outputs and build log are helpful to have on hand when debugging issues
+            find ./Build ./Conf > $out/all-build-outputs
 
-        for file in Build/BUILDLOG_*.txt ${builtins.concatStringsSep " " _outputs} ; do
-          mv -v $file $out/
-        done
+            for file in Build/BUILDLOG_*.txt ${builtins.concatStringsSep " " _outputs} ; do
+              mv -v $file $out/
+            done
 
-        runHook postInstall
-      '';
+            # Everything is statically linked
+            nuke-refs $out/*
 
-      meta.platforms = [ "aarch64-linux" ];
-    });
+            runHook postInstall
+          '';
+
+          meta = meta // { platforms = [ "aarch64-linux" ]; };
+        };
+    };
 
   jetson-edk2-uefi = mkJetsonUefi {
     platformBuild = "Jetson";

--- a/pkgs/uefi-firmware/r35/default.nix
+++ b/pkgs/uefi-firmware/r35/default.nix
@@ -278,48 +278,39 @@ let
         };
     };
 
-  jetson-edk2-uefi = mkJetsonUefi {
+  uefi-firmware = mkJetsonUefi (finalAttrs: {
     platformBuild = "Jetson";
     outputs = [
       "FV/UEFI_NS.Fv"
       "AARCH64/L4TLauncher.efi"
       "AARCH64/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree/OUTPUT/*.dtb"
     ];
-  };
-  jetson-edk-uefi-stmm-optee = mkJetsonUefi {
+
+    postInstall = ''
+      python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+
+      mkdir -p $out/dtbs
+      for filename in $out/*.dtb; do
+        mv $filename $out/dtbs/$(basename "$filename" ".dtb").dtbo
+      done
+    '';
+
+    passthru.biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
+  });
+
+  jetsonStandaloneMMOptee = mkJetsonUefi (finalAttrs: {
     platformBuild = "StandaloneMmOptee";
     outputs = [ "FV/UEFI_MM.Fv" ];
-  };
 
-  uefi-firmware = runCommand "uefi-firmware-${l4tMajorMinorPatchVersion}"
-    {
-      nativeBuildInputs = [ python3 nukeReferences ];
-      # Keep in sync with BUILDID_STRING and BUILD_HASH above
-      passthru.biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${jetson-edk2-uefi}");
-    } ''
-    mkdir -p $out
-    python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
-      ${jetson-edk2-uefi}/UEFI_NS.Fv \
-      $out/uefi_jetson.bin
-
-    python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
-      ${jetson-edk2-uefi}/L4TLauncher.efi \
-      $out/L4TLauncher.efi
-
-    python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
-      ${jetson-edk-uefi-stmm-optee}/UEFI_MM.Fv \
-      $out/standalonemm_optee.bin
-
-    mkdir -p $out/dtbs
-    for filename in ${jetson-edk2-uefi}/*.dtb; do
-      cp $filename $out/dtbs/$(basename "$filename" ".dtb").dtbo
-    done
-
-    # Get rid of any string references to source(s)
-    nuke-refs $out/uefi_jetson.bin
-    nuke-refs $out/standalonemm_optee.bin
-  '';
+    postInstall = ''
+      python3 ${edk2-nvidia}/Silicon/NVIDIA/Tools/FormatUefiBinary.py \
+        $out/UEFI_MM.Fv \
+        $out/standalonemm_optee.bin
+    '';
+  });
 in
 {
-  inherit edk2-jetson uefi-firmware;
+  inherit uefi-firmware jetsonStandaloneMMOptee;
 }

--- a/pkgs/uefi-firmware/r36/default.nix
+++ b/pkgs/uefi-firmware/r36/default.nix
@@ -7,6 +7,7 @@
 , applyPatches
 , nukeReferences
 , l4tMajorMinorPatchVersion
+, patchfv
 , uniqueHash ? ""
 , socFamily ? "t23x"
 , defconfig ? "${socFamily}_general"
@@ -103,7 +104,11 @@ let
     };
   };
 
-  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; });
+  fakeHash = "123456789012";
+  fakeVersion = "${l4tMajorMinorPatchVersion}-${fakeHash}";
+  biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${jetsonUefi}");
+
+  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; uniqueHash = fakeHash; });
 
   jetsonUefi = mkStuartDrv {
     platformBuild = "Tegra";
@@ -123,27 +128,27 @@ let
   uefi-firmware = runCommand "uefi-firmware-${l4tMajorMinorPatchVersion}"
     {
       nativeBuildInputs = [ python3 nukeReferences ];
-      # Keep in sync with FIRMWARE_VERSION_BASE and GIT_SYNC_REVISION above
       passthru = {
-        biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${jetsonUefi}");
-        inherit jetsonUefi jetsonStandaloneMMOptee;
+        inherit biosVersion jetsonUefi jetsonStandaloneMMOptee;
       } // patchedRepos;
     }
     ''
       mkdir -p $out
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/UEFI_NS.Fv \
-        $out/uefi_jetson.bin
+
+      ${lib.getExe patchfv} ${jetsonUefi}/UEFI_NS.Fv $out/UEFI_NS.Fv ${fakeVersion} ${biosVersion}
 
       python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/L4TLauncher.efi \
-        $out/L4TLauncher.efi
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+
+      cp ${jetsonUefi}/L4TLauncher.efi $out/L4TLauncher.efi
 
       python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
         ${jetsonStandaloneMMOptee}/UEFI_MM.Fv \
         $out/standalonemm_optee.bin
 
       # Get rid of any string references to source(s)
+      nuke-refs $out/UEFI_NS.Fv
       nuke-refs $out/uefi_jetson.bin
       nuke-refs $out/standalonemm_optee.bin
     '';

--- a/pkgs/uefi-firmware/r36/default.nix
+++ b/pkgs/uefi-firmware/r36/default.nix
@@ -105,7 +105,7 @@ let
 
   mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; });
 
-  jetsonUefi = mkStuartDrv {
+  uefi-firmware = mkStuartDrv (finalAttrs: {
     platformBuild = "Tegra";
     stuartExtraArgs = "--init-defconfig edk2-nvidia/Platform/NVIDIA/Tegra/DefConfigs/${defconfig}.defconfig";
     outputs = [
@@ -113,43 +113,31 @@ let
       "AARCH64/L4TLauncher.efi"
       "AARCH64/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree/OUTPUT/*.dtb"
     ];
-  };
+
+    postInstall = ''
+      python3 edk2-nvidia/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+    '';
+
+    passthru = {
+      biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
+    };
+  });
 
   jetsonStandaloneMMOptee = mkStuartDrv {
     platformBuild = "StandaloneMmOptee";
     outputs = [ "FV/UEFI_MM.Fv" ];
-  };
 
-  uefi-firmware = runCommand "uefi-firmware-${l4tMajorMinorPatchVersion}"
-    {
-      nativeBuildInputs = [ python3 nukeReferences ];
-      # Keep in sync with FIRMWARE_VERSION_BASE and GIT_SYNC_REVISION above
-      passthru = {
-        biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${jetsonUefi}");
-        inherit jetsonUefi jetsonStandaloneMMOptee;
-      } // patchedRepos;
-    }
-    ''
-      mkdir -p $out
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/UEFI_NS.Fv \
-        $out/uefi_jetson.bin
-
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/L4TLauncher.efi \
-        $out/L4TLauncher.efi
-
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonStandaloneMMOptee}/UEFI_MM.Fv \
+    postInstall = ''
+      python3 edk2-nvidia/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_MM.Fv \
         $out/standalonemm_optee.bin
-
-      # Get rid of any string references to source(s)
-      nuke-refs $out/uefi_jetson.bin
-      nuke-refs $out/standalonemm_optee.bin
     '';
+  };
 in
 {
-  inherit uefi-firmware;
+  inherit uefi-firmware jetsonStandaloneMMOptee;
 }
 
 

--- a/pkgs/uefi-firmware/r36/default.nix
+++ b/pkgs/uefi-firmware/r36/default.nix
@@ -1,4 +1,5 @@
 { lib
+, buildPackages
 , callPackage
 , fetchFromGitHub
 , fetchpatch
@@ -7,6 +8,7 @@
 , applyPatches
 , nukeReferences
 , l4tMajorMinorPatchVersion
+, patchfv
 , uniqueHash ? ""
 , socFamily ? "t23x"
 , defconfig ? "${socFamily}_general"
@@ -103,9 +105,13 @@ let
     };
   };
 
-  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; });
+  fakeHash = "123456789012";
+  fakeVersion = "${l4tMajorMinorPatchVersion}-${fakeHash}";
+  biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${unstamped-firmware}");
 
-  uefi-firmware = mkStuartDrv (finalAttrs: {
+  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; uniqueHash = fakeHash; });
+
+  unstamped-firmware = mkStuartDrv {
     platformBuild = "Tegra";
     stuartExtraArgs = "--init-defconfig edk2-nvidia/Platform/NVIDIA/Tegra/DefConfigs/${defconfig}.defconfig";
     outputs = [
@@ -119,11 +125,23 @@ let
         $out/UEFI_NS.Fv \
         $out/uefi_jetson.bin
     '';
+  };
 
-    passthru = {
-      biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
-    };
-  });
+  uefi-firmware = runCommand "${unstamped-firmware.pname}-${unstamped-firmware.version}-stamped"
+    {
+      nativeBuildInputs = [ python3 buildPackages.nvidia-jetpack.patchfv ];
+      passthru = { inherit biosVersion; };
+    } ''
+    mkdir -p $out
+    cp -r ${unstamped-firmware}/* $out
+
+    rm $out/UEFI_NS.Fv $out/uefi_jetson.bin
+    patchfv ${unstamped-firmware}/UEFI_NS.Fv $out/UEFI_NS.Fv ${fakeVersion} ${biosVersion}
+
+    python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+  '';
 
   jetsonStandaloneMMOptee = mkStuartDrv {
     platformBuild = "StandaloneMmOptee";

--- a/pkgs/uefi-firmware/r38/default.nix
+++ b/pkgs/uefi-firmware/r38/default.nix
@@ -1,4 +1,5 @@
 { lib
+, buildPackages
 , callPackage
 , fetchFromGitHub
 , fetchpatch
@@ -7,6 +8,7 @@
 , applyPatches
 , nukeReferences
 , l4tMajorMinorPatchVersion
+, patchfv
 , uniqueHash ? ""
 , socFamily ? "t26x"
 , defconfig ? "${socFamily}_general"
@@ -89,14 +91,19 @@ let
     };
   };
 
-  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; });
+  fakeHash = "123456789012";
+  fakeVersion = "${l4tMajorMinorPatchVersion}-${fakeHash}";
+  biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${unstamped-firmware}");
 
-  uefi-firmware = mkStuartDrv (finalAttrs: {
+  mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; uniqueHash = fakeHash; });
+
+  unstamped-firmware = mkStuartDrv {
     platformBuild = "Tegra";
     stuartExtraArgs = "--init-defconfig edk2-nvidia/Platform/NVIDIA/Tegra/DefConfigs/${defconfig}.defconfig";
     outputs = [
       "FV/UEFI_NS.Fv"
       "AARCH64/L4TLauncher.efi"
+      "AARCH64/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree/OUTPUT/*.dtb"
     ];
 
     postInstall = ''
@@ -104,11 +111,23 @@ let
         $out/UEFI_NS.Fv \
         $out/uefi_jetson.bin
     '';
+  };
 
-    passthru = {
-      biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
-    };
-  });
+  uefi-firmware = runCommand "${unstamped-firmware.pname}-${unstamped-firmware.version}-stamped"
+    {
+      nativeBuildInputs = [ python3 buildPackages.nvidia-jetpack.patchfv ];
+      passthru = { inherit biosVersion; };
+    } ''
+    mkdir -p $out
+    cp -r ${unstamped-firmware}/* $out
+
+    rm $out/UEFI_NS.Fv $out/uefi_jetson.bin
+    patchfv ${unstamped-firmware}/UEFI_NS.Fv $out/UEFI_NS.Fv ${fakeVersion} ${biosVersion}
+
+    python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+  '';
 
   jetsonStandaloneMMOptee = mkStuartDrv {
     platformBuild = "StandaloneMmOptee";

--- a/pkgs/uefi-firmware/r38/default.nix
+++ b/pkgs/uefi-firmware/r38/default.nix
@@ -91,51 +91,38 @@ let
 
   mkStuartDrv = callPackage ../stuart.nix (args // { srcs = patchedRepos; });
 
-  jetsonUefi = mkStuartDrv {
+  uefi-firmware = mkStuartDrv (finalAttrs: {
     platformBuild = "Tegra";
     stuartExtraArgs = "--init-defconfig edk2-nvidia/Platform/NVIDIA/Tegra/DefConfigs/${defconfig}.defconfig";
     outputs = [
       "FV/UEFI_NS.Fv"
       "AARCH64/L4TLauncher.efi"
     ];
-  };
+
+    postInstall = ''
+      python3 edk2-nvidia/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_NS.Fv \
+        $out/uefi_jetson.bin
+    '';
+
+    passthru = {
+      biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${finalAttrs.out}");
+    };
+  });
 
   jetsonStandaloneMMOptee = mkStuartDrv {
     platformBuild = "StandaloneMmOptee";
     outputs = [ "FV/UEFI_MM.Fv" ];
-  };
 
-  uefi-firmware = runCommand "uefi-firmware-${l4tMajorMinorPatchVersion}"
-    {
-      nativeBuildInputs = [ python3 nukeReferences ];
-      passthru = {
-        # Keep in sync with FIRMWARE_VERSION_BASE and GIT_SYNC_REVISION above
-        biosVersion = "${l4tMajorMinorPatchVersion}-" + lib.substring 0 12 (builtins.hashString "sha256" "${uniqueHash}-${jetsonUefi}");
-        inherit jetsonUefi jetsonStandaloneMMOptee;
-      } // patchedRepos;
-    }
-    (''
-      mkdir -p $out
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/UEFI_NS.Fv \
-        $out/uefi_jetson.bin
-
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonUefi}/L4TLauncher.efi \
-        $out/L4TLauncher.efi
-
-      # Get rid of any string references to source(s)
-      nuke-refs $out/uefi_jetson.bin
-    '' + lib.optionalString (socFamily == "t19x" || socFamily == "t23x") ''
-      python3 ${patchedRepos.edk2-nvidia}/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
-        ${jetsonStandaloneMMOptee}/UEFI_MM.Fv \
+    postInstall = ''
+      python3 edk2-nvidia/Silicon/NVIDIA/edk2nv/FormatUefiBinary.py \
+        $out/UEFI_MM.Fv \
         $out/standalonemm_optee.bin
-
-      nuke-refs $out/standalonemm_optee.bin
-    '');
+    '';
+  };
 in
 {
-  inherit uefi-firmware;
+  inherit uefi-firmware jetsonStandaloneMMOptee;
 }
 
 

--- a/pkgs/uefi-firmware/stuart.nix
+++ b/pkgs/uefi-firmware/stuart.nix
@@ -144,7 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     export LDFLAGS=$NIX_LDFLAGS_FOR_BUILD
 
     export WORKSPACE=$(pwd)
-    export GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
+    export GIT_SYNC_REVISION="${uniqueHash}"
     python edk2/BaseTools/Edk2ToolsBuild.py -t GCC5
     # DANGER: If someone else modifies PYTHONPATH, then we lose this
     # We're okay when this was written.

--- a/pkgs/uefi-firmware/stuart.nix
+++ b/pkgs/uefi-firmware/stuart.nix
@@ -10,6 +10,7 @@
 , which
 , nasm
 , applyPatches
+, nukeReferences
 , l4tMajorMinorPatchVersion
 , uniqueHash ? ""
 , # Optional path to a boot logo that will be converted and cropped into the format required
@@ -65,118 +66,126 @@ let
       "LOONGARCH64"
     else
       throw "Unsupported architecture";
-
 in
-{ platformBuild
-, outputs
-, stuartExtraArgs ? ""
-}:
-let
-  _outputs = builtins.map (s: "Build/*/*/" + s) outputs;
-in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "${platformBuild}-edk2-uefi-${buildTarget}";
-  version = l4tMajorMinorPatchVersion;
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [ "platformBuild" "outputs" "stuartExtraArgs" ];
+  extendDrvArgs = finalAttrs: { platformBuild, outputs, stuartExtraArgs ? "", nativeBuildInputs ? [ ], depsBuildBuild ? [ ], env ? { }, patches ? [ ], meta ? { }, ... }:
+    let
+      _outputs = builtins.map (s: "Build/*/*/" + s) outputs;
+    in
+    {
+      pname = "${platformBuild}-edk2-uefi-${buildTarget}";
+      version = l4tMajorMinorPatchVersion;
 
-  srcs = builtins.attrValues patchedSrcs;
+      srcs = builtins.attrValues patchedSrcs;
 
-  sourceRoot = ".";
+      sourceRoot = ".";
 
-  depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.bash libuuid ];
-  nativeBuildInputs = [
-    pythonEnv
+      depsBuildBuild = depsBuildBuild ++ [ buildPackages.stdenv.cc buildPackages.bash libuuid ];
+      nativeBuildInputs = nativeBuildInputs ++ [
+        pythonEnv
+        nukeReferences
 
-    # from nixpkgs, for stuart
-    acpica-tools
-    dtc
-    nasm
-    unixtools.whereis
-    which
-  ];
-  strictDeps = true;
+        # from nixpkgs, for stuart
+        acpica-tools
+        dtc
+        nasm
+        unixtools.whereis
+        which
+      ];
+      strictDeps = true;
 
-  env = {
-    # NVIDIA's PrePI performs C function calls before stack has been set up.
-    # https://github.com/NVIDIA/edk2-nvidia/blob/r38.2/Silicon/NVIDIA/Library/TegraPlatformInfoLib/AArch64/TegraPlatformInfo.S#L61
-    # https://github.com/NVIDIA/edk2-nvidia/blob/r38.2/Silicon/NVIDIA/Library/TegraPlatformInfoLib/TegraPlatformInfoLib.c#L24
-    # nixos/nixpkgs#399014 enables `-fno-omit-frame-pointer` by default which
-    # causes PrePI to try to derefence uninitalized stack pointer.
-    NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
+      env = {
+        # NVIDIA's PrePI performs C function calls before stack has been set up.
+        # https://github.com/NVIDIA/edk2-nvidia/blob/r38.2/Silicon/NVIDIA/Library/TegraPlatformInfoLib/AArch64/TegraPlatformInfo.S#L61
+        # https://github.com/NVIDIA/edk2-nvidia/blob/r38.2/Silicon/NVIDIA/Library/TegraPlatformInfoLib/TegraPlatformInfoLib.c#L24
+        # nixos/nixpkgs#399014 enables `-fno-omit-frame-pointer` by default which
+        # causes PrePI to try to derefence uninitalized stack pointer.
+        NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
 
-    # stuart (nvidia extensions) really wants CROSS_COMPILER_PREFIX to look like this
-    CROSS_COMPILER_PREFIX = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
-    # Version is ${FIRMWARE_VERSION_BASE}-${GIT_SYNC_REVISION}
-    FIRMWARE_VERSION_BASE = "${l4tMajorMinorPatchVersion}";
+        # stuart (nvidia extensions) really wants CROSS_COMPILER_PREFIX to look like this
+        CROSS_COMPILER_PREFIX = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
+        # Version is ${FIRMWARE_VERSION_BASE}-${GIT_SYNC_REVISION}
+        FIRMWARE_VERSION_BASE = "${l4tMajorMinorPatchVersion}";
 
-    # Needed for Edk2ToolsBuild
-    # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
-    ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-    ${"GCC_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-  };
+        # Needed for Edk2ToolsBuild
+        # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
+        ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+        ${"GCC_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+      } // env;
 
-  # see nixpkgs/pkgs/by-name/ed/edk2/package.nix
-  hardeningDisable = [
-    "format"
-    "fortify"
-  ];
+      # see nixpkgs/pkgs/by-name/ed/edk2/package.nix
+      hardeningDisable = [
+        "format"
+        "fortify"
+      ];
 
-  patches = edk2UefiPatches;
+      patches = edk2UefiPatches ++ patches;
 
-  patchPhase = ''
-    find . -name \*_ext_dep.yaml -delete
-    patchShebangs .
-  '' + lib.optionalString errorLevelInfo ''
-    sed -i 's#PcdDebugPrintErrorLevel|.*#PcdDebugPrintErrorLevel|0x8000004F#' edk2-nvidia/Platform/NVIDIA/NVIDIA.common.dsc.inc
-  '' + lib.optionalString (bootLogo != null) ''
-    cp ${bootLogoVariants}/logo1080.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray1080.bmp
-    cp ${bootLogoVariants}/logo720.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray720.bmp
-    cp ${bootLogoVariants}/logo480.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray480.bmp
-  '';
+      patchPhase = ''
+        runHook prePatch
 
-  configurePhase = ''
-    runHook preConfigure
+        find . -name \*_ext_dep.yaml -delete
+        patchShebangs .
+      '' + lib.optionalString errorLevelInfo ''
+        sed -i 's#PcdDebugPrintErrorLevel|.*#PcdDebugPrintErrorLevel|0x8000004F#' edk2-nvidia/Platform/NVIDIA/NVIDIA.common.dsc.inc
+      '' + lib.optionalString (bootLogo != null) ''
+        cp ${bootLogoVariants}/logo1080.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray1080.bmp
+        cp ${bootLogoVariants}/logo720.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray720.bmp
+        cp ${bootLogoVariants}/logo480.bmp edk2-nvidia/Silicon/NVIDIA/Drivers/Logo/nvidiagray480.bmp
 
-    export CC=$CC_FOR_BUILD
-    export LD=$LD_FOR_BUILD
-    export CPP=$CPP_FOR_BUILD
-    export CXX=$CXX_FOR_BUILD
-    export CFLAGS=$NIX_CFLAGS_COMPILE_FOR_BUILD
-    export LDFLAGS=$NIX_LDFLAGS_FOR_BUILD
+        runHook postPatch
+      '';
 
-    export WORKSPACE=$(pwd)
-    export GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
-    python edk2/BaseTools/Edk2ToolsBuild.py -t GCC5
-    # DANGER: If someone else modifies PYTHONPATH, then we lose this
-    # We're okay when this was written.
-    export PYTHONPATH=$(pwd)/edk2-nvidia/Silicon/NVIDIA
+      configurePhase = ''
+        runHook preConfigure
 
-    ${lib.optionalString (trustedPublicCertPemFile != null) ''
-    echo Using ${trustedPublicCertPemFile} as public certificate for capsule verification
-    ${lib.getExe buildPackages.openssl} x509 -outform DER -in ${trustedPublicCertPemFile} -out edk2/PublicCapsuleKey.cer
-    python3 edk2/BaseTools/Scripts/BinToPcd.py -p gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer -i edk2/PublicCapsuleKey.cer -o edk2/PublicCapsuleKey.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
-    python3 edk2/BaseTools/Scripts/BinToPcd.py -x -p gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr -i edk2/PublicCapsuleKey.cer -o edk2/PublicCapsuleKey.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
-    ''}
+        export CC=$CC_FOR_BUILD
+        export LD=$LD_FOR_BUILD
+        export CPP=$CPP_FOR_BUILD
+        export CXX=$CXX_FOR_BUILD
+        export CFLAGS=$NIX_CFLAGS_COMPILE_FOR_BUILD
+        export LDFLAGS=$NIX_LDFLAGS_FOR_BUILD
 
-    runHook postConfigure
-  '';
+        export WORKSPACE=$(pwd)
+        export GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
+        python edk2/BaseTools/Edk2ToolsBuild.py -t GCC5
+        # DANGER: If someone else modifies PYTHONPATH, then we lose this
+        # We're okay when this was written.
+        export PYTHONPATH=$(pwd)/edk2-nvidia/Silicon/NVIDIA
 
-  buildPhase = ''
-    stuart_setup -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py"
-    stuart_build -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py" ${stuartExtraArgs} --target ${buildTarget}
-  '';
+        ${lib.optionalString (trustedPublicCertPemFile != null) ''
+        echo Using ${trustedPublicCertPemFile} as public certificate for capsule verification
+        ${lib.getExe buildPackages.openssl} x509 -outform DER -in ${trustedPublicCertPemFile} -out edk2/PublicCapsuleKey.cer
+        python3 edk2/BaseTools/Scripts/BinToPcd.py -p gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer -i edk2/PublicCapsuleKey.cer -o edk2/PublicCapsuleKey.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
+        python3 edk2/BaseTools/Scripts/BinToPcd.py -x -p gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr -i edk2/PublicCapsuleKey.cer -o edk2/PublicCapsuleKey.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+        ''}
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out
-    # all-build-outputs and build log are helpful to have on hand when debugging issues
-    find ./Build ./Conf > $out/all-build-outputs
+        runHook postConfigure
+      '';
 
-    for file in Build/BUILDLOG_*.txt ${builtins.concatStringsSep " " _outputs} ; do
-      mv -v $file $out/
-    done
+      buildPhase = ''
+        stuart_setup -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py"
+        stuart_build -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py" ${stuartExtraArgs} --target ${buildTarget}
+      '';
 
-    runHook postInstall
-  '';
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out
+        # all-build-outputs and build log are helpful to have on hand when debugging issues
+        find ./Build ./Conf > $out/all-build-outputs
 
-  meta.platforms = [ "aarch64-linux" ];
-})
+        for file in Build/BUILDLOG_*.txt ${builtins.concatStringsSep " " _outputs} ; do
+          mv -v $file $out/
+        done
+
+        # Everything is statically linked
+        nuke-refs $out/*
+
+        runHook postInstall
+      '';
+
+      meta = meta // { platforms = [ "aarch64-linux" ]; };
+    };
+}

--- a/pkgs/uefi-firmware/stuart.nix
+++ b/pkgs/uefi-firmware/stuart.nix
@@ -149,7 +149,7 @@ lib.extendMkDerivation {
         export LDFLAGS=$NIX_LDFLAGS_FOR_BUILD
 
         export WORKSPACE=$(pwd)
-        export GIT_SYNC_REVISION=$(printf "%s-%s" "${uniqueHash}" "$out" | sha256sum | head -c 12)
+        export GIT_SYNC_REVISION="${uniqueHash}"
         python edk2/BaseTools/Edk2ToolsBuild.py -t GCC5
         # DANGER: If someone else modifies PYTHONPATH, then we lose this
         # We're okay when this was written.


### PR DESCRIPTION
###### Description of changes

When anything in the BUP changes (e.g. devicetree), it requires rebuilding all of uefi-firmware which takes several minutes in order to use the new BUP unique hash. To help increase the develop-test cycle, we can build EDK2 with a well-known version string and then do a find/replace to the unique version string using patchfv.

TODO:
 - [x] Use patchfv in r35
 - [x] Use patchfv in r36
 - [x] Use patchfv in r37
 - [x] Pull out StandaloneMMOPTEE into separate top-level drv so OP-TEE doesn't have to rebuild one BUP hash changes (possibly separate PR)

###### Testing

- [x] boot Orin JP6
- [x] boot JP5
- [x] boot JP7