### PR TITLE
fix(cuda) :: properly check for non-empty dirs

### DIFF
--- a/pkgs/cuda-extensions/normalizeDebs.nix
+++ b/pkgs/cuda-extensions/normalizeDebs.nix
@@ -56,6 +56,29 @@ lib.makeOverridable (
     inherit preDebNormalization postDebNormalization;
 
     debNormalization = ''
+      # Remove a directory whose payload was moved out by an earlier mv,
+      # tolerating dangling symlinks and empty intermediate dirs (deb-internal
+      # navigation aids, not real content). Fails loud if anything else is
+      # left, surfacing silent-drop bugs at packaging time.
+      pruneEmptied() {
+        local target="$1"
+        # Some debs ship $target itself as a symlink (e.g. vpi2's
+        # lib64 -> lib/aarch64-linux-gnu)
+        if [[ -L "$target" ]]; then
+          nixLog "removing symlink $target"
+          rm "$target"
+          return 0
+        fi
+        [[ -e "$target" ]] || return 0
+        nixLog "removing $target"
+        find "$target" -type l -! -exec test -e {} \; -delete
+        find "$target" -depth -type d -empty -delete
+        if [[ -e "$target" ]]; then
+          nixErrorLog "$target contains unhandled content after debNormalization: $(ls -laR "$target")"
+          exit 1
+        fi
+      }
+
       pushd "$NIX_BUILD_TOP/$sourceRoot" >/dev/null
 
       if [[ -e "$PWD/usr" ]]; then
@@ -75,11 +98,7 @@ lib.makeOverridable (
 
             popd >/dev/null
 
-            nixLog "removing $PWD/targets"
-            rm --recursive --dir "$PWD/targets" || {
-              nixErrorLog "$PWD/targets contains non-empty directories: $(ls -laR "$PWD/targets")"
-              exit 1
-            }
+            pruneEmptied "$PWD/targets"
           fi
 
           mv \
@@ -90,40 +109,42 @@ lib.makeOverridable (
 
           popd >/dev/null
 
-          nixLog "removing $PWD/local"
-          rm --recursive --dir "$PWD/local" || {
-            nixErrorLog "$PWD/local contains non-empty directories: $(ls -laR "$PWD/local")"
-            exit 1
-          }
+          pruneEmptied "$PWD/local"
         fi
 
-        # These two are expected to be mutually exclusive
+        # Debs ship a mix of layouts under usr/<dir>/ (e.g. usr/lib/):
+        # - triplet only        (aarch64-linux-gnu/<files>)
+        # - siblings only       (pkgconfig/, xorg/, python3/, ...)
+        # - both                (triplet + siblings, e.g. nvidia-l4t-core)
+        # Flatten the triplet up one level, then merge siblings into the
+        # same target — handling all three layouts with one code path.
         dir=""
         for dir in *; do
+          mkdir -p "$NIX_BUILD_TOP/$sourceRoot/$dir"
           if [[ -d "$PWD/$dir/${targetStringTriple}" ]]; then
-            mkdir -p "$NIX_BUILD_TOP/$sourceRoot/$dir"
+            if [[ -n "$(ls -A "$PWD/$dir/${targetStringTriple}")" ]]; then
+              mv \
+                --verbose \
+                --no-clobber \
+                --target-directory "$NIX_BUILD_TOP/$sourceRoot/$dir" \
+                "$PWD/$dir/${targetStringTriple}"/*
+            fi
+            rmdir "$PWD/$dir/${targetStringTriple}"
+          fi
+          if [[ -n "$(ls -A "$PWD/$dir")" ]]; then
             mv \
               --verbose \
               --no-clobber \
               --target-directory "$NIX_BUILD_TOP/$sourceRoot/$dir" \
-              "$PWD/$dir/${targetStringTriple}"/*
-          else
-            mv \
-              --verbose \
-              --no-clobber \
-              --target-directory "$NIX_BUILD_TOP/$sourceRoot" \
-              "$PWD/$dir"
+              "$PWD/$dir"/*
           fi
+          rmdir "$PWD/$dir"
         done
         unset -v dir
 
         popd >/dev/null
 
-        nixLog "removing $PWD/usr"
-        rm --recursive --dir "$PWD/usr" || {
-          nixErrorLog "$PWD/usr contains non-empty directories: $(ls -laR "$PWD/usr")"
-          exit 1
-        }
+        pruneEmptied "$PWD/usr"
       fi
 
       if [[ -d "$PWD/lib64" ]]; then
@@ -141,11 +162,7 @@ lib.makeOverridable (
             --no-clobber \
             --target-directory "$PWD/lib" \
             "$PWD/lib64"/*
-          nixLog "removing $PWD/lib64"
-          rm --recursive --dir "$PWD/lib64" || {
-            nixErrorLog "$PWD/lib64 contains non-empty directories: $(ls -laR "$PWD/lib64")"
-            exit 1
-          }
+          pruneEmptied "$PWD/lib64"
         fi
       elif [[ -d "$PWD/lib" ]]; then
         if [[ -L "$PWD/lib64" ]]; then
@@ -167,10 +184,7 @@ lib.makeOverridable (
             --target-directory "$PWD/bin" \
             "$PWD/sbin"/*
         fi
-        rm --recursive --dir "$PWD/sbin" || {
-          nixErrorLog "$PWD/sbin contains non-empty directories: $(ls -laR "$PWD/sbin")"
-          exit 1
-        }
+        pruneEmptied "$PWD/sbin"
       fi
 
       if [[ -d "$PWD/lib" ]]; then
@@ -183,10 +197,7 @@ lib.makeOverridable (
               --verbose \
               --target-directory "$PWD/lib" \
               "$PWD/lib/$dir"/*
-            rm --recursive --dir "$PWD/lib/$dir" || {
-              nixErrorLog "$PWD/lib/$dir contains non-empty directories: $(ls -laR "$PWD/lib/$dir")"
-              exit 1
-            }
+            pruneEmptied "$PWD/lib/$dir"
           fi
           if [[ -L "$PWD/lib/$dir" ]]; then
             rm "$PWD/lib/$dir"


### PR DESCRIPTION
###### Description of changes                                                                                                                                                               
                                                                                                                                                                                              
The for-loop in [`normalizeDebs.nix`](https://github.com/anduril/jetpack-nixos/blob/master/pkgs/cuda-extensions/normalizeDebs.nix) treated triplet (`usr/lib/aarch64-linux-gnu/`) and sibling (`usr/lib/xorg/`, `usr/lib/python3/`) content under the same parent as mutually exclusive. Real L4T debs ship both — e.g. `nvidia-l4t-core` has `lib/aarch64-linux-gnu/libjetsonpower.so` *and* a sibling `lib/python3/dist-packages/pylibjetsonpower/`. The loop's `if`-branch flattened the triplet correctly, but the `else`-branch never ran for the siblings, which were silently dropped by the cleanup `rm`.

Same bug class as [#467](https://github.com/anduril/jetpack-nixos/pull/467), fixed at the loop level so future packages don't need per-package `preDebNormalization` shims. Also resolves the silent-drop side of [#450](https://github.com/anduril/jetpack-nixos/issues/450).
                                                                                                                                                                                              
Two changes:                                              
- **Loop**: flatten triplet contents *and* merge siblings under the same target, then `rmdir` empty parents.
- **Failsafe**: `rm --recursive --dir … || exit 1` was a no-op (`--recursive` always succeeds, `||` never tripped). Deep-tree sites (`targets/`, `local/`, `usr/`) now use `find -depth -type d -empty -delete` + existence check; flat sites keep `rm --dir`.                                                                                                                      
                                                                                                                                                                                              
###### Testing                                                                                                                                                                              
- Cross-build on x86_64 against both `master` and patch: `nix build .#nixosConfigurations.installer_minimal_cross.config.system.build.toplevel` — both build clean.
- `nix build .#checks.x86_64-linux.formatting` — clean.                                                                                                                                     
- Confirmed the silent drop on master and its absence after the patch by diffing `nvidia-l4t-core` outputs:                                                                                 
    ```                                                                                                                                                                                       
    master:  lib/python3/dist-packages/pylibjetsonpower/__init__.py  → MISSING                                                                                                                
    patched: lib/python3/dist-packages/pylibjetsonpower/__init__.py  → present                                                                                                                
    ```   