### PR TITLE
feat(optee): add support for fTPM on JetPack 6

### DIFF
--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -11,6 +11,8 @@ let
 
   cfg = config.hardware.nvidia-jetpack.firmware.optee;
 
+  inherit (pkgs.nvidia-jetpack) l4tAtLeast l4tOlder;
+
 in
 {
   imports = [
@@ -68,6 +70,63 @@ in
         '';
       };
 
+      ftpm = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable fTPM (Firmware TPM) support. Builds the MS TPM 2.0
+            reference TA and the fTPM helper TA, embeds them in the OP-TEE
+            tos.img firmware, and loads the tpm_ftpm_tee kernel driver
+            after tee-supplicant is ready. Toggling this option requires
+            re-flashing the platform firmware.
+
+            Currently only supported on l4t r36.x. r35 lacks fTPM source;
+            r38 refactored fTPM compilation (see CFG_MS_TPM_20_REF) and is
+            not yet wired up here.
+          '';
+        };
+
+        measuredBoot = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable measured-boot support. Sets CFG_TA_MEASURED_BOOT in the
+            MS TPM 2.0 reference TA build and CFG_CORE_TPM_EVENT_LOG in
+            OP-TEE OS.
+          '';
+        };
+
+        taLogLevel = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            CFG_TA_LOG_LEVEL passed to the MS TPM 2.0 reference TA build.
+            Independent from
+            hardware.nvidia-jetpack.firmware.optee.taLogLevel.
+          '';
+        };
+
+        unsecureInjectEPS = {
+          enable = mkEnableOption ''
+            unsecure EPS injection. The fTPM TA exposes functionality to
+            inject a custom Endorsement Primary Seed (EPS). This is
+            effectively a TPM backdoor and should ONLY be used for testing
+          '';
+
+          value = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "0xdeadbeef...";
+            description = ''
+              Specific EPS value (64-byte hex string with 0x prefix) to
+              inject. If null, a random EPS is generated on first boot
+              and persisted to /var/lib/unsecureInjectEPS.hex.
+            '';
+          };
+        };
+      };
+
       patches = mkOption {
         type = types.listOf types.path;
         default = [ ];
@@ -108,43 +167,131 @@ in
     };
   };
 
-  config = mkIf config.hardware.nvidia-jetpack.enable {
-    hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
-      lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
-      ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.tas;
+  config = mkIf config.hardware.nvidia-jetpack.enable (lib.mkMerge [
+    {
+      assertions = [{
+        # TODO: extend to r38 once fTPM is wired up via CFG_MS_TPM_20_REF.
+        assertion = !cfg.ftpm.enable || (l4tAtLeast "36" && l4tOlder "38");
+        message = ''
+          hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
+          requires l4t r36.x. r35 lacks fTPM source; r38 refactored fTPM
+          compilation to use the CFG_MS_TPM_20_REF flag and is not yet
+          supported here.
+        '';
+      }];
 
-    hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
-      lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
+      hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
+        lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
+        ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.tas;
 
-    systemd.services.tee-supplicant =
-      let
-        teeApplications = pkgs.symlinkJoin {
-          name = "tee-applications";
-          paths = cfg.supplicant.trustedApplications;
+      hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
+        lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
+
+      systemd.services.tee-supplicant =
+        let
+          teeApplications = pkgs.symlinkJoin {
+            name = "tee-applications";
+            paths = cfg.supplicant.trustedApplications;
+          };
+
+          supplicantPlugins = pkgs.symlinkJoin {
+            name = "tee-supplicant-plugins";
+            paths = cfg.supplicant.plugins;
+          };
+
+          args = lib.escapeShellArgs (
+            [
+              "--ta-path=${teeApplications}"
+              "--plugin-path=${supplicantPlugins}"
+            ]
+            ++ cfg.supplicant.extraArgs
+          );
+        in
+        mkIf cfg.supplicant.enable {
+          description = "Userspace supplicant for OPTEE-OS";
+          serviceConfig = {
+            # tee-supplicant is patched to call sd_notify(READY=1); without
+            # NOTIFY_SOCKET this is a harmless no-op for non-systemd users.
+            Type = "notify";
+            ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
+            Restart = "always";
+          };
+          wantedBy = [ "multi-user.target" ];
         };
 
-        supplicantPlugins = pkgs.symlinkJoin {
-          name = "tee-supplicant-plugins";
-          paths = cfg.supplicant.plugins;
-        };
+      environment.systemPackages = lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
+    }
 
-        args = lib.escapeShellArgs (
-          [
-            "--ta-path=${teeApplications}"
-            "--plugin-path=${supplicantPlugins}"
-          ]
-          ++ cfg.supplicant.extraArgs
-        );
-      in
-      mkIf cfg.supplicant.enable {
-        description = "Userspace supplicant for OPTEE-OS";
-        serviceConfig = {
-          ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
-          Restart = "always";
-        };
-        wantedBy = [ "multi-user.target" ];
-      };
+    (mkIf cfg.ftpm.enable {
+      boot.kernelModules = [ "tpm" ];
+      boot.initrd.availableKernelModules = [ "tpm" "tpm_ftpm_tee" ];
+      # tpm_ftpm_tee must load after tee-supplicant is up.
+      boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
 
-    environment.systemPackages = lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
-  };
+      boot.kernelPatches = [{
+        name = "fTPM_tee";
+        patch = null;
+        structuredExtraConfig = with lib.kernel; {
+          TCG_TPM = module;
+          TCG_FTPM_TEE = module;
+        };
+        features.fTPM_tee = true;
+      }];
+
+      systemd.services.ftpm-driver =
+        let
+          epsFile = "/var/lib/unsecureInjectEPS.hex";
+          helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
+
+          epsInjectScript =
+            if cfg.ftpm.unsecureInjectEPS.value != null then ''
+              echo "Injecting configured EPS into fTPM..."
+              ${helper} -g ${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}
+            '' else ''
+              EPS_FILE=${lib.escapeShellArg epsFile}
+              EPS_SIZE=64
+
+              if [ ! -f "$EPS_FILE" ]; then
+                echo "Generating random EPS for fTPM..."
+                mkdir -p "$(dirname "$EPS_FILE")"
+                EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
+                echo "$EPS_HEX" > "$EPS_FILE"
+                chmod 600 "$EPS_FILE"
+                echo "EPS saved to $EPS_FILE"
+              else
+                echo "Using existing EPS from $EPS_FILE"
+              fi
+
+              EPS_VALUE=$(cat "$EPS_FILE")
+              echo "Injecting EPS into fTPM..."
+              ${helper} -g "$EPS_VALUE"
+            '';
+
+          script = pkgs.writeShellScript "ftpm-driver-load" ''
+            set -euo pipefail
+
+            ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable epsInjectScript}
+
+            echo "Loading tpm_ftpm_tee driver..."
+            ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+          '';
+        in
+        {
+          description = "Load fTPM driver after TEE supplicant";
+          after = [
+            "tee-supplicant.service"
+            "local-fs.target"
+            "systemd-modules-load.service"
+          ];
+          requires = [ "tee-supplicant.service" ];
+          before = [ "tpm2.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = script;
+          };
+        };
+    })
+  ]);
 }

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -284,7 +284,6 @@ in
             "systemd-modules-load.service"
           ];
           requires = [ "tee-supplicant.service" ];
-          before = [ "tpm2.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             Type = "oneshot";

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -121,7 +121,7 @@ in
             description = ''
               Specific EPS value (64-byte hex string with 0x prefix) to
               inject. If null, a random EPS is generated on first boot
-              and persisted to /var/lib/unsecureInjectEPS.hex.
+              and persisted to /var/lib/optee/ftpm/unsecureInjectEPS.hex.
             '';
           };
         };
@@ -177,6 +177,12 @@ in
           requires l4t r36.x. r35 lacks fTPM source; r38 refactored fTPM
           compilation to use the CFG_MS_TPM_20_REF flag and is not yet
           supported here.
+        '';
+      } {
+        assertion = !cfg.ftpm.enable || pkgs.nvidia-jetpack.socType == "t234";
+        message = ''
+          hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
+          requires a t234 (Orin) SoC. Got: ${pkgs.nvidia-jetpack.socType}
         '';
       }];
 
@@ -240,32 +246,35 @@ in
 
       systemd.services.ftpm-driver =
         let
-          epsFile = "/var/lib/unsecureInjectEPS.hex";
+          epsFile = "/var/lib/optee/ftpm/unsecureInjectEPS.hex";
           helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
+          # nvftpm-helper-app CLI changed between JetPack releases:
+          #   JP5 (r35): -g injects EPS
+          #   JP6+ (r36+): -g queries ECID, -m injects EPS
+          epsFlag = if l4tAtLeast "36" then "-m" else "-g";
 
-          epsInjectScript =
-            if cfg.ftpm.unsecureInjectEPS.value != null then ''
-              echo "Injecting configured EPS into fTPM..."
-              ${helper} -g ${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}
-            '' else ''
-              EPS_FILE=${lib.escapeShellArg epsFile}
-              EPS_SIZE=64
-
-              if [ ! -f "$EPS_FILE" ]; then
+          epsInjectScript = ''
+            EPS_FILE=${lib.escapeShellArg epsFile}
+            EPS_SIZE=64
+            if [ ! -f "$EPS_FILE" ]; then
+              ${if cfg.ftpm.unsecureInjectEPS.value != null then ''
+                echo "Generating configured EPS for fTPM..."
+                EPS_HEX="${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}"
+              '' else ''
                 echo "Generating random EPS for fTPM..."
                 mkdir -p "$(dirname "$EPS_FILE")"
                 EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
-                echo "$EPS_HEX" > "$EPS_FILE"
-                chmod 600 "$EPS_FILE"
-                echo "EPS saved to $EPS_FILE"
-              else
-                echo "Using existing EPS from $EPS_FILE"
-              fi
-
-              EPS_VALUE=$(cat "$EPS_FILE")
-              echo "Injecting EPS into fTPM..."
-              ${helper} -g "$EPS_VALUE"
-            '';
+              ''}
+              echo "$EPS_HEX" > "$EPS_FILE"
+              chmod 600 "$EPS_FILE"
+              echo "EPS saved to $EPS_FILE"
+            else
+              echo "Using existing EPS from $EPS_FILE"
+            fi
+            EPS_VALUE=$(cat "$EPS_FILE")
+            echo "Injecting EPS into fTPM..."
+            ${helper} ${epsFlag} "$EPS_VALUE"
+          '';
 
           script = pkgs.writeShellScript "ftpm-driver-load" ''
             set -euo pipefail
@@ -289,6 +298,7 @@ in
             Type = "oneshot";
             RemainAfterExit = true;
             ExecStart = script;
+            StateDirectory = "optee/ftpm";
           };
         };
     })

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -76,11 +76,42 @@ final: prev: (
       armTrustedFirmware = prevJetpack.armTrustedFirmware.overrideAttrs {
         inherit (finalJetpack) socType;
       };
+
+      # fTPM TAs are referenced from the BASE scope (`prev.nvidia-jetpack`), not
+      # `finalJetpack`/`prevJetpack`. `taDevKit = optee-os.overrideAttrs(...)`,
+      # so resolving via the new scope would create a cycle:
+      # optee-os.earlyTaPaths -> fTPM TA -> taDevKit -> optee-os. The TAs are
+      # functionally independent of the user's optee-os overrides (they only
+      # need ta_dev_kit headers, not the user's CFG flags or patches).
+      msTpm20RefTa = prev.nvidia-jetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
+        patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
+        makeFlags = prevAttrs.makeFlags or [ ]
+          ++ [ "CFG_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
+          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot "CFG_TA_MEASURED_BOOT=y";
+      });
+
       optee-os = prevJetpack.optee-os.overrideAttrs (prevAttrs: {
         inherit (finalJetpack) socType;
         inherit (cfg.firmware.optee) taPublicKeyFile coreLogLevel taLogLevel;
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
-        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
+        makeFlags = prevAttrs.makeFlags or [ ]
+          ++ cfg.firmware.optee.extraMakeFlags
+          ++ lib.optionals cfg.firmware.optee.ftpm.enable [
+            "CFG_REE_STATE=y"
+            "CFG_JETSON_FTPM_HELPER_PTA=y"
+          ]
+          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot
+            "CFG_CORE_TPM_EVENT_LOG=y"
+          ++ lib.optional cfg.firmware.optee.ftpm.unsecureInjectEPS.enable
+            (lib.warn
+              "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
+              "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y");
+        earlyTaPaths = prevAttrs.earlyTaPaths or [ ]
+          ++ lib.optionals
+            (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234") [
+              "${prev.nvidia-jetpack.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
+              "${finalJetpack.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
+            ];
       });
 
       flashInitrd =

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -77,13 +77,7 @@ final: prev: (
         inherit (finalJetpack) socType;
       };
 
-      # fTPM TAs are referenced from the BASE scope (`prev.nvidia-jetpack`), not
-      # `finalJetpack`/`prevJetpack`. `taDevKit = optee-os.overrideAttrs(...)`,
-      # so resolving via the new scope would create a cycle:
-      # optee-os.earlyTaPaths -> fTPM TA -> taDevKit -> optee-os. The TAs are
-      # functionally independent of the user's optee-os overrides (they only
-      # need ta_dev_kit headers, not the user's CFG flags or patches).
-      msTpm20RefTa = prev.nvidia-jetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
+      msTpm20RefTa = prevJetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
         makeFlags = prevAttrs.makeFlags or [ ]
           ++ [ "CFG_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
@@ -94,24 +88,14 @@ final: prev: (
         inherit (finalJetpack) socType;
         inherit (cfg.firmware.optee) taPublicKeyFile coreLogLevel taLogLevel;
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
-        makeFlags = prevAttrs.makeFlags or [ ]
-          ++ cfg.firmware.optee.extraMakeFlags
-          ++ lib.optionals cfg.firmware.optee.ftpm.enable [
-            "CFG_REE_STATE=y"
-            "CFG_JETSON_FTPM_HELPER_PTA=y"
-          ]
-          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot
-            "CFG_CORE_TPM_EVENT_LOG=y"
-          ++ lib.optional cfg.firmware.optee.ftpm.unsecureInjectEPS.enable
-            (lib.warn
-              "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
-              "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y");
-        earlyTaPaths = prevAttrs.earlyTaPaths or [ ]
-          ++ lib.optionals
-            (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234") [
-              "${prev.nvidia-jetpack.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
-              "${finalJetpack.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
-            ];
+        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
+        enableFTPM = cfg.firmware.optee.ftpm.enable;
+        measuredBoot = cfg.firmware.optee.ftpm.measuredBoot;
+        unsecureInjectEPS = cfg.firmware.optee.ftpm.unsecureInjectEPS.enable;
+        ftpmHelperTa = if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+                       then finalJetpack.ftpmHelperTa else null;
+        msTpm20RefTa = if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+                       then finalJetpack.msTpm20RefTa else null;
       });
 
       flashInitrd =

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -92,9 +92,9 @@ final: prev: (
         enableFTPM = cfg.firmware.optee.ftpm.enable;
         measuredBoot = cfg.firmware.optee.ftpm.measuredBoot;
         unsecureInjectEPS = cfg.firmware.optee.ftpm.unsecureInjectEPS.enable;
-        ftpmHelperTa = if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+        ftpmHelperTa = if cfg.firmware.optee.ftpm.enable
                        then finalJetpack.ftpmHelperTa else null;
-        msTpm20RefTa = if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+        msTpm20RefTa = if cfg.firmware.optee.ftpm.enable
                        then finalJetpack.msTpm20RefTa else null;
       });
 

--- a/pkgs/optee/0001-ftpm-helper-no-install-makefile.patch
+++ b/pkgs/optee/0001-ftpm-helper-no-install-makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/optee/samples/ftpm-helper/host/Makefile b/optee/samples/ftpm-helper/host/Makefile
+index 8f26a1f..2ec5f5d 100644
+--- a/optee/samples/ftpm-helper/host/Makefile
++++ b/optee/samples/ftpm-helper/host/Makefile
+@@ -20,7 +20,7 @@ OBJS = $(patsubst %.c,$(O)/%.o,$(SRCS))
+ BINARY = nvftpm-helper-app
+
+ .PHONY: all install
+-all: $(BINARY) install
++all: $(BINARY)
+
+ $(BINARY): $(OBJS)
+ 	$(CC) -o $(O)/$@ $< $(LDADD)

--- a/pkgs/optee/0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
+++ b/pkgs/optee/0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
@@ -1,0 +1,10 @@
+--- a/optee/optee_client/tee-supplicant/Makefile
++++ b/optee/optee_client/tee-supplicant/Makefile
+@@ -18,7 +18,6 @@
+ 		   teec_ta_load.c \
+ 		   tee_supp_fs.c \
+ 		   rpmb.c \
+-		   nvme_rpmb.c \
+ 		   handle.c
+ 
+ ifeq ($(CFG_GP_SOCKETS),y)

--- a/pkgs/optee/0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
+++ b/pkgs/optee/0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
@@ -1,0 +1,10 @@
+--- a/optee/optee_client/tee-supplicant/Makefile
++++ b/optee/optee_client/tee-supplicant/Makefile
+@@ -18,6 +18,7 @@
+ 		   teec_ta_load.c \
+ 		   tee_supp_fs.c \
+ 		   rpmb.c \
++		   nvme_rpmb.c \
+ 		   handle.c \
+ 		   sd_notify.c
+ 

--- a/pkgs/optee/ftpmHelperTa.nix
+++ b/pkgs/optee/ftpmHelperTa.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, taDevKit
+, opteeClient
+, l4tMajorMinorPatchVersion
+, buildPackages
+, gitRepos
+}:
+stdenv.mkDerivation {
+  pname = "ftpm-helper-ta";
+  version = l4tMajorMinorPatchVersion;
+  src = gitRepos."tegra/optee-src/nv-optee";
+  patches = [ ./0001-ftpm-helper-no-install-makefile.patch ];
+  nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+  enableParallelBuilding = true;
+  makeFlags = [
+    "-C optee/samples/ftpm-helper"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+    "OPTEE_CLIENT_EXPORT=${opteeClient}"
+    "O=$(PWD)/out"
+  ];
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin out/ca/ftpm-helper/nvftpm-helper-app
+    install -Dm755 -t $out out/early_ta/ftpm-helper/*.stripped.elf
+
+    runHook postInstall
+  '';
+  meta.platforms = [ "aarch64-linux" ];
+}

--- a/pkgs/optee/msTpm20RefTa.nix
+++ b/pkgs/optee/msTpm20RefTa.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, taDevKit
+, opteeClient
+, l4tMajorMinorPatchVersion
+, buildPackages
+, gitRepos
+}:
+# TODO: r38 refactored fTPM compilation to use the CFG_MS_TPM_20_REF flag in
+# the optee-os build itself, which would make this separate TA derivation
+# obsolete on r38. Add an r38 code path here (or replace this with the
+# optee-os flag) once r38 fTPM support is wired up.
+stdenv.mkDerivation {
+  pname = "ms-tpm-20-ref-ta";
+  version = l4tMajorMinorPatchVersion;
+  src = gitRepos."tegra/optee-src/nv-optee";
+  nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+  enableParallelBuilding = true;
+
+  # Suppress GCC 13+ warnings-as-errors from upstream sources to avoid
+  # depending on gcc13.
+  NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types -Wno-implicit-function-declaration";
+
+  makeFlags = [
+    "-C optee/samples/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+    "OPTEE_CLIENT_EXPORT=${opteeClient}"
+    "OPTEE_OS_DIR=$(PWD)/optee/optee_os"
+    "O=$(PWD)/out"
+    "CFG_USE_PLATFORM_EPS=y"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out out/early_ta/ms-tpm/*.stripped.elf
+
+    runHook postInstall
+  '';
+  meta.platforms = [ "aarch64-linux" ];
+}

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -21,7 +21,6 @@ in
   version = l4tMajorMinorPatchVersion;
 
   # Override-able arguments
-  earlyTaPaths = [ ];
   socType =
     if l4tMajorVersion == "35" then "t194"
     else if l4tMajorVersion == "36" then "t234"
@@ -30,6 +29,18 @@ in
   coreLogLevel = 2;
   taLogLevel = finalAttrs.coreLogLevel;
   taPublicKeyFile = null;
+
+  # fTPM — set ftpmHelperTa/msTpm20RefTa to the TA derivations to embed them as early TAs
+  enableFTPM = false;
+  measuredBoot = false;
+  unsecureInjectEPS = false;
+  ftpmHelperTa = null;
+  msTpm20RefTa = null;
+
+  earlyTaPaths = lib.optionals (finalAttrs.ftpmHelperTa != null) [
+    "${finalAttrs.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
+    "${finalAttrs.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
+  ];
 
   src = gitRepos."tegra/optee-src/nv-optee";
   patches = [
@@ -70,6 +81,15 @@ in
     "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin"
   ])
   ++ (lib.optional (finalAttrs.taPublicKeyFile != null) "TA_PUBLIC_KEY=${finalAttrs.taPublicKeyFile}")
+  ++ lib.optionals finalAttrs.enableFTPM [
+    "CFG_REE_STATE=y"
+    "CFG_JETSON_FTPM_HELPER_PTA=y"
+  ]
+  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.measuredBoot) "CFG_CORE_TPM_EVENT_LOG=y"
+  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.unsecureInjectEPS)
+    (lib.warn
+      "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
+      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y")
   ;
 
   dontInstall = true;

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -37,7 +37,16 @@ in
   ftpmHelperTa = null;
   msTpm20RefTa = null;
 
-  earlyTaPaths = lib.optionals (finalAttrs.ftpmHelperTa != null) [
+  # Stripped ELFs are used here rather than signed .ta files. Early TAs
+  # are embedded directly in the OP-TEE binary image and do not require
+  # signing — they inherit the same trust level as OP-TEE OS itself.
+  # Only REE (file-system-loaded) TAs need to be signed.
+  # See: https://optee.readthedocs.io/en/latest/building/trusted_applications.html#signing-of-tas
+  #
+  # Using enableFTPM (rather than ftpmHelperTa != null) ensures that if
+  # enableFTPM = true but the TA paths weren't provided, you get an
+  # immediate eval error instead of a silent disable of fTPM.
+  earlyTaPaths = lib.optionals finalAttrs.enableFTPM [
     "${finalAttrs.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
     "${finalAttrs.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
   ];
@@ -81,15 +90,15 @@ in
     "CFG_STMM_PATH=${uefi-firmware}/standalonemm_optee.bin"
   ])
   ++ (lib.optional (finalAttrs.taPublicKeyFile != null) "TA_PUBLIC_KEY=${finalAttrs.taPublicKeyFile}")
-  ++ lib.optionals finalAttrs.enableFTPM [
+  ++ lib.optionals finalAttrs.enableFTPM ([
     "CFG_REE_STATE=y"
     "CFG_JETSON_FTPM_HELPER_PTA=y"
   ]
-  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.measuredBoot) "CFG_CORE_TPM_EVENT_LOG=y"
-  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.unsecureInjectEPS)
+  ++ lib.optional finalAttrs.measuredBoot "CFG_CORE_TPM_EVENT_LOG=y"
+  ++ lib.optional finalAttrs.unsecureInjectEPS
     (lib.warn
       "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
-      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y")
+      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y"))
   ;
 
   dontInstall = true;

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
         url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
         stripLen = 1;
         extraPrefix = "optee/optee_client/";
-        hash = "sha256-85DYu8BmWgpeowLMptLwXb77MWytNgvwqSZuPGtBFG4=";
+        hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
     ];
 

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   src = gitRepos."tegra/optee-src/nv-optee";
 
   patches =
-    if l4tAtLeast "36" then [ ] else [
+    (if l4tAtLeast "36" then [ ] else [
       ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch
       (fetchpatch {
         name = "tee-supplicant-Allow-for-TA-load-path-to-be-specified-at-runtime.patch";
@@ -20,6 +20,14 @@ stdenv.mkDerivation {
         stripLen = 1;
         extraPrefix = "optee/optee_client/";
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
+      })
+    ]) ++ [
+      (fetchpatch {
+        name = "tee-supplicant-add-systemd-sd_notify-support.patch";
+        url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
+        stripLen = 1;
+        extraPrefix = "optee/optee_client/";
+        hash = "sha256-85DYu8BmWgpeowLMptLwXb77MWytNgvwqSZuPGtBFG4=";
       })
     ];
 

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
       })
     ]) ++ [
+      ./0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
       (fetchpatch {
         name = "tee-supplicant-add-systemd-sd_notify-support.patch";
         url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
@@ -29,6 +30,7 @@ stdenv.mkDerivation {
         extraPrefix = "optee/optee_client/";
         hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
+      ./0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
     ];
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -11,6 +11,21 @@ stdenv.mkDerivation {
   version = l4tMajorMinorPatchVersion;
   src = gitRepos."tegra/optee-src/nv-optee";
 
+  # Patching strategy for nv-optee's optee_client (forked from upstream
+  # OP-TEE/optee_client).
+  #
+  # r35 only: Upstream tee-supplicant prepends hardcoded paths. Patch
+  # 0001 removes that behaviour, and we backport the runtime TA-load-path
+  # feature (f3845d8). Both are already present in r36+.
+  #
+  # r35 & r36 only: nv-optee carries an extra nvme_rpmb.c source that
+  # isn't in upstream OP-TEE/optee_client, so a straight fetchpatch of the
+  # sd_notify commit (a5b1ffcd) would fail. Instead we:
+  #   1. Drop nvme_rpmb.c from the Makefile (0002)
+  #   2. Apply the sd_notify fetchpatch (a5b1ffcd)
+  #   3. Restore nvme_rpmb.c in the Makefile (0003)
+  # r38 already includes a5b1ffcd in its nv-optee baseline, so this
+  # drop-fetchpatch-restore dance is unnecessary there.
   patches =
     (if l4tAtLeast "36" then [ ] else [
       ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch
@@ -21,7 +36,7 @@ stdenv.mkDerivation {
         extraPrefix = "optee/optee_client/";
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
       })
-    ]) ++ [
+    ]) ++ (if l4tAtLeast "38" then [ ] else [
       ./0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
       (fetchpatch {
         name = "tee-supplicant-add-systemd-sd_notify-support.patch";
@@ -31,7 +46,7 @@ stdenv.mkDerivation {
         hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
       ./0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
-    ];
+    ]);
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libuuid ];

--- a/pkgs/optee/taDevKit.nix
+++ b/pkgs/optee/taDevKit.nix
@@ -1,5 +1,6 @@
 { optee-os }:
 optee-os.overrideAttrs (finalAttrs: {
   pname = "optee-ta-dev-kit";
+  uefi-firmware = null;
   makeFlags = finalAttrs.makeFlags or [ ] ++ [ "ta_dev_kit" ];
 })

--- a/pkgs/optee/taDevKit.nix
+++ b/pkgs/optee/taDevKit.nix
@@ -2,5 +2,7 @@
 optee-os.overrideAttrs (finalAttrs: {
   pname = "optee-ta-dev-kit";
   uefi-firmware = null;
+  ftpmHelperTa = null;
+  msTpm20RefTa = null;
   makeFlags = finalAttrs.makeFlags or [ ] ++ [ "ta_dev_kit" ];
 })


### PR DESCRIPTION
###### Description of changes

Rebases PR #484 (fTPM support) on top of #480 (optee-nix refactor), and addresses all review comments from the original PR.

Adds `hardware.nvidia-jetpack.firmware.optee.ftpm` options that build the MS TPM 2.0 reference TA + the fTPM helper TA, embed them as early TAs in `tos.img`, and load `tpm_ftpm_tee` after `tee-supplicant` (now `Type=notify`).

Currently scoped to l4t r36.x: r35 lacks fTPM source; r38 refactored fTPM compilation around `CFG_MS_TPM_20_REF` and isn't wired up here yet.

**Changes from PR #484 (review comments)**

- Use default GCC with `NIX_CFLAGS_COMPILE` instead of pinning `gcc13` for the MS TPM 2.0 ref TA build.
- Renamed `unsafeInjectEPS` → `unsecureInjectEPS`. Made the EPS value configurable (`unsecureInjectEPS.value`); falls back to a random, persisted-in-`/var/lib` EPS when null.
- New `firmware.optee.ftpm.measuredBoot` option, gating `CFG_TA_MEASURED_BOOT` (in the TA build) and `CFG_CORE_TPM_EVENT_LOG` (in OP-TEE OS) together.
- New `firmware.optee.ftpm.taLogLevel` option (default 0, NVIDIA's default), separate from the global `taLogLevel`.
- `ftpm-driver.service` now `After=local-fs.target systemd-modules-load.service` in addition to `tee-supplicant.service`.
- Assertion blocks `ftpm.enable` on l4t r35 / r38.
- The systemd `sd_notify` patch is applied via `fetchpatch` from upstream `OP-TEE/optee_client@a5b1ffcd`, flanked by two local patches to handle `nvme_rpmb.c` present in nv-optee but not upstream.

**Changes from #480 refactor**

- New `pkgs/optee/{ftpmHelperTa,msTpm20RefTa}.nix` follow the per-derivation pattern.
- `pkgs/optee/optee-os.nix` gains overrideable fTPM attrs (`enableFTPM`, `measuredBoot`, `unsecureInjectEPS`, `ftpmHelperTa`, `msTpm20RefTa`); `overlay-with-config.nix` sets them from the NixOS config.
- `taDevKit` unconditionally clears `uefi-firmware`, `ftpmHelperTa`, and `msTpm20RefTa` to break an `optee-os → fTPM TA → taDevKit → optee-os` evaluation cycle and prevent a duplicate EDK2 build when fTPM is enabled.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->

- Tested with ftpm enabled and disabled on Jetson Orin Nano with Jetpack 6. The functionality is verified with `tpm2-tools`.