### PR TITLE
optee: avoid creating default attribute

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -178,5 +178,8 @@ makeScope final.newScope (self: {
 // (final.callPackages ./pkgs/l4t {
   inherit self l4tAtLeast l4tOlder;
 })
-  // (final.callPackages ./pkgs/optee { inherit self; })
+  // final.lib.packagesFromDirectoryRecursive {
+  inherit (self) callPackage;
+  directory = ./pkgs/optee;
+}
 )

--- a/pkgs/optee/default.nix
+++ b/pkgs/optee/default.nix
@@ -1,5 +1,0 @@
-{ lib, self }:
-lib.packagesFromDirectoryRecursive {
-  inherit (self) callPackage;
-  directory = ./.;
-}


### PR DESCRIPTION
###### Description of changes

As written, `default.nix` was `callPackage`'d and included as an attribute in the `nvidia-jetpack` scope. This change undoes that.

###### Testing

Manual verification attribute is gone. `default` was not a valid attribute and would error on evaluation (missing argument `self`).
