### PR TITLE
kernels: r35: Add patch names

### DIFF
--- a/pkgs/kernels/r35/default.nix
+++ b/pkgs/kernels/r35/default.nix
@@ -121,16 +121,28 @@ buildLinux (args // {
     # Without this patch, resolve_btfids doesn't handle this case and
     # miscounts, leading to the failure. The underlying cause of why we have
     # multiple structs of the same name is still unresolved as of 2023-07-29
-    { patch = ./0001-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch; }
+    {
+      name = " tools/resolve_btfids: Warn when having multiple IDs for single type";
+      patch = ./0001-tools-resolve_btfids-Warn-when-having-multiple-IDs-f.patch;
+    }
 
     # Fix Ethernet "downshifting" (e.g.1000Base-T -> 100Base-T) with realtek
     # PHY used on Xavier NX
-    { patch = ./0002-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch; }
+    {
+      name = "net: phy: realtek: read actual speed on rtl8211f to detect downshift";
+      patch = ./0002-net-phy-realtek-read-actual-speed-on-rtl8211f-to-det.patch;
+    }
 
     # Lower priority of tegra-se crypto modules since they're slow and flaky
-    { patch = ./0003-Lower-priority-of-tegra-se-crypto.patch; }
+    {
+      name = "Lower priority of tegra-se crypto";
+      patch = ./0003-Lower-priority-of-tegra-se-crypto.patch;
+    }
 
-    { patch = ./0001-kbuild-Also-install-dtbos-in-make-dtbs_install.patch; }
+    {
+      name = "kbuild: Also install dtbos in make dtbs_install";
+      patch = ./0001-kbuild-Also-install-dtbos-in-make-dtbs_install.patch;
+    }
   ] ++ kernelPatches;
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
###### Description of changes

Adding names to the patches, since `kernelPatches` expects to have a list of attribute sets with `name` and `patch` defined.

###### Testing

- [x] hydra eval passes
