### PR TITLE
feat(kernel): add hardware.nvidia-jetpack.rtc.hctosys.enable option

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -260,7 +260,7 @@ in
           name = "disable-rtc-hctosys";
           patch = null;
           structuredExtraConfig = with lib.kernel; {
-            RTC_HCTOSYS = no;
+            RTC_HCTOSYS = lib.mkForce no;
           };
         }
       ];

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -259,7 +259,7 @@ in
         {
           name = "disable-rtc-hctosys";
           patch = null;
-          extraStructuredConfig = with lib.kernel; {
+          structuredExtraConfig = with lib.kernel; {
             RTC_HCTOSYS = no;
           };
         }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -97,6 +97,21 @@ in
         '';
       };
 
+      rtc.hctosys.enable = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to set the system clock from the hardware RTC at boot
+          (CONFIG_RTC_HCTOSYS). Enabled by default for compatibility with
+          carrier boards that have a battery-backed RTC (e.g. AGX Orin with
+          C512).
+
+          If your device has no RTC battery, the RTC reads as epoch 0 and
+          the kernel will clobber CLOCK_REALTIME after userspace has started.
+          In that case, disable this option.
+        '';
+      };
+
       carrierBoard = mkOption {
         type = types.enum [
           "generic"
@@ -233,6 +248,22 @@ in
           pkgs.nvidia-jetpack.rtkernelPackages
         else
           pkgs.nvidia-jetpack.kernelPackages).extend pkgs.nvidia-jetpack.kernelPackagesOverlay;
+
+      # Disable CONFIG_RTC_HCTOSYS when the user opts out (i.e. the device
+      # has no RTC battery). Without a battery, the RTC reads as epoch 0
+      # and the kernel's hctosys call clobbers CLOCK_REALTIME after
+      # userspace has already started (systemd-timesyncd, chrony, etc.).
+      # Users without a battery-backed RTC should set
+      # hardware.nvidia-jetpack.rtc.hctosys.enable = false;
+      boot.kernelPatches = lib.mkIf (!cfg.rtc.hctosys.enable) [
+        {
+          name = "disable-rtc-hctosys";
+          patch = null;
+          extraStructuredConfig = with lib.kernel; {
+            RTC_HCTOSYS = no;
+          };
+        }
+      ];
 
       boot.kernelParams = [
         # Needed on Orin at least, but upstream has it for both


### PR DESCRIPTION
###### Description of changes

Jetson Orin devices expose two RTCs: `rtc1` (`tegra_rtc`, SoC-internal, loads ~1.7s) and `rtc0` (`nvvrs-pseq-rtc`, PMIC, loads ~13.5s). The kernel defaults to `CONFIG_RTC_HCTOSYS=y` with device `rtc0`. On dev kits without an RTC backup battery, both RTCs read epoch 0. When `rtc0` probes late in boot, it calls `hctosys` and clobbers `CLOCK_REALTIME` back to 1970 — after systemd-timesyncd has already advanced the clock to a sane epoch. Services started in that window (journald, agenix decryption, TLS) produce garbage timestamps.

Users with a battery-backed RTC (e.g. AGX Orin with a populated C512 socket) are unaffected and need `CONFIG_RTC_HCTOSYS=y`.

This adds `hardware.nvidia-jetpack.rtc.hctosys.enable` (default: `true`, preserving existing behavior). When set to `false`, the module disables `CONFIG_RTC_HCTOSYS` via `boot.kernelPatches`.

```nix
# Devices without an RTC battery:
hardware.nvidia-jetpack.rtc.hctosys.enable = false;
```

###### Testing

- Environment: Orin Nano devkit (no RTC battery), NixOS with custom initrd (LUKS + network + chrony)
- Before: `date` pinned at 1970 after boot; `timedatectl timesync-status` reports `Packet count: 0`, `Server: n/a`
- After (`rtc.hctosys.enable = false`): kernel no longer clobbers the clock; timesyncd advances to built-in epoch; NTP sync proceeds normally once network is ready
- Regression: verified that `zcat /proc/config.gz | grep RTC_HCTOSYS` shows `# CONFIG_RTC_HCTOSYS is not set` with the option disabled