### PR TITLE
fix: ota_utils Thor fab 401 compat

### DIFF
--- a/pkgs/ota-utils/ota_helpers.sh
+++ b/pkgs/ota-utils/ota_helpers.sh
@@ -73,7 +73,7 @@ generate_compat_spec() {
   3834)
     if [[ "${boardsku}" == "0008" ]]; then
       if [[ "${fab}" -gt 400 ]]; then
-        fab="400"
+        fab="401"
       else
         fab="000"
       fi


### PR DESCRIPTION
###### Description of changes

`pkgs/ota-utils/ota_helpers.sh:generate_compat_spec()` clamps `fab` to `"400"` for Thor-AGX silicon at `FAB > 400`, introduced alongside the FAB=401 variant in #472. 

`nvidia-l4t-init/opt/nvidia/nv-l4t-bootloader-config.sh` clamps the same value to `"401"`, cf.

```bash
grep -n -A 12 'update_jetson_agx_thor_spec ()' \
  "$(nix build --no-link --print-out-paths github:anduril/jetpack-nixos#legacyPackages.aarch64-linux.nvidia-jetpack7.l4t-bootloader-utils)/opt/nvidia/l4t-bootloader-config/nv-l4t-bootloader-config.sh"
```

Downstream symptom: at runtime, `setup-jetson-efi-variables.service` writes `TegraPlatformCompatSpec` via `ota-setup-efivars`, which calls `generate_compat_spec`, producing `3834-400-...` due to the typo. Capsule payloads are looked up against the `-400-` spec, only find `-401-` variants in the BUP, and the capsule application is refused: `last_attempt_status: 6151 IMAGE_NOT_IN_PACKAGE`

cc: @danielfullmer 

###### Testing

On Thor-AGX FAB=401 hardware:
- `TegraPlatformCompatSpec` EFI var now reads `3834-401---1--<targetBoard>-` & aligns with BUP variants.
- Capsule applied successfully
