### PR TITLE
feat(nix) :: add nix development shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,29 @@ To make `jetpack-nixos`'s CUDA package set the default, provide Nixpkgs with thi
 final: _: { inherit (final.nvidia-jetpack) cudaPackages; }
 ```
 
+## Development
+
+The flake exposes a nix development shell, so working on the codebase needs no setup beyond Nix with flakes enabled.
+
+```shell
+$ nix develop   # shell with treefmt, helpful dev tools, and cachix
+$ nix fmt       # format the repo via ./treefmt.nix
+```
+
+### Cross-building aarch64 outputs from x86_64
+
+Most flake outputs (ISOs, flash scripts, NixOS configurations) target `aarch64-linux`. If you are on an `x86_64-linux` host then you can cross compile packages by enable `aarch64-linux` emulation. This probably will also cause builds to take longer as they have to be ran via QEMU.
+
+On a NixOS host, add the following to your configuration. On non-NixOS Linux, install `qemu-user-static` and register the handlers via your distro's binfmt service (e.g. `systemd-binfmt.service`). On other hosts and systems, you will have to find the equivlant.
+
+```nix
+{ lib, pkgs, ... }: {
+  boot.binfmt.emulatedSystems = lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 [
+    "aarch64-linux"
+  ];
+}
+```
+
 ## Additional Links
 
 Much of this is inspired by the great work done by [OpenEmbedded for Tegra](https://github.com/OE4T).

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,15 @@
 {
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://cache.nixos-cuda.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
 
@@ -196,6 +207,24 @@
       });
 
       formatter = forAllSystems ({ pkgs, ... }: import ./treefmt.nix pkgs);
+
+      devShells = forAllSystems ({ system, ... }:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            name = "jetpack-nixos";
+            packages = [
+              self.formatter.${system}
+              pkgs.git
+              pkgs.gh
+            ];
+          };
+        });
 
       legacyPackages = forAllSystems ({ system, ... }:
         let


### PR DESCRIPTION
###### Description of changes

Bar raises the development env by adding a nix dev shell with proper cachix configs and relevant packages to be able to build and work on the repo. Also includes updates to README.md about the nix dev shell and how to cross-compile packages. 

Some cuda packages still re-compile as the hash does not match the versions published in cachix. This upstream fix should help with that :: https://github.com/NixOS/nixpkgs/pull/515928 

(note :: a follow up fix in the cuda cache package will also be needed)

###### Testing

I use NixOS as my daily drive Linux machine. While making these changes, I used this nix dev shell to test these changes :: https://github.com/anduril/jetpack-nixos/pull/495