### PR TITLE
optee: Apply Overlayed OP-TEE Patches to opteeClient

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -82,6 +82,9 @@ final: prev: (
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
         makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
       });
+      opteeClient = prevJetpack.opteeClient.overrideAttrs (prevAttrs: {
+        patches = (prevAttrs.patches or [ ]) ++ cfg.firmware.optee.patches;
+      });
 
       flashInitrd =
         let

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -83,7 +83,8 @@ final: prev: (
         makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
       });
       opteeClient = prevJetpack.opteeClient.overrideAttrs (prevAttrs: {
-        patches = (prevAttrs.patches or [ ]) ++ cfg.firmware.optee.patches;
+        patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
+        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
       });
 
       flashInitrd =


### PR DESCRIPTION
###### Description of changes

This PR applies the OP-TEE patches exposed by `hardware.nvidia-jetpack.firmware.optee.patches` to `opteeClient`.
These changes were formerly only applied to `optee-os`. This works because `opteeClient` and `optee-os` share the same underlying `nv-optee` repository.

###### Testing

Verified that changes get applied using a patch targeting OP-TEE Client (used a Jetson AGX board on JP6).
