### PR TITLE
Add equivalent of 0003-Lower-priority-of-tegra-se-crypto.patch for JP6

### DIFF
--- a/pkgs/kernels/r36/oot-modules.nix
+++ b/pkgs/kernels/r36/oot-modules.nix
@@ -29,6 +29,7 @@ let
         ./patches/nvidia-oot/0003-Fix-conftest-use-with-gcc15.patch
         ./patches/nvidia-oot/0004-rtl8852e-Fix-conflicting-types.patch
         ./patches/nvidia-oot/0005-Fix-header-guard-in-halfrf_ops_rtl8852c.h.patch
+        ./patches/nvidia-oot/0006-Lower-priority-of-tegra-se-crypto.patch
         ./patches/nvidia-oot/0001-crypto-tegra-Disable-softirqs-before-finalizing-requ.patch
       ];
     };

--- a/pkgs/kernels/r36/patches/nvidia-oot/0001-rtl8822ce-Fix-Werror-address.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0001-rtl8822ce-Fix-Werror-address.patch
@@ -1,7 +1,7 @@
-From 6ede4b83f47381b033288f95958ad7f1f70682a4 Mon Sep 17 00:00:00 2001
+From 92f038bc5f764f24289186843af79d4039c1551d Mon Sep 17 00:00:00 2001
 From: Elliot Berman <eberman@anduril.com>
 Date: Fri, 25 Apr 2025 08:21:53 -0700
-Subject: [PATCH 1/5] rtl8822ce: Fix -Werror=address
+Subject: [PATCH 1/6] rtl8822ce: Fix -Werror=address
 
 For -Werror=address
 
@@ -316,5 +316,5 @@ index cd4001af..315db53f 100644
  			input_idx++;
  		}
 -- 
-2.52.0
+2.53.0
 

--- a/pkgs/kernels/r36/patches/nvidia-oot/0002-sound-Fix-include-path-for-tegra-virt-alt-include.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0002-sound-Fix-include-path-for-tegra-virt-alt-include.patch
@@ -1,7 +1,7 @@
-From 560f476283e96f8d4710e12de388444a86c6ed45 Mon Sep 17 00:00:00 2001
+From 2ca8bdfa07843b72b92916dc45106bcf995710e2 Mon Sep 17 00:00:00 2001
 From: Elliot Berman <eberman@anduril.com>
 Date: Fri, 25 Apr 2025 08:40:40 -0700
-Subject: [PATCH 2/5] sound: Fix include path for tegra-virt-alt/include
+Subject: [PATCH 2/6] sound: Fix include path for tegra-virt-alt/include
 
 overlay isn't defined.
 
@@ -24,5 +24,5 @@ index 77bad808..2853f096 100644
  ccflags-y += -I$(srctree.nvidia-oot)/sound/soc/tegra-virt-alt/nvaudio_ivc/
  
 -- 
-2.52.0
+2.53.0
 

--- a/pkgs/kernels/r36/patches/nvidia-oot/0003-Fix-conftest-use-with-gcc15.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0003-Fix-conftest-use-with-gcc15.patch
@@ -1,7 +1,7 @@
-From 6d5a47ffd4a87b57d3af955b56319884f882626a Mon Sep 17 00:00:00 2001
+From 093d4d5ac87bfe12fc98c30f9cb12a6c36f63562 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Mon, 19 Jan 2026 00:38:04 -0800
-Subject: [PATCH 3/5] Fix conftest use with gcc15
+Subject: [PATCH 3/6] Fix conftest use with gcc15
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -36,5 +36,5 @@ index 781ae90b..89b86575 100755
  
      if [ "$OUTPUT" != "$SOURCES" ]; then
 -- 
-2.52.0
+2.53.0
 

--- a/pkgs/kernels/r36/patches/nvidia-oot/0004-rtl8852e-Fix-conflicting-types.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0004-rtl8852e-Fix-conflicting-types.patch
@@ -1,7 +1,7 @@
-From 0a0e80bb9b800aee2322c1b934b1357a34662b1a Mon Sep 17 00:00:00 2001
+From f0b86f2b773c37096ab1e22915e179754aba1e0b Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <dfullmer@anduril.com>
 Date: Fri, 6 Feb 2026 18:52:49 -0800
-Subject: [PATCH 4/5] rtl8852e: Fix conflicting types
+Subject: [PATCH 4/6] rtl8852e: Fix conflicting types
 
 ---
  .../realtek/rtl8852ce/phl/hal_g6/phy/bb/halbb_physts.h        | 4 ++--
@@ -23,5 +23,5 @@ index dab93dbb..80367e33 100644
  			       enum bb_physts_ie_t ie, bool en);
  void halbb_phy_sts_manual_trig(struct bb_info *bb, enum bb_mode_type mode, u8 ss);
 -- 
-2.52.0
+2.53.0
 

--- a/pkgs/kernels/r36/patches/nvidia-oot/0005-Fix-header-guard-in-halfrf_ops_rtl8852c.h.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0005-Fix-header-guard-in-halfrf_ops_rtl8852c.h.patch
@@ -1,7 +1,7 @@
-From d6aa1bf797db8354aa2f4372ff2dd633b5ec3940 Mon Sep 17 00:00:00 2001
+From 2e99faf3d0f1d15cd26348d15785f17e51984cb2 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Mon, 19 Jan 2026 10:54:40 -0800
-Subject: [PATCH 5/5] Fix header guard in halfrf_ops_rtl8852c.h
+Subject: [PATCH 5/6] Fix header guard in halfrf_ops_rtl8852c.h
 
 Fails compiler check -Werror=header-guard
 ---
@@ -22,5 +22,5 @@ index 7966290a..094ebd0f 100644
  
  
 -- 
-2.52.0
+2.53.0
 

--- a/pkgs/kernels/r36/patches/nvidia-oot/0006-Lower-priority-of-tegra-se-crypto.patch
+++ b/pkgs/kernels/r36/patches/nvidia-oot/0006-Lower-priority-of-tegra-se-crypto.patch
@@ -1,0 +1,202 @@
+From 7849973f51090dcca7f6d80f677f19aa8a00c5c0 Mon Sep 17 00:00:00 2001
+From: Khoi Trinh <ktrinh@anduril.com>
+Date: Mon, 1 Jun 2026 00:30:28 -0700
+Subject: [PATCH 6/6] Lower priority of tegra-se crypto
+
+This is the JP6 equivalent of r35/0003-Lower-priority-of-tegra-se-crypto.patch
+---
+ drivers/crypto/tegra/tegra-se-aes.c  | 14 +++++++-------
+ drivers/crypto/tegra/tegra-se-hash.c | 26 +++++++++++++-------------
+ 2 files changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/crypto/tegra/tegra-se-aes.c b/drivers/crypto/tegra/tegra-se-aes.c
+index ff1c58c0..e341d195 100644
+--- a/drivers/crypto/tegra/tegra-se-aes.c
++++ b/drivers/crypto/tegra/tegra-se-aes.c
+@@ -547,7 +547,7 @@ static struct tegra_se_alg tegra_aes_algs[] = {
+ 			.base = {
+ 				.cra_name = "cbc(aes)",
+ 				.cra_driver_name = "cbc-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_SKCIPHER | CRYPTO_ALG_ASYNC,
+ 				.cra_blocksize = AES_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_aes_ctx),
+@@ -574,7 +574,7 @@ static struct tegra_se_alg tegra_aes_algs[] = {
+ 			.base = {
+ 				.cra_name = "ecb(aes)",
+ 				.cra_driver_name = "ecb-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_SKCIPHER | CRYPTO_ALG_ASYNC,
+ 				.cra_blocksize = AES_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_aes_ctx),
+@@ -602,7 +602,7 @@ static struct tegra_se_alg tegra_aes_algs[] = {
+ 			.base = {
+ 				.cra_name = "ctr(aes)",
+ 				.cra_driver_name = "ctr-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_SKCIPHER | CRYPTO_ALG_ASYNC,
+ 				.cra_blocksize = 1,
+ 				.cra_ctxsize = sizeof(struct tegra_aes_ctx),
+@@ -630,7 +630,7 @@ static struct tegra_se_alg tegra_aes_algs[] = {
+ 			.base = {
+ 				.cra_name = "xts(aes)",
+ 				.cra_driver_name = "xts-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_blocksize = AES_BLOCK_SIZE,
+ 				.cra_ctxsize	   = sizeof(struct tegra_aes_ctx),
+ 				.cra_alignmask	   = (__alignof__(u64) - 1),
+@@ -1983,7 +1983,7 @@ static struct tegra_se_alg tegra_aead_algs[] = {
+ 			.base = {
+ 				.cra_name = "gcm(aes)",
+ 				.cra_driver_name = "gcm-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_blocksize = 1,
+ 				.cra_ctxsize = sizeof(struct tegra_aead_ctx),
+ 				.cra_alignmask = 0xf,
+@@ -2011,7 +2011,7 @@ static struct tegra_se_alg tegra_aead_algs[] = {
+ 			.base = {
+ 				.cra_name = "ccm(aes)",
+ 				.cra_driver_name = "ccm-aes-tegra",
+-				.cra_priority = 500,
++				.cra_priority = 1,
+ 				.cra_blocksize = 1,
+ 				.cra_ctxsize = sizeof(struct tegra_aead_ctx),
+ 				.cra_alignmask = 0xf,
+@@ -2044,7 +2044,7 @@ static struct tegra_se_alg tegra_cmac_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "cmac(aes)",
+ 				.cra_driver_name = "tegra-se-cmac",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = AES_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_cmac_ctx),
+diff --git a/drivers/crypto/tegra/tegra-se-hash.c b/drivers/crypto/tegra/tegra-se-hash.c
+index 71e3a72b..f7ef48ad 100644
+--- a/drivers/crypto/tegra/tegra-se-hash.c
++++ b/drivers/crypto/tegra/tegra-se-hash.c
+@@ -701,7 +701,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha1",
+ 				.cra_driver_name = "tegra-se-sha1",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA1_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -732,7 +732,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha224",
+ 				.cra_driver_name = "tegra-se-sha224",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA224_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -763,7 +763,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha256",
+ 				.cra_driver_name = "tegra-se-sha256",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA256_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -794,7 +794,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha384",
+ 				.cra_driver_name = "tegra-se-sha384",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA384_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -825,7 +825,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha512",
+ 				.cra_driver_name = "tegra-se-sha512",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA512_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -856,7 +856,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha3-224",
+ 				.cra_driver_name = "tegra-se-sha3-224",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA3_224_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -887,7 +887,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha3-256",
+ 				.cra_driver_name = "tegra-se-sha3-256",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA3_256_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -918,7 +918,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha3-384",
+ 				.cra_driver_name = "tegra-se-sha3-384",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA3_384_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -949,7 +949,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "sha3-512",
+ 				.cra_driver_name = "tegra-se-sha3-512",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH,
+ 				.cra_blocksize = SHA3_512_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -982,7 +982,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "hmac(sha224)",
+ 				.cra_driver_name = "tegra-se-hmac-sha224",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH | CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA224_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -1015,7 +1015,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "hmac(sha256)",
+ 				.cra_driver_name = "tegra-se-hmac-sha256",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH | CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA256_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -1048,7 +1048,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "hmac(sha384)",
+ 				.cra_driver_name = "tegra-se-hmac-sha384",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH | CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA384_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+@@ -1081,7 +1081,7 @@ static struct tegra_se_alg tegra_hash_algs[] = {
+ 			.halg.base = {
+ 				.cra_name = "hmac(sha512)",
+ 				.cra_driver_name = "tegra-se-hmac-sha512",
+-				.cra_priority = 300,
++				.cra_priority = 1,
+ 				.cra_flags = CRYPTO_ALG_TYPE_AHASH | CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA512_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct tegra_sha_ctx),
+-- 
+2.53.0
+


### PR DESCRIPTION
###### Description of changes
Add equivalent of 0003-Lower-priority-of-tegra-se-crypto.patch for JP6

###### Testing
Local testing with a netboot install shows without the patch, the installation is significantly slower on LUKS rootfs