### PR TITLE
udev: rename tegra-devices rules from 99 to 90 prefix

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -370,7 +370,8 @@ in
 
       services.udev.packages = [
         (pkgs.runCommand "jetson-udev-rules" { } ''
-          install -D -t $out/etc/udev/rules.d ${pkgs.nvidia-jetpack.l4t-init}/etc/udev/rules.d/99-tegra-devices.rules
+          install -D ${pkgs.nvidia-jetpack.l4t-init}/etc/udev/rules.d/99-tegra-devices.rules \
+            $out/etc/udev/rules.d/90-tegra-devices.rules
           sed -i \
             -e '/camera_device_detect/d' \
             -e 's#/bin/mknod#${lib.getExe' pkgs.coreutils "mknod"}#' \
@@ -379,7 +380,7 @@ in
             -e 's#/bin/grep#${lib.getExe pkgs.gnugrep}#' \
             -e 's#/bin/bash /etc/systemd/nvpower.sh#${pkgs.nvidia-jetpack.l4t-nvpmodel}/etc/systemd/nvpower.sh#' \
             -e 's#/bin/bash#${lib.getExe pkgs.bash}#' \
-            $out/etc/udev/rules.d/99-tegra-devices.rules
+            $out/etc/udev/rules.d/90-tegra-devices.rules
         '')
       ];
 


### PR DESCRIPTION
###### Description of changes

The L4T udev rules were installed as 99-tegra-devices.rules. NixOS places rules from services.udev.extraRules into 99-local.rules, which sorts lexicographically *before* 99-tegra-devices.rules. This means the tegra rules run last and win, making it impossible to easily override them via extraRules.

Rename the file to 90-tegra-devices.rules so it is processed earlier in the udev rule ordering, allowing users to override tegra device rules through the standard services.udev.extraRules mechanism (which lands in 99-local.rules).

###### Testing

Verified rules file was renamed and device is booting without issue on:
- [x] orin-agx-devkit-jp5
- [x] orin-agx-devkit-jp6
- [x] thor-agx-devkit
