### PR TITLE
flash-script: make initrd-flash host-side timeouts configurable

### DIFF
--- a/device-pkgs/initrdflash-script.nix
+++ b/device-pkgs/initrdflash-script.nix
@@ -118,7 +118,7 @@ let
     # --log-strip -> Strip control characters and escape sequences
     # --mute -> Mute tio messages
     spawn -noecho "${lib.getExe tio}" --log-strip --mute "$modem"
-    set timeout 900
+    set timeout ${builtins.toString cfg.flashScriptOverrides.initrdFlashCompletionTimeoutSeconds}
     set failed 0
     expect {
       "Flashing platform firmware successful" {
@@ -159,10 +159,10 @@ in
 
   # TODO(eberman): maybe stop assuming /dev/serial/by-id is present
   # It'll be populated with udev, so most Linux systems will work fine
-  echo -n "Waiting for Jetson device to appear via USB, this may take up to 4 minutes"
+  echo -n "Waiting up to ${builtins.toString cfg.flashScriptOverrides.initrdFlashSerialEnumerateTimeoutSeconds}s for Jetson device to appear via USB"
 
   counter=0
-  until [[ -e /dev/serial/by-id/${serialPortId} || $counter -gt ${builtins.toString (4 * 60 * 2)} ]] ; do
+  until [[ -e /dev/serial/by-id/${serialPortId} || $counter -gt ${builtins.toString (cfg.flashScriptOverrides.initrdFlashSerialEnumerateTimeoutSeconds * 2)} ]] ; do
     echo -n "."
     sleep 0.5
     ((++counter))

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -315,6 +315,29 @@ in
           defaultText = lib.literalExpression "config.boot.initrd.availableKernelModules";
           description = "Additional kernel modules to be loaded during the initrd flashing method.";
         };
+        initrdFlashSerialEnumerateTimeoutSeconds = mkOption {
+          type = types.ints.positive;
+          default = 240;
+          description = ''
+            Host-side timeout, in seconds, for the USB serial device of the
+            booted initrd to appear at `/dev/serial/by-id/...`. The default
+            of 240 seconds (4 minutes) matches historical behavior. Raise
+            this when device-side firmware-flash legitimately takes longer
+            than 4 minutes (for example, slow QSPI parts that prevent the
+            gadget serial from re-enumerating quickly).
+          '';
+        };
+
+        initrdFlashCompletionTimeoutSeconds = mkOption {
+          type = types.ints.positive;
+          default = 900;
+          description = ''
+            Host-side timeout, in seconds, used by the `expect` watcher to
+            wait for `Flashing platform firmware successful` (or the
+            unsuccessful counterpart) on the device's serial console. The
+            default of 900 seconds (15 minutes) matches historical behavior.
+          '';
+        };
       };
 
       flashScript = mkOption {


### PR DESCRIPTION
Replace the hardcoded initrd-flash host-side timeouts with NixOS options so they can be raised for slow hardware without patching the module:

- `initrdFlashSerialEnumerateTimeoutSeconds` (default 240s) — wait for the booted initrd's USB serial to appear at `/dev/serial/by-id/...`.
- `initrdFlashCompletionTimeoutSeconds` (default 900s) — `expect` watcher timeout for the flash-success/-failure line on the device serial console.

Defaults preserve historical behavior. Raise them for slow QSPI parts or long firmware flashes.

Eval-tested against `orin-agx-devkit` (options resolve to 900/240). `treefmt` formatting check passes clean. Not exercised on real hardware (needs aarch64).