### PR TITLE
optee: Apply overlayed OP-TEE patches to opteeTest

### DIFF
--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -86,6 +86,10 @@ final: prev: (
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
         makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
       });
+      opteeXtest = prevJetpack.opteeXtest.overrideAttrs (prevAttrs: {
+        patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
+        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
+      });
 
       flashInitrd =
         let


### PR DESCRIPTION
###### Description of changes

This PR applies the OP-TEE patches exposed by `hardware.nvidia-jetpack.firmware.optee.patches` to `opteeTest`.
Follows: https://github.com/anduril/jetpack-nixos/pull/505 

###### Testing

Verified that changes get applied using a patch targeting OP-TEE Client (used a Jetson AGX board on JP6).
