### PR TITLE
USB_XHCI_TEGRA = lib.mkForce yes

### DIFF
--- a/pkgs/kernels/r35/default.nix
+++ b/pkgs/kernels/r35/default.nix
@@ -155,7 +155,7 @@ buildLinux (args // {
     #ERROR: modpost: "xhci_urb_enqueue" [drivers/usb/host/xhci-tegra.ko] undefined!
     #ERROR: modpost: "xhci_irq" [drivers/usb/host/xhci-tegra.ko] undefined!
     #USB_XHCI_TEGRA = module;
-    USB_XHCI_TEGRA = yes;
+    USB_XHCI_TEGRA = lib.mkForce yes;
 
     # stage-1 links /lib/firmware to the /nix/store path in the initramfs.
     # However, since it's builtin and not a module, that's too late, since


### PR DESCRIPTION
###### Description of changes

With nixpkgs unstable, setting `USB_XHCI_TEGRA = yes` conflicts with the changes made in
https://github.com/NixOS/nixpkgs/commit/9497b712f6704c2ac3857df38464e81a328a5df1
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
