### PR TITLE
Replace bzip2_1_1 with bzip2

### DIFF
--- a/mk-overlay.nix
+++ b/mk-overlay.nix
@@ -63,10 +63,7 @@ makeScope final.newScope (self: {
           url = "https://developer.download.nvidia.com/embedded/L4T/r${versions.major l4tMajorMinorPatchVersion}_Release_v${versions.minor l4tMajorMinorPatchVersion}.${versions.patch l4tMajorMinorPatchVersion}/release/Jetson_Linux_R${l4tMajorMinorPatchVersion}_aarch64.tbz2";
           hash = bspHash;
         };
-        # We use a more recent version of bzip2 here because we hit this bug
-        # extracting nvidia's archives:
-        # https://bugs.launchpad.net/ubuntu/+source/bzip2/+bug/1834494
-        nativeBuildInputs = [ final.buildPackages.bzip2_1_1 ];
+        nativeBuildInputs = [ final.buildPackages.bzip2 ];
       } ''
       bzip2 -d -c $src | tar xf -
       mv Linux_for_Tegra $out

--- a/pkgs/flash-tools/default.nix
+++ b/pkgs/flash-tools/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , makeWrapper
-, bzip2_1_1
 , fetchurl
 , python3
 , perl


### PR DESCRIPTION
###### Description of changes

bzip2_1_1 has been removed in nixpkgs unstable. The version of bzip2 in nixpkgs (25.11 and later, at least) is 1.0.8, while the bug in question was fixed in bzip2 1.0.6.
<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
