### PR TITLE
Remove use of deprecated `xorg` package set.

### DIFF
--- a/pkgs/cuda-packages-11-4/nsight_compute_host.nix
+++ b/pkgs/cuda-packages-11-4/nsight_compute_host.nix
@@ -12,7 +12,13 @@
 , qt6
 , stdenv
 , xkeyboard_config
-, xorg
+, libxcb
+, libxcomposite
+, libxdamage
+, libXtst
+, libsm
+, libice
+, libxfixes
 ,
 }:
 let
@@ -65,18 +71,18 @@ buildFHSEnv {
     (
       [
         ncurses5
-        xorg.libxcb
+        libxcb
         fontconfig
         noto-fonts
         dbus
         nss
-        xorg.libXcomposite
-        xorg.libXdamage
+        libxcomposite
+        libxdamage
         alsa-lib
-        xorg.libXtst
-        xorg.libSM
-        xorg.libICE
-        xorg.libXfixes
+        libXtst
+        libsm
+        libice
+        libxfixes
         xkeyboard_config
         expat
         nspr

--- a/pkgs/cuda-packages-11-4/nsight_systems_host.nix
+++ b/pkgs/cuda-packages-11-4/nsight_systems_host.nix
@@ -14,7 +14,13 @@
 , requireFile
 , stdenv
 , xkeyboard_config
-, xorg
+, libxcb
+, libxcomposite
+, libxdamage
+, libXtst
+, libsm
+, libice
+, libxfixes
 ,
 }:
 let
@@ -86,18 +92,18 @@ buildFHSEnv {
     (
       [
         ncurses5
-        xorg.libxcb
+        libxcb
         fontconfig
         noto-fonts
         dbus
         nss
-        xorg.libXcomposite
-        xorg.libXdamage
+        libxcomposite
+        libxdamage
         alsa-lib
-        xorg.libXtst
-        xorg.libSM
-        xorg.libICE
-        xorg.libXfixes
+        libXtst
+        libsm
+        libice
+        libxfixes
         xkeyboard_config
         expat
         nspr

--- a/pkgs/l4t/driverDebs.nix
+++ b/pkgs/l4t/driverDebs.nix
@@ -3,7 +3,8 @@
 , debs
 , lib
 , libgcc
-, xorg
+, libx11
+, libxext
 }:
 let
   findDriverDebNames = majorVersion: lib.filter (lib.hasSuffix "-${majorVersion}") (lib.attrNames debs.common);
@@ -14,10 +15,10 @@ let
 
     buildInputs = lib.attrByPath [ pname ] [ ] {
       libnvidia-compute-580 = [ driverDebs.libnvidia-decode-580 libgcc ];
-      libnvidia-decode-580 = [ xorg.libX11 xorg.libXext ];
+      libnvidia-decode-580 = [ libx11 libxext ];
       libnvidia-encode-580 = [ driverDebs.libnvidia-decode-580 ];
-      libnvidia-fbc1-580 = [ xorg.libX11 xorg.libXext ];
-      libnvidia-gl-580 = [ xorg.libX11 xorg.libXext libgcc driverDebs.libnvidia-gpucomp-580 ];
+      libnvidia-fbc1-580 = [ libx11 libxext ];
+      libnvidia-gl-580 = [ libx11 libxext libgcc driverDebs.libnvidia-gpucomp-580 ];
     };
   });
 in

--- a/pkgs/l4t/l4t-3d-core.nix
+++ b/pkgs/l4t/l4t-3d-core.nix
@@ -4,7 +4,9 @@
 , l4t-core
 , lib
 , libglvnd
-, xorg
+, libx11
+, libxext
+, libxcb
 ,
 }:
 # TODO: Split this package up into subpackages similar to what is done in meta-tegra: vulkan, glx, egl, etc
@@ -60,5 +62,5 @@ buildFromDebs {
     rm -r share/doc
   '';
 
-  appendRunpaths = [ "${placeholder "out"}/lib" ] ++ builtins.map (p: (lib.getLib p) + "/lib") [ libglvnd xorg.libX11 xorg.libXext xorg.libxcb ];
+  appendRunpaths = [ "${placeholder "out"}/lib" ] ++ builtins.map (p: (lib.getLib p) + "/lib") [ libglvnd libx11 libxext libxcb ];
 }


### PR DESCRIPTION
###### Description of changes

The `xorg` package set was deprecated on 2026-01-29.

<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
`nix flake check` passes