### PR TITLE
feat(optee): fTPM support for JetPack 5.1+, 6, and 7

### DIFF
--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -11,6 +11,8 @@ let
 
   cfg = config.hardware.nvidia-jetpack.firmware.optee;
 
+  inherit (pkgs.nvidia-jetpack) l4tAtLeast l4tOlder;
+
 in
 {
   imports = [
@@ -68,6 +70,63 @@ in
         '';
       };
 
+      ftpm = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable fTPM (Firmware TPM) support. Builds the MS TPM 2.0
+            reference TA and the fTPM helper TA, embeds them in the OP-TEE
+            tos.img firmware, and loads the tpm_ftpm_tee kernel driver
+            after tee-supplicant is ready. Toggling this option requires
+            re-flashing the platform firmware.
+
+            Currently only supported on l4t r36.x. r35 lacks fTPM source;
+            r38 refactored fTPM compilation (see CFG_MS_TPM_20_REF) and is
+            not yet wired up here.
+          '';
+        };
+
+        measuredBoot = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable measured-boot support. Sets CFG_TA_MEASURED_BOOT in the
+            MS TPM 2.0 reference TA build and CFG_CORE_TPM_EVENT_LOG in
+            OP-TEE OS.
+          '';
+        };
+
+        taLogLevel = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            CFG_TA_LOG_LEVEL passed to the MS TPM 2.0 reference TA build.
+            Independent from
+            hardware.nvidia-jetpack.firmware.optee.taLogLevel.
+          '';
+        };
+
+        unsecureInjectEPS = {
+          enable = mkEnableOption ''
+            unsecure EPS injection. The fTPM TA exposes functionality to
+            inject a custom Endorsement Primary Seed (EPS). This is
+            effectively a TPM backdoor and should ONLY be used for testing
+          '';
+
+          value = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "0xdeadbeef...";
+            description = ''
+              Specific EPS value (64-byte hex string with 0x prefix) to
+              inject. If null, a random EPS is generated on first boot
+              and persisted to /var/lib/unsecureInjectEPS.hex.
+            '';
+          };
+        };
+      };
+
       patches = mkOption {
         type = types.listOf types.path;
         default = [ ];
@@ -108,43 +167,131 @@ in
     };
   };
 
-  config = mkIf config.hardware.nvidia-jetpack.enable {
-    hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
-      lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
-      ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.tas;
+  config = mkIf config.hardware.nvidia-jetpack.enable (lib.mkMerge [
+    {
+      assertions = [{
+        # TODO: extend to r38 once fTPM is wired up via CFG_MS_TPM_20_REF.
+        assertion = !cfg.ftpm.enable || (l4tAtLeast "36" && l4tOlder "38");
+        message = ''
+          hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
+          requires l4t r36.x. r35 lacks fTPM source; r38 refactored fTPM
+          compilation to use the CFG_MS_TPM_20_REF flag and is not yet
+          supported here.
+        '';
+      }];
 
-    hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
-      lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
+      hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
+        lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
+        ++ lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.tas;
 
-    systemd.services.tee-supplicant =
-      let
-        teeApplications = pkgs.symlinkJoin {
-          name = "tee-applications";
-          paths = cfg.supplicant.trustedApplications;
+      hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
+        lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
+
+      systemd.services.tee-supplicant =
+        let
+          teeApplications = pkgs.symlinkJoin {
+            name = "tee-applications";
+            paths = cfg.supplicant.trustedApplications;
+          };
+
+          supplicantPlugins = pkgs.symlinkJoin {
+            name = "tee-supplicant-plugins";
+            paths = cfg.supplicant.plugins;
+          };
+
+          args = lib.escapeShellArgs (
+            [
+              "--ta-path=${teeApplications}"
+              "--plugin-path=${supplicantPlugins}"
+            ]
+            ++ cfg.supplicant.extraArgs
+          );
+        in
+        mkIf cfg.supplicant.enable {
+          description = "Userspace supplicant for OPTEE-OS";
+          serviceConfig = {
+            # tee-supplicant is patched to call sd_notify(READY=1); without
+            # NOTIFY_SOCKET this is a harmless no-op for non-systemd users.
+            Type = "notify";
+            ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
+            Restart = "always";
+          };
+          wantedBy = [ "multi-user.target" ];
         };
 
-        supplicantPlugins = pkgs.symlinkJoin {
-          name = "tee-supplicant-plugins";
-          paths = cfg.supplicant.plugins;
-        };
+      environment.systemPackages = lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
+    }
 
-        args = lib.escapeShellArgs (
-          [
-            "--ta-path=${teeApplications}"
-            "--plugin-path=${supplicantPlugins}"
-          ]
-          ++ cfg.supplicant.extraArgs
-        );
-      in
-      mkIf cfg.supplicant.enable {
-        description = "Userspace supplicant for OPTEE-OS";
-        serviceConfig = {
-          ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
-          Restart = "always";
-        };
-        wantedBy = [ "multi-user.target" ];
-      };
+    (mkIf cfg.ftpm.enable {
+      boot.kernelModules = [ "tpm" ];
+      boot.initrd.availableKernelModules = [ "tpm" "tpm_ftpm_tee" ];
+      # tpm_ftpm_tee must load after tee-supplicant is up.
+      boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
 
-    environment.systemPackages = lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
-  };
+      boot.kernelPatches = [{
+        name = "fTPM_tee";
+        patch = null;
+        structuredExtraConfig = with lib.kernel; {
+          TCG_TPM = module;
+          TCG_FTPM_TEE = module;
+        };
+        features.fTPM_tee = true;
+      }];
+
+      systemd.services.ftpm-driver =
+        let
+          epsFile = "/var/lib/unsecureInjectEPS.hex";
+          helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
+
+          epsInjectScript =
+            if cfg.ftpm.unsecureInjectEPS.value != null then ''
+              echo "Injecting configured EPS into fTPM..."
+              ${helper} -g ${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}
+            '' else ''
+              EPS_FILE=${lib.escapeShellArg epsFile}
+              EPS_SIZE=64
+
+              if [ ! -f "$EPS_FILE" ]; then
+                echo "Generating random EPS for fTPM..."
+                mkdir -p "$(dirname "$EPS_FILE")"
+                EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
+                echo "$EPS_HEX" > "$EPS_FILE"
+                chmod 600 "$EPS_FILE"
+                echo "EPS saved to $EPS_FILE"
+              else
+                echo "Using existing EPS from $EPS_FILE"
+              fi
+
+              EPS_VALUE=$(cat "$EPS_FILE")
+              echo "Injecting EPS into fTPM..."
+              ${helper} -g "$EPS_VALUE"
+            '';
+
+          script = pkgs.writeShellScript "ftpm-driver-load" ''
+            set -euo pipefail
+
+            ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable epsInjectScript}
+
+            echo "Loading tpm_ftpm_tee driver..."
+            ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+          '';
+        in
+        {
+          description = "Load fTPM driver after TEE supplicant";
+          after = [
+            "tee-supplicant.service"
+            "local-fs.target"
+            "systemd-modules-load.service"
+          ];
+          requires = [ "tee-supplicant.service" ];
+          before = [ "tpm2.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = script;
+          };
+        };
+    })
+  ]);
 }

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -284,7 +284,6 @@ in
             "systemd-modules-load.service"
           ];
           requires = [ "tee-supplicant.service" ];
-          before = [ "tpm2.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             Type = "oneshot";

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -526,6 +526,11 @@ in
               Type = "oneshot";
               RemainAfterExit = true;
               ExecStart = initrdStartScript;
+              # Unload module during switch-root cleanup so /dev/tpm0
+              # disappears. Prevents stale session from being probed by
+              # udev/systemd-tpm2-setup before the normal ftpm-driver
+              # can establish a fresh session post-switch-root.
+              ExecStop = "${pkgs.kmod}/bin/modprobe -r tpm_ftpm_tee";
             };
           };
         };

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -11,7 +11,7 @@ let
 
   cfg = config.hardware.nvidia-jetpack.firmware.optee;
 
-  inherit (pkgs.nvidia-jetpack) l4tAtLeast l4tOlder;
+  inherit (pkgs.nvidia-jetpack) l4tAtLeast;
 
 in
 {
@@ -81,9 +81,11 @@ in
             after tee-supplicant is ready. Toggling this option requires
             re-flashing the platform firmware.
 
-            Currently only supported on l4t r36.x. r35 lacks fTPM source;
-            r38 refactored fTPM compilation (see CFG_MS_TPM_20_REF) and is
-            not yet wired up here.
+            Supported on l4t r36.x (Orin / t234) and r38.x (Thor / t264).
+            r35 lacks fTPM source. On r38, additionally drops the patch
+            that force-disables UEFI's fTPM stack (see
+            pkgs/uefi-firmware/r38/disable-ftpm.diff) so that UEFI can
+            reach the fTPM TA over FF-A.
           '';
         };
 
@@ -170,20 +172,20 @@ in
   config = mkIf config.hardware.nvidia-jetpack.enable (lib.mkMerge [
     {
       assertions = [{
-        # TODO: extend to r38 once fTPM is wired up via CFG_MS_TPM_20_REF.
-        assertion = !cfg.ftpm.enable || (l4tAtLeast "36" && l4tOlder "38");
+        assertion = !cfg.ftpm.enable || l4tAtLeast "36";
         message = ''
-          hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
-          requires l4t r36.x. r35 lacks fTPM source; r38 refactored fTPM
-          compilation to use the CFG_MS_TPM_20_REF flag and is not yet
-          supported here.
+          hardware.nvidia-jetpack.firmware.optee.ftpm.enable requires
+          l4t r36.x or later. r35 lacks fTPM source.
         '';
       }
         {
-          assertion = !cfg.ftpm.enable || pkgs.nvidia-jetpack.socType == "t234";
+          assertion = !cfg.ftpm.enable
+            || pkgs.nvidia-jetpack.socType == "t234"
+            || pkgs.nvidia-jetpack.socType == "t264";
           message = ''
-            hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
-            requires a t234 (Orin) SoC. Got: ${pkgs.nvidia-jetpack.socType}
+            hardware.nvidia-jetpack.firmware.optee.ftpm.enable requires
+            a t234 (Orin) or t264 (Thor) SoC.
+            Got: ${pkgs.nvidia-jetpack.socType}
           '';
         }];
 

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -13,6 +13,29 @@ let
 
   inherit (pkgs.nvidia-jetpack) l4tAtLeast;
 
+  # Shared derivations used by both initrd and normal-root services.
+  teeApplications = pkgs.symlinkJoin {
+    name = "tee-applications";
+    paths = cfg.supplicant.trustedApplications;
+  };
+
+  supplicantPlugins = pkgs.symlinkJoin {
+    name = "tee-supplicant-plugins";
+    paths = cfg.supplicant.plugins;
+  };
+
+  fsParentPathArgs = lib.optional (cfg.supplicant.fsParentPath != null)
+    "--fs-parent-path=${cfg.supplicant.fsParentPath}";
+
+  supplicantArgs = lib.escapeShellArgs (
+    [
+      "--ta-path=${teeApplications}"
+      "--plugin-path=${supplicantPlugins}"
+    ]
+    ++ fsParentPathArgs
+    ++ cfg.supplicant.extraArgs
+  );
+
 in
 {
   imports = [
@@ -25,6 +48,47 @@ in
     hardware.nvidia-jetpack.firmware.optee = {
       supplicant = {
         enable = mkEnableOption "tee-supplicant daemon" // { default = true; };
+
+        earlyBoot = {
+          enable = mkEnableOption ''
+            starting tee-supplicant in the initrd (stage-1) so the fTPM
+            is available before local-fs.target. Required for LUKS
+            auto-unlock with fTPM. Mounts the boot partition in the
+            initrd for REE_FS secure storage at /boot/OP-TEE/REE-FS/
+          '';
+
+          trustedApplications = mkOption {
+            type = types.listOf types.package;
+            default = cfg.supplicant.trustedApplications;
+            defaultText = "supplicant.trustedApplications";
+            description = ''
+              Trusted applications for the initrd tee-supplicant. Defaults
+              to the same list as the normal-root supplicant. Override to
+              reduce initrd size by including only what's needed for LUKS.
+            '';
+          };
+
+          plugins = mkOption {
+            type = types.listOf types.package;
+            default = cfg.supplicant.plugins;
+            defaultText = "supplicant.plugins";
+            description = ''
+              Plugins for the initrd tee-supplicant. Defaults to the same
+              list as the normal-root supplicant. Override to reduce initrd
+              size by including only what's needed for LUKS.
+            '';
+          };
+        };
+
+        fsParentPath = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            Path passed to tee-supplicant --fs-parent-path for REE_FS
+            secure storage location. If null, uses tee-supplicant's
+            compiled-in default.
+          '';
+        };
 
         extraArgs = mkOption {
           type = types.listOf types.str;
@@ -53,6 +117,7 @@ in
           '';
         };
       };
+
 
       pkcs11Support = mkOption {
         type = types.bool;
@@ -123,7 +188,8 @@ in
             description = ''
               Specific EPS value (64-byte hex string with 0x prefix) to
               inject. If null, a random EPS is generated on first boot
-              and persisted to /var/lib/optee/ftpm/unsecureInjectEPS.hex.
+              and persisted. Location: /var/lib/optee/ftpm/unsecureInjectEPS.hex
+              (normal) or /boot/OP-TEE/unsecureInjectEPS.hex (earlyBoot).
             '';
           };
         };
@@ -171,13 +237,14 @@ in
 
   config = mkIf config.hardware.nvidia-jetpack.enable (lib.mkMerge [
     {
-      assertions = [{
-        assertion = !cfg.ftpm.enable || l4tAtLeast "35.5";
-        message = ''
-          hardware.nvidia-jetpack.firmware.optee.ftpm.enable requires
-          l4t >= r35.5.0.
-        '';
-      }
+      assertions = [
+        {
+          assertion = !cfg.ftpm.enable || l4tAtLeast "35.5";
+          message = ''
+            hardware.nvidia-jetpack.firmware.optee.ftpm.enable requires
+            l4t >= r35.5.0.
+          '';
+        }
         {
           assertion = !cfg.ftpm.enable
             || pkgs.nvidia-jetpack.socType == "t234"
@@ -187,7 +254,24 @@ in
             a t234 (Orin) or t264 (Thor) SoC.
             Got: ${pkgs.nvidia-jetpack.socType}
           '';
-        }];
+        }
+        {
+          assertion = !cfg.supplicant.earlyBoot.enable || cfg.ftpm.enable;
+          message = ''
+            supplicant.earlyBoot requires ftpm.enable (the initrd
+            services are only useful for fTPM-based LUKS unlock).
+          '';
+        }
+        {
+          assertion = !cfg.supplicant.earlyBoot.enable
+            || config.fileSystems ? "/boot";
+          message = ''
+            supplicant.earlyBoot requires fileSystems."/boot" to be
+            defined. The boot partition is mounted in the initrd for
+            OP-TEE REE_FS secure storage (/boot/optee/).
+          '';
+        }
+      ];
 
       hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
         lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
@@ -196,111 +280,92 @@ in
       hardware.nvidia-jetpack.firmware.optee.supplicant.plugins =
         lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest.plugins;
 
-      systemd.services.tee-supplicant =
-        let
-          teeApplications = pkgs.symlinkJoin {
-            name = "tee-applications";
-            paths = cfg.supplicant.trustedApplications;
-          };
-
-          supplicantPlugins = pkgs.symlinkJoin {
-            name = "tee-supplicant-plugins";
-            paths = cfg.supplicant.plugins;
-          };
-
-          args = lib.escapeShellArgs (
-            [
-              "--ta-path=${teeApplications}"
-              "--plugin-path=${supplicantPlugins}"
-            ]
-            ++ cfg.supplicant.extraArgs
-          );
-        in
-        mkIf cfg.supplicant.enable {
-          description = "Userspace supplicant for OPTEE-OS";
-          unitConfig.DefaultDependencies = false;
-          after = [ "local-fs.target" "modprobe@optee.service" ];
-          wants = [ "modprobe@optee.service" ];
-          before = [ "shutdown.target" ];
-          conflicts = [ "shutdown.target" ];
-          serviceConfig = {
-            # tee-supplicant is patched to call sd_notify(READY=1); without
-            # NOTIFY_SOCKET this is a harmless no-op for non-systemd users.
-            Type = "notify";
-            ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${args}";
-            Restart = "always";
-          };
-          wantedBy = [ "multi-user.target" ];
+      systemd.services.tee-supplicant = mkIf cfg.supplicant.enable {
+        description = "Userspace supplicant for OPTEE-OS";
+        unitConfig.DefaultDependencies = false;
+        after = [ "local-fs.target" "modprobe@optee.service" ];
+        wants = [ "modprobe@optee.service" ];
+        before = [ "shutdown.target" ];
+        conflicts = [ "shutdown.target" ];
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${supplicantArgs}";
+          Restart = "always";
         };
+        wantedBy = [ "multi-user.target" ];
+      };
 
       environment.systemPackages = lib.optional cfg.xtest pkgs.nvidia-jetpack.opteeXtest;
     }
 
-    (mkIf cfg.ftpm.enable {
-      boot.kernelModules = [ "tpm" ];
-      boot.initrd.availableKernelModules = [ "tpm" "tpm_ftpm_tee" ];
-      # tpm_ftpm_tee must load after tee-supplicant is up.
-      boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
+    (mkIf cfg.ftpm.enable (
+      let
+        epsFile =
+          if cfg.supplicant.earlyBoot.enable
+          then "/boot/OP-TEE/unsecureInjectEPS.hex"
+          else "/var/lib/optee/ftpm/unsecureInjectEPS.hex";
+        helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
+        # nvftpm-helper-app CLI changed between JetPack releases:
+        #   JP5 (r35): -g injects EPS
+        #   JP6+ (r36+): -g queries ECID, -m injects EPS
+        epsFlag = if l4tAtLeast "36" then "-m" else "-g";
 
-      boot.kernelPatches = [{
-        name = "fTPM_tee";
-        patch = null;
-        structuredExtraConfig = with lib.kernel; {
-          TCG_TPM = module;
-          TCG_FTPM_TEE = module;
-        };
-        features.fTPM_tee = true;
-      }];
+        epsInjectScript = ''
+          EPS_FILE=${lib.escapeShellArg epsFile}
+          EPS_SIZE=64
+          if [ ! -f "$EPS_FILE" ]; then
+            ${if cfg.ftpm.unsecureInjectEPS.value != null then ''
+              echo "Generating configured EPS for fTPM..."
+              EPS_HEX="${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}"
+            '' else ''
+              echo "Generating random EPS for fTPM..."
+              mkdir -p "$(dirname "$EPS_FILE")"
+              EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
+            ''}
+            echo "$EPS_HEX" > "$EPS_FILE"
+            chmod 600 "$EPS_FILE"
+            echo "EPS saved to $EPS_FILE"
+          else
+            echo "Using existing EPS from $EPS_FILE"
+          fi
+          EPS_VALUE=$(cat "$EPS_FILE")
+          echo "Injecting EPS into fTPM..."
+          ${helper} ${epsFlag} "$EPS_VALUE"
+        '';
 
-      systemd.services.ftpm-driver =
-        let
-          epsFile = "/var/lib/optee/ftpm/unsecureInjectEPS.hex";
-          helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
-          # nvftpm-helper-app CLI changed between JetPack releases:
-          #   JP5 (r35): -g injects EPS
-          #   JP6+ (r36+): -g queries ECID, -m injects EPS
-          epsFlag = if l4tAtLeast "36" then "-m" else "-g";
+        startScript = pkgs.writeShellScript "ftpm-driver-load" ''
+          set -euo pipefail
 
-          epsInjectScript = ''
-            EPS_FILE=${lib.escapeShellArg epsFile}
-            EPS_SIZE=64
-            if [ ! -f "$EPS_FILE" ]; then
-              ${if cfg.ftpm.unsecureInjectEPS.value != null then ''
-                echo "Generating configured EPS for fTPM..."
-                EPS_HEX="${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}"
-              '' else ''
-                echo "Generating random EPS for fTPM..."
-                mkdir -p "$(dirname "$EPS_FILE")"
-                EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
-              ''}
-              echo "$EPS_HEX" > "$EPS_FILE"
-              chmod 600 "$EPS_FILE"
-              echo "EPS saved to $EPS_FILE"
-            else
-              echo "Using existing EPS from $EPS_FILE"
-            fi
-            EPS_VALUE=$(cat "$EPS_FILE")
-            echo "Injecting EPS into fTPM..."
-            ${helper} ${epsFlag} "$EPS_VALUE"
-          '';
+          ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable epsInjectScript}
 
-          startScript = pkgs.writeShellScript "ftpm-driver-load" ''
-            set -euo pipefail
+          echo "Loading tpm_ftpm_tee driver..."
+          ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+        '';
 
-            ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable epsInjectScript}
+        stopScript = pkgs.writeShellScript "ftpm-driver-unload" ''
+          set -euo pipefail
 
-            echo "Loading tpm_ftpm_tee driver..."
-            ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
-          '';
+          echo "Unloading tpm_ftpm_tee driver..."
+          ${pkgs.kmod}/bin/modprobe -v -r tpm_ftpm_tee
+        '';
+      in
+      {
+        boot.kernelModules = [ "tpm" ];
+        boot.initrd.availableKernelModules = [ "tpm" "tpm_ftpm_tee" ];
+        # tpm_ftpm_tee must load after tee-supplicant is up.
+        boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
 
-          stopScript = pkgs.writeShellScript "ftpm-driver-unload" ''
-            set -euo pipefail
+        boot.kernelPatches = [{
+          name = "fTPM_tee";
+          patch = null;
+          structuredExtraConfig = with lib.kernel; {
+            TCG_TPM = module;
+            TCG_FTPM_TEE = module;
+          };
+          features.fTPM_tee = true;
+        }];
 
-            echo "Unloading tpm_ftpm_tee driver..."
-            ${pkgs.kmod}/bin/modprobe -v -r tpm_ftpm_tee
-          '';
-        in
-        {
+        systemd.services.ftpm-driver = {
           description = "Load fTPM driver after TEE supplicant";
           unitConfig.DefaultDependencies = false;
           after = [
@@ -320,12 +385,137 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
+            # In earlyBoot, module is already loaded from initrd — modprobe
+            # is idempotent and returns 0 for already-loaded modules.
             ExecStart = startScript;
             ExecStop = stopScript;
             StateDirectory = "optee/ftpm";
           };
         };
+      }
+    ))
 
-    })
+    # earlyBoot: run tee-supplicant and ftpm-driver in the initrd so
+    # /dev/tpm0 is available before local-fs.target (for LUKS unlock).
+    (mkIf (cfg.supplicant.earlyBoot.enable && cfg.ftpm.enable) (
+      let
+        bootFs = config.fileSystems."/boot";
+
+        initrdTeeApplications = pkgs.symlinkJoin {
+          name = "tee-applications-initrd";
+          paths = cfg.supplicant.earlyBoot.trustedApplications;
+        };
+
+        initrdSupplicantPlugins = pkgs.symlinkJoin {
+          name = "tee-supplicant-plugins-initrd";
+          paths = cfg.supplicant.earlyBoot.plugins;
+        };
+
+        initrdSupplicantArgs = lib.escapeShellArgs (
+          [
+            "--ta-path=${initrdTeeApplications}"
+            "--plugin-path=${initrdSupplicantPlugins}"
+          ]
+          ++ fsParentPathArgs
+          ++ cfg.supplicant.extraArgs
+        );
+
+        initrdEpsInjectScript = ''
+          EPS_FILE="/boot/OP-TEE/unsecureInjectEPS.hex"
+          EPS_SIZE=64
+          if [ ! -f "$EPS_FILE" ]; then
+            ${if cfg.ftpm.unsecureInjectEPS.value != null then ''
+              echo "Generating configured EPS for fTPM..."
+              EPS_HEX="${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}"
+            '' else ''
+              echo "Generating random EPS for fTPM..."
+              mkdir -p "$(dirname "$EPS_FILE")"
+              EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
+            ''}
+            echo "$EPS_HEX" > "$EPS_FILE"
+            chmod 600 "$EPS_FILE"
+            echo "EPS saved to $EPS_FILE"
+          else
+            echo "Using existing EPS from $EPS_FILE"
+          fi
+          EPS_VALUE=$(cat "$EPS_FILE")
+          echo "Injecting EPS into fTPM..."
+          ${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app ${if l4tAtLeast "36" then "-m" else "-g"} "$EPS_VALUE"
+        '';
+
+        initrdStartScript = pkgs.writeShellScript "ftpm-driver-load-initrd" ''
+          set -euo pipefail
+
+          ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable initrdEpsInjectScript}
+
+          echo "Loading tpm_ftpm_tee driver..."
+          ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+        '';
+      in
+      {
+        # Force-load optee in initrd so /dev/tee0 appears immediately.
+        boot.initrd.kernelModules = [ "optee" ];
+
+        # Default fsParentPath to /boot/OP-TEE/REE-FS when earlyBoot is enabled.
+        hardware.nvidia-jetpack.firmware.optee.supplicant.fsParentPath =
+          lib.mkDefault "/boot/OP-TEE/REE-FS";
+
+        boot.initrd.systemd = {
+          storePaths = [
+            "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant"
+            "${initrdTeeApplications}"
+            "${initrdSupplicantPlugins}"
+            "${pkgs.kmod}/bin/modprobe"
+            "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app"
+          ] ++ lib.optionals cfg.ftpm.unsecureInjectEPS.enable [
+            "${pkgs.coreutils}/bin/dd"
+            "${pkgs.xxd}/bin/xxd"
+          ];
+
+          # Mount /boot in the initrd for REE_FS secure storage access.
+          mounts = [{
+            where = "/boot";
+            what = bootFs.device;
+            type = bootFs.fsType or "vfat";
+            options = lib.concatStringsSep "," (bootFs.options or [ ]);
+          }];
+
+          services.tee-supplicant = {
+            description = "Userspace supplicant for OPTEE-OS (initrd)";
+            unitConfig.DefaultDependencies = false;
+            after = [ "boot.mount" "systemd-modules-load.service" ];
+            requires = [ "boot.mount" ];
+            before = [ "shutdown.target" ];
+            conflicts = [ "shutdown.target" ];
+            serviceConfig = {
+              Type = "notify";
+              ExecStart = "${pkgs.nvidia-jetpack.opteeClient}/bin/tee-supplicant ${initrdSupplicantArgs}";
+              Restart = "always";
+            };
+            wantedBy = [ "sysinit.target" ];
+          };
+
+          services.ftpm-driver = {
+            description = "Load fTPM driver (initrd)";
+            unitConfig.DefaultDependencies = false;
+            after = [ "tee-supplicant.service" "boot.mount" ];
+            before = [
+              "tpm2.target"
+              "systemd-tpm2-setup-early.service"
+              "systemd-tpm2-setup.service"
+              "shutdown.target"
+            ];
+            conflicts = [ "shutdown.target" ];
+            requires = [ "tee-supplicant.service" ];
+            wantedBy = [ "tpm2.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = initrdStartScript;
+            };
+          };
+        };
+      }
+    ))
   ]);
 }

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -279,13 +279,20 @@ in
             ${helper} ${epsFlag} "$EPS_VALUE"
           '';
 
-          script = pkgs.writeShellScript "ftpm-driver-load" ''
+          startScript = pkgs.writeShellScript "ftpm-driver-load" ''
             set -euo pipefail
 
             ${lib.optionalString cfg.ftpm.unsecureInjectEPS.enable epsInjectScript}
 
             echo "Loading tpm_ftpm_tee driver..."
             ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+          '';
+
+          stopScript = pkgs.writeShellScript "ftpm-driver-unload" ''
+            set -euo pipefail
+
+            echo "Unloading tpm_ftpm_tee driver..."
+            ${pkgs.kmod}/bin/modprobe -v -r tpm_ftpm_tee
           '';
         in
         {
@@ -300,7 +307,8 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
-            ExecStart = script;
+            ExecStart = startScript;
+            ExecStop = stopScript;
             StateDirectory = "optee/ftpm";
           };
         };

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -103,7 +103,7 @@ in
           type = types.int;
           default = 0;
           description = ''
-            CFG_TA_LOG_LEVEL passed to the MS TPM 2.0 reference TA build.
+            CFG_TEE_TA_LOG_LEVEL passed to the MS TPM 2.0 reference TA build.
             Independent from
             hardware.nvidia-jetpack.firmware.optee.taLogLevel.
           '';

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -258,6 +258,15 @@ in
         }
         {
           assertion = !cfg.supplicant.earlyBoot.enable
+            || config.boot.initrd.systemd.enable;
+          message = ''
+            supplicant.earlyBoot requires boot.initrd.systemd.enable = true.
+            The current earlyBoot implementation for LUKS support requires
+            systemd in the initrd.
+          '';
+        }
+        {
+          assertion = !cfg.supplicant.earlyBoot.enable
             || config.fileSystems ? "/boot";
           message = ''
             supplicant.earlyBoot requires fileSystems."/boot" to be

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -218,6 +218,11 @@ in
         in
         mkIf cfg.supplicant.enable {
           description = "Userspace supplicant for OPTEE-OS";
+          unitConfig.DefaultDependencies = false;
+          after = [ "local-fs.target" "modprobe@optee.service" ];
+          wants = [ "modprobe@optee.service" ];
+          before = [ "shutdown.target" ];
+          conflicts = [ "shutdown.target" ];
           serviceConfig = {
             # tee-supplicant is patched to call sd_notify(READY=1); without
             # NOTIFY_SOCKET this is a harmless no-op for non-systemd users.
@@ -297,13 +302,21 @@ in
         in
         {
           description = "Load fTPM driver after TEE supplicant";
+          unitConfig.DefaultDependencies = false;
           after = [
             "tee-supplicant.service"
             "local-fs.target"
             "systemd-modules-load.service"
           ];
+          before = [
+            "tpm2.target"
+            "systemd-tpm2-setup-early.service"
+            "systemd-tpm2-setup.service"
+            "shutdown.target"
+          ];
+          conflicts = [ "shutdown.target" ];
           requires = [ "tee-supplicant.service" ];
-          wantedBy = [ "multi-user.target" ];
+          wantedBy = [ "tpm2.target" ];
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
@@ -312,6 +325,7 @@ in
             StateDirectory = "optee/ftpm";
           };
         };
+
     })
   ]);
 }

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -467,6 +467,7 @@ in
             "${initrdSupplicantPlugins}"
             "${pkgs.kmod}/bin/modprobe"
             "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app"
+            "${initrdStartScript}"
           ] ++ lib.optionals cfg.ftpm.unsecureInjectEPS.enable [
             "${pkgs.coreutils}/bin/dd"
             "${pkgs.xxd}/bin/xxd"

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -121,7 +121,7 @@ in
             description = ''
               Specific EPS value (64-byte hex string with 0x prefix) to
               inject. If null, a random EPS is generated on first boot
-              and persisted to /var/lib/unsecureInjectEPS.hex.
+              and persisted to /var/lib/optee/ftpm/unsecureInjectEPS.hex.
             '';
           };
         };
@@ -178,7 +178,14 @@ in
           compilation to use the CFG_MS_TPM_20_REF flag and is not yet
           supported here.
         '';
-      }];
+      }
+        {
+          assertion = !cfg.ftpm.enable || pkgs.nvidia-jetpack.socType == "t234";
+          message = ''
+            hardware.nvidia-jetpack.firmware.optee.ftpm.enable currently
+            requires a t234 (Orin) SoC. Got: ${pkgs.nvidia-jetpack.socType}
+          '';
+        }];
 
       hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications =
         lib.optional cfg.pkcs11Support pkgs.nvidia-jetpack.pkcs11Ta
@@ -240,32 +247,35 @@ in
 
       systemd.services.ftpm-driver =
         let
-          epsFile = "/var/lib/unsecureInjectEPS.hex";
+          epsFile = "/var/lib/optee/ftpm/unsecureInjectEPS.hex";
           helper = "${pkgs.nvidia-jetpack.ftpmHelperTa}/bin/nvftpm-helper-app";
+          # nvftpm-helper-app CLI changed between JetPack releases:
+          #   JP5 (r35): -g injects EPS
+          #   JP6+ (r36+): -g queries ECID, -m injects EPS
+          epsFlag = if l4tAtLeast "36" then "-m" else "-g";
 
-          epsInjectScript =
-            if cfg.ftpm.unsecureInjectEPS.value != null then ''
-              echo "Injecting configured EPS into fTPM..."
-              ${helper} -g ${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}
-            '' else ''
-              EPS_FILE=${lib.escapeShellArg epsFile}
-              EPS_SIZE=64
-
-              if [ ! -f "$EPS_FILE" ]; then
+          epsInjectScript = ''
+            EPS_FILE=${lib.escapeShellArg epsFile}
+            EPS_SIZE=64
+            if [ ! -f "$EPS_FILE" ]; then
+              ${if cfg.ftpm.unsecureInjectEPS.value != null then ''
+                echo "Generating configured EPS for fTPM..."
+                EPS_HEX="${lib.escapeShellArg cfg.ftpm.unsecureInjectEPS.value}"
+              '' else ''
                 echo "Generating random EPS for fTPM..."
                 mkdir -p "$(dirname "$EPS_FILE")"
                 EPS_HEX="0x$(${pkgs.coreutils}/bin/dd if=/dev/urandom bs=1 count=$EPS_SIZE 2>/dev/null | ${pkgs.xxd}/bin/xxd -p -c 256)"
-                echo "$EPS_HEX" > "$EPS_FILE"
-                chmod 600 "$EPS_FILE"
-                echo "EPS saved to $EPS_FILE"
-              else
-                echo "Using existing EPS from $EPS_FILE"
-              fi
-
-              EPS_VALUE=$(cat "$EPS_FILE")
-              echo "Injecting EPS into fTPM..."
-              ${helper} -g "$EPS_VALUE"
-            '';
+              ''}
+              echo "$EPS_HEX" > "$EPS_FILE"
+              chmod 600 "$EPS_FILE"
+              echo "EPS saved to $EPS_FILE"
+            else
+              echo "Using existing EPS from $EPS_FILE"
+            fi
+            EPS_VALUE=$(cat "$EPS_FILE")
+            echo "Injecting EPS into fTPM..."
+            ${helper} ${epsFlag} "$EPS_VALUE"
+          '';
 
           script = pkgs.writeShellScript "ftpm-driver-load" ''
             set -euo pipefail
@@ -289,6 +299,7 @@ in
             Type = "oneshot";
             RemainAfterExit = true;
             ExecStart = script;
+            StateDirectory = "optee/ftpm";
           };
         };
     })

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -154,15 +154,9 @@ in
           '';
         };
 
-        measuredBoot = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Enable measured-boot support. Sets CFG_TA_MEASURED_BOOT in the
-            MS TPM 2.0 reference TA build and CFG_CORE_TPM_EVENT_LOG in
-            OP-TEE OS.
-          '';
-        };
+        # Sets CFG_TA_MEASURED_BOOT in the MS TPM 2.0 reference TA build
+        # and CFG_CORE_TPM_EVENT_LOG in OP-TEE OS.
+        measuredBoot = mkEnableOption "measured-boot support" // { default = true; };
 
         taLogLevel = mkOption {
           type = types.int;

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -342,6 +342,18 @@ in
           ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
         '';
 
+        # Used when earlyBoot is enabled: cycle the module to close the
+        # stale TEE session from the initrd supplicant and open a fresh one
+        # with the post-switch-root supplicant (cf. OP-TEE issue #5766).
+        reloadScript = pkgs.writeShellScript "ftpm-driver-reload" ''
+          set -euo pipefail
+
+          echo "Reloading tpm_ftpm_tee (fresh session after switch-root)..."
+          ${pkgs.kmod}/bin/modprobe -r tpm_ftpm_tee
+          sleep 1
+          ${pkgs.kmod}/bin/modprobe tpm_ftpm_tee
+        '';
+
         stopScript = pkgs.writeShellScript "ftpm-driver-unload" ''
           set -euo pipefail
 
@@ -385,9 +397,10 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
-            # In earlyBoot, module is already loaded from initrd — modprobe
-            # is idempotent and returns 0 for already-loaded modules.
-            ExecStart = startScript;
+            ExecStart =
+              if cfg.supplicant.earlyBoot.enable
+              then reloadScript
+              else startScript;
             ExecStop = stopScript;
             StateDirectory = "optee/ftpm";
           };

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -172,10 +172,10 @@ in
   config = mkIf config.hardware.nvidia-jetpack.enable (lib.mkMerge [
     {
       assertions = [{
-        assertion = !cfg.ftpm.enable || l4tAtLeast "36";
+        assertion = !cfg.ftpm.enable || l4tAtLeast "35.5";
         message = ''
           hardware.nvidia-jetpack.firmware.optee.ftpm.enable requires
-          l4t r36.x or later. r35 lacks fTPM source.
+          l4t >= r35.5.0.
         '';
       }
         {

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -92,13 +92,7 @@ final: prev: (
         inherit (finalJetpack) socType;
       };
 
-      # fTPM TAs are referenced from the BASE scope (`prev.nvidia-jetpack`), not
-      # `finalJetpack`/`prevJetpack`. `taDevKit = optee-os.overrideAttrs(...)`,
-      # so resolving via the new scope would create a cycle:
-      # optee-os.earlyTaPaths -> fTPM TA -> taDevKit -> optee-os. The TAs are
-      # functionally independent of the user's optee-os overrides (they only
-      # need ta_dev_kit headers, not the user's CFG flags or patches).
-      msTpm20RefTa = prev.nvidia-jetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
+      msTpm20RefTa = prevJetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
         makeFlags = prevAttrs.makeFlags or [ ]
           ++ [ "CFG_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
@@ -109,24 +103,16 @@ final: prev: (
         inherit (finalJetpack) socType;
         inherit (cfg.firmware.optee) taPublicKeyFile coreLogLevel taLogLevel;
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
-        makeFlags = prevAttrs.makeFlags or [ ]
-          ++ cfg.firmware.optee.extraMakeFlags
-          ++ lib.optionals cfg.firmware.optee.ftpm.enable [
-          "CFG_REE_STATE=y"
-          "CFG_JETSON_FTPM_HELPER_PTA=y"
-        ]
-          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot
-          "CFG_CORE_TPM_EVENT_LOG=y"
-          ++ lib.optional cfg.firmware.optee.ftpm.unsecureInjectEPS.enable
-          (lib.warn
-            "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
-            "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y");
-        earlyTaPaths = prevAttrs.earlyTaPaths or [ ]
-          ++ lib.optionals
-          (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234") [
-          "${prev.nvidia-jetpack.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
-          "${finalJetpack.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
-        ];
+        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
+        enableFTPM = cfg.firmware.optee.ftpm.enable;
+        measuredBoot = cfg.firmware.optee.ftpm.measuredBoot;
+        unsecureInjectEPS = cfg.firmware.optee.ftpm.unsecureInjectEPS.enable;
+        ftpmHelperTa =
+          if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+          then finalJetpack.ftpmHelperTa else null;
+        msTpm20RefTa =
+          if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+          then finalJetpack.msTpm20RefTa else null;
       });
       opteeClient = prevJetpack.opteeClient.overrideAttrs (prevAttrs: {
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -108,10 +108,10 @@ final: prev: (
         measuredBoot = cfg.firmware.optee.ftpm.measuredBoot;
         unsecureInjectEPS = cfg.firmware.optee.ftpm.unsecureInjectEPS.enable;
         ftpmHelperTa =
-          if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+          if cfg.firmware.optee.ftpm.enable
           then finalJetpack.ftpmHelperTa else null;
         msTpm20RefTa =
-          if (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234")
+          if cfg.firmware.optee.ftpm.enable
           then finalJetpack.msTpm20RefTa else null;
       });
       opteeClient = prevJetpack.opteeClient.overrideAttrs (prevAttrs: {

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -101,7 +101,7 @@ final: prev: (
       msTpm20RefTa = prevJetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
         makeFlags = prevAttrs.makeFlags or [ ]
-          ++ [ "CFG_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
+          ++ [ "CFG_TEE_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
           ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot "CFG_TA_MEASURED_BOOT=y";
       });
 

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -71,6 +71,12 @@ final: prev: (
             })).bup;
           in
           builtins.hashString "sha256" "${cursedBup}";
+      } // lib.optionalAttrs (prevJetpack.l4tAtLeast "38") {
+        # r38-only: when true, skip the disable-ftpm.diff patch so UEFI uses
+        # the fTPM TA we embedded in tos.img. r35/r36 builders don't accept
+        # this argument (their fn args don't include enableFTPM), so we only
+        # pass it on r38+.
+        enableFTPM = cfg.firmware.optee.ftpm.enable;
       } // lib.optionalAttrs cfg.firmware.uefi.capsuleAuthentication.enable {
         inherit (cfg.firmware.uefi.capsuleAuthentication) trustedPublicCertPemFile;
       });

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -91,11 +91,42 @@ final: prev: (
       armTrustedFirmware = prevJetpack.armTrustedFirmware.overrideAttrs {
         inherit (finalJetpack) socType;
       };
+
+      # fTPM TAs are referenced from the BASE scope (`prev.nvidia-jetpack`), not
+      # `finalJetpack`/`prevJetpack`. `taDevKit = optee-os.overrideAttrs(...)`,
+      # so resolving via the new scope would create a cycle:
+      # optee-os.earlyTaPaths -> fTPM TA -> taDevKit -> optee-os. The TAs are
+      # functionally independent of the user's optee-os overrides (they only
+      # need ta_dev_kit headers, not the user's CFG flags or patches).
+      msTpm20RefTa = prev.nvidia-jetpack.msTpm20RefTa.overrideAttrs (prevAttrs: {
+        patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
+        makeFlags = prevAttrs.makeFlags or [ ]
+          ++ [ "CFG_TA_LOG_LEVEL=${toString cfg.firmware.optee.ftpm.taLogLevel}" ]
+          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot "CFG_TA_MEASURED_BOOT=y";
+      });
+
       optee-os = prevJetpack.optee-os.overrideAttrs (prevAttrs: {
         inherit (finalJetpack) socType;
         inherit (cfg.firmware.optee) taPublicKeyFile coreLogLevel taLogLevel;
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;
-        makeFlags = prevAttrs.makeFlags or [ ] ++ cfg.firmware.optee.extraMakeFlags;
+        makeFlags = prevAttrs.makeFlags or [ ]
+          ++ cfg.firmware.optee.extraMakeFlags
+          ++ lib.optionals cfg.firmware.optee.ftpm.enable [
+          "CFG_REE_STATE=y"
+          "CFG_JETSON_FTPM_HELPER_PTA=y"
+        ]
+          ++ lib.optional cfg.firmware.optee.ftpm.measuredBoot
+          "CFG_CORE_TPM_EVENT_LOG=y"
+          ++ lib.optional cfg.firmware.optee.ftpm.unsecureInjectEPS.enable
+          (lib.warn
+            "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
+            "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y");
+        earlyTaPaths = prevAttrs.earlyTaPaths or [ ]
+          ++ lib.optionals
+          (cfg.firmware.optee.ftpm.enable && finalJetpack.socType == "t234") [
+          "${prev.nvidia-jetpack.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
+          "${finalJetpack.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
+        ];
       });
       opteeClient = prevJetpack.opteeClient.overrideAttrs (prevAttrs: {
         patches = prevAttrs.patches or [ ] ++ cfg.firmware.optee.patches;

--- a/pkgs/optee/0001-ftpm-helper-no-install-makefile.patch
+++ b/pkgs/optee/0001-ftpm-helper-no-install-makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/optee/samples/ftpm-helper/host/Makefile b/optee/samples/ftpm-helper/host/Makefile
+index 8f26a1f..2ec5f5d 100644
+--- a/optee/samples/ftpm-helper/host/Makefile
++++ b/optee/samples/ftpm-helper/host/Makefile
+@@ -20,7 +20,7 @@ OBJS = $(patsubst %.c,$(O)/%.o,$(SRCS))
+ BINARY = nvftpm-helper-app
+
+ .PHONY: all install
+-all: $(BINARY) install
++all: $(BINARY)
+
+ $(BINARY): $(OBJS)
+ 	$(CC) -o $(O)/$@ $< $(LDADD)

--- a/pkgs/optee/0001-jetson_ftpm_helper_pta-Return-SHORT_BUFFER-when-EPS-.patch
+++ b/pkgs/optee/0001-jetson_ftpm_helper_pta-Return-SHORT_BUFFER-when-EPS-.patch
@@ -1,0 +1,54 @@
+From 9c6495e90fcb39cb9e632aacecda539255488f29 Mon Sep 17 00:00:00 2001
+From: dperezzoghbi <dperezzoghbi@anduril.com>
+Date: Wed, 29 Jul 2026 15:28:50 -0700
+Subject: [PATCH] jetson_ftpm_helper_pta: Return SHORT_BUFFER when EPS buf too
+ small
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+get_prop_endorsement_seed() silently truncated the EPS to whatever
+buffer size the caller passed, returning TEE_SUCCESS with a partial
+copy and *blen reflecting the request rather than the true property
+size. This violates the GP TEE Internal Core API requirement that
+SHORT_BUFFER be returned with *blen set to the full required size
+when the output buffer is insufficient.
+
+The practical consequence: TEE_GetPropertyAsString() probes the
+property size with a minimal internal buffer (clamped to
+sizeof(TEE_Identity) = 20 bytes), receives a truncated 20-byte
+"value" with TEE_SUCCESS, and base64-encodes that to a required
+length of 29 — inconsistent with the 89 bytes reported on a full
+read. xtest regression_1006 detects this inconsistency.
+
+Fix by returning TEE_ERROR_SHORT_BUFFER with *blen = sizeof(eps)
+when the caller's buffer is smaller than the full EPS, matching
+the GP spec requirement. The only legitimate consumer,
+_plat__GetEPS(), passes a buffer large enough for its requested
+Size, so this change is safe for that caller.
+---
+ optee/optee_os/core/pta/tegra/jetson_ftpm_helper_pta.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/optee/optee_os/core/pta/tegra/jetson_ftpm_helper_pta.c b/optee/optee_os/core/pta/tegra/jetson_ftpm_helper_pta.c
+index 42b7886d..af9f9314 100644
+--- a/optee/optee_os/core/pta/tegra/jetson_ftpm_helper_pta.c
++++ b/optee/optee_os/core/pta/tegra/jetson_ftpm_helper_pta.c
+@@ -463,10 +463,11 @@ out:
+ 	if (rc != TEE_SUCCESS)
+ 		return rc;
+ 
+-	if (*blen < sizeof(eps))
+-		eps_len = *blen;
+-	else
++	if (*blen < sizeof(eps)) {
+ 		*blen = sizeof(eps);
++		return TEE_ERROR_SHORT_BUFFER;
++	}
++	*blen = sizeof(eps);
+ 
+ 	return copy_to_user(buf, eps, eps_len);
+ }
+-- 
+2.51.2
+

--- a/pkgs/optee/0002-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set.patch
+++ b/pkgs/optee/0002-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set.patch
@@ -1,0 +1,48 @@
+From eadf869252df100a5bceee894a3570d52d605f9e Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Fri, 3 Jul 2026 11:09:17 -0700
+Subject: [PATCH] build tpm_log_test TA when CFG_CORE_TPM_EVENT_LOG is set
+
+The host xtest binary compiles regression_1024 (the
+PTA_SYSTEM_GET_TPM_EVENT_LOG test) whenever the OP-TEE OS TA-devkit
+reports CFG_CORE_TPM_EVENT_LOG, but the TA build never builds the
+tpm_log_test TA that the test depends on (only the CMake build lists
+it).
+
+On platforms that enable CFG_CORE_TPM_EVENT_LOG (e.g. Tegra264/Thor
+with fTPM) this leaves regression_1024 opening a session against a TA
+that is not installed. The test does not check the return code of
+xtest_teec_open_session() and then invokes a command on the resulting
+NULL session context, which crashes xtest with SIGSEGV and aborts the
+whole regression suite before any later test can run.
+
+Build (and therefore install) the tpm_log_test TA under the same guard
+that the host side uses to compile the test, so xtest and the TA stay
+in sync and the regression suite runs to completion.
+
+Ported from meta-tegra:
+https://github.com/OE4T/meta-tegra/pull/2286
+
+Upstream-Status: Pending
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ optee/optee_test/ta/Makefile.gmake | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/optee/optee_test/ta/Makefile.gmake b/optee/optee_test/ta/Makefile.gmake
+index 8f3f802..2f227bd 100644
+--- a/optee/optee_test/ta/Makefile.gmake
++++ b/optee/optee_test/ta/Makefile.gmake
+@@ -43,6 +43,10 @@ ifeq ($(CFG_TA_BTI),y)
+ TA_DIRS += bti_test
+ endif
+
++ifeq ($(CFG_CORE_TPM_EVENT_LOG),y)
++TA_DIRS += tpm_log_test
++endif
++
+ .PHONY: all
+ all: ta
+
+--
+2.43.0

--- a/pkgs/optee/0002-ftpm-helper-skip-prov-mode-for-inject-eps.patch
+++ b/pkgs/optee/0002-ftpm-helper-skip-prov-mode-for-inject-eps.patch
@@ -1,0 +1,45 @@
+From 70c68469b2bb6765fb396fe6f5ffb80766dfec7b Mon Sep 17 00:00:00 2001
+From: dperezzoghbi <dperezzoghbi@anduril.com>
+Date: Wed, 6 May 2026 20:14:28 -0700
+Subject: [PATCH] ftpm-helper: skip prov_mode query for inject_eps
+
+The ca_query_prov_mode() call gates all CA commands behind a PTA
+is_ready check. On devices where BootSecurityInfo fuse bits 11/13
+are not set, the fTPM DT node is never enabled by MB2, causing
+ftpm_helper_dt_init() to fail and is_ready to remain false.
+
+The inject_eps PTA command itself has no is_ready guard -- it
+unconditionally writes to the external_eps buffer. Skip the entire
+prov_mode query and validation when inject_eps is the requested
+operation to avoid spurious error output and allow EPS injection
+on unprovisioned devices.
+---
+ optee/samples/ftpm-helper/host/ftpm_helper_ca.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/optee/samples/ftpm-helper/host/ftpm_helper_ca.c b/optee/samples/ftpm-helper/host/ftpm_helper_ca.c
+index 1395527..80b8c61 100644
+--- a/optee/samples/ftpm-helper/host/ftpm_helper_ca.c
++++ b/optee/samples/ftpm-helper/host/ftpm_helper_ca.c
+@@ -683,6 +683,10 @@ int main(int argc, char *argv[])
+ 	if(prepare_tee_session(&ca_sess))
+ 		goto err_out;
+ 
++	/* inject_eps works regardless of provisioning state */
++	if (argus.ftpm_helper_options & FTPM_HELPER_INJECT_EPS)
++		goto skip_prov_mode;
++
+ 	ca_sess.prov_mode = FTPM_PROV_MODE_UNKNOWN;
+ 	ca_query_prov_mode();
+ 
+@@ -707,6 +711,7 @@ int main(int argc, char *argv[])
+ 		goto err_out;
+ 	}
+ 
++skip_prov_mode:
+ 	handle_ftpm_helper_options(&ca_sess);
+ 
+ err_out:
+-- 
+2.51.2
+

--- a/pkgs/optee/0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
+++ b/pkgs/optee/0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
@@ -1,0 +1,10 @@
+--- a/optee/optee_client/tee-supplicant/Makefile
++++ b/optee/optee_client/tee-supplicant/Makefile
+@@ -18,7 +18,6 @@
+ 		   teec_ta_load.c \
+ 		   tee_supp_fs.c \
+ 		   rpmb.c \
+-		   nvme_rpmb.c \
+ 		   handle.c
+ 
+ ifeq ($(CFG_GP_SOCKETS),y)

--- a/pkgs/optee/0003-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set-pre-gmake.patch
+++ b/pkgs/optee/0003-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set-pre-gmake.patch
@@ -1,0 +1,52 @@
+From eadf869252df100a5bceee894a3570d52d605f9e Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Fri, 3 Jul 2026 11:09:17 -0700
+Subject: [PATCH] build tpm_log_test TA when CFG_CORE_TPM_EVENT_LOG is set
+
+The host xtest binary compiles regression_1024 (the
+PTA_SYSTEM_GET_TPM_EVENT_LOG test) whenever the OP-TEE OS TA-devkit
+reports CFG_CORE_TPM_EVENT_LOG, but the TA build never builds the
+tpm_log_test TA that the test depends on (only the CMake build lists
+it).
+
+On platforms that enable CFG_CORE_TPM_EVENT_LOG (e.g. via
+hardware.nvidia-jetpack.firmware.optee.ftpm.measuredBoot, which
+defaults to true whenever fTPM is enabled) this leaves regression_1024
+opening a session against a TA that is not installed. The test does
+not check the return code of xtest_teec_open_session() and then
+invokes a command on the resulting NULL session context, which
+crashes xtest with SIGSEGV and aborts the whole regression suite
+before any later test can run.
+
+Build (and therefore install) the tpm_log_test TA under the same guard
+that the host side uses to compile the test, so xtest and the TA stay
+in sync and the regression suite runs to completion.
+
+This is the r35/r36 (pre Makefile.gmake rename) counterpart of the fix
+ported from meta-tegra in
+0002-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set.patch:
+https://github.com/OE4T/meta-tegra/pull/2286
+
+Upstream-Status: Pending
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ optee/optee_test/ta/Makefile | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/optee/optee_test/ta/Makefile b/optee/optee_test/ta/Makefile
+index 8f3f802..2f227bd 100644
+--- a/optee/optee_test/ta/Makefile
++++ b/optee/optee_test/ta/Makefile
+@@ -43,6 +43,10 @@ ifeq ($(CFG_TA_BTI),y)
+ TA_DIRS += bti_test
+ endif
+
++ifeq ($(CFG_CORE_TPM_EVENT_LOG),y)
++TA_DIRS += tpm_log_test
++endif
++
+ .PHONY: all
+ all: ta
+
+--
+2.43.0

--- a/pkgs/optee/0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
+++ b/pkgs/optee/0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
@@ -1,0 +1,10 @@
+--- a/optee/optee_client/tee-supplicant/Makefile
++++ b/optee/optee_client/tee-supplicant/Makefile
+@@ -18,6 +18,7 @@
+ 		   teec_ta_load.c \
+ 		   tee_supp_fs.c \
+ 		   rpmb.c \
++		   nvme_rpmb.c \
+ 		   handle.c \
+ 		   sd_notify.c
+ 

--- a/pkgs/optee/ftpmHelperTa.nix
+++ b/pkgs/optee/ftpmHelperTa.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, taDevKit
+, opteeClient
+, l4tMajorMinorPatchVersion
+, buildPackages
+, gitRepos
+}:
+stdenv.mkDerivation {
+  pname = "ftpm-helper-ta";
+  version = l4tMajorMinorPatchVersion;
+  src = gitRepos."tegra/optee-src/nv-optee";
+  patches = [ ./0001-ftpm-helper-no-install-makefile.patch ];
+  nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+  enableParallelBuilding = true;
+  makeFlags = [
+    "-C optee/samples/ftpm-helper"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+    "OPTEE_CLIENT_EXPORT=${opteeClient}"
+    "O=$(PWD)/out"
+  ];
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin out/ca/ftpm-helper/nvftpm-helper-app
+    install -Dm755 -t $out out/early_ta/ftpm-helper/*.stripped.elf
+
+    runHook postInstall
+  '';
+  meta.platforms = [ "aarch64-linux" ];
+}

--- a/pkgs/optee/ftpmHelperTa.nix
+++ b/pkgs/optee/ftpmHelperTa.nix
@@ -1,7 +1,9 @@
-{ stdenv
+{ lib
+, stdenv
 , taDevKit
 , opteeClient
 , l4tMajorMinorPatchVersion
+, l4tAtLeast
 , buildPackages
 , gitRepos
 }:
@@ -9,7 +11,11 @@ stdenv.mkDerivation {
   pname = "ftpm-helper-ta";
   version = l4tMajorMinorPatchVersion;
   src = gitRepos."tegra/optee-src/nv-optee";
-  patches = [ ./0001-ftpm-helper-no-install-makefile.patch ];
+  patches = [
+    ./0001-ftpm-helper-no-install-makefile.patch
+  ] ++ lib.optionals (l4tAtLeast "36") [
+    ./0002-ftpm-helper-skip-prov-mode-for-inject-eps.patch
+  ];
   nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
   enableParallelBuilding = true;
   makeFlags = [

--- a/pkgs/optee/msTpm20RefTa.nix
+++ b/pkgs/optee/msTpm20RefTa.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, taDevKit
+, opteeClient
+, l4tMajorMinorPatchVersion
+, buildPackages
+, gitRepos
+}:
+# TODO: r38 refactored fTPM compilation to use the CFG_MS_TPM_20_REF flag in
+# the optee-os build itself, which would make this separate TA derivation
+# obsolete on r38. Add an r38 code path here (or replace this with the
+# optee-os flag) once r38 fTPM support is wired up.
+stdenv.mkDerivation {
+  pname = "ms-tpm-20-ref-ta";
+  version = l4tMajorMinorPatchVersion;
+  src = gitRepos."tegra/optee-src/nv-optee";
+  nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
+  enableParallelBuilding = true;
+
+  # Suppress GCC 13+ warnings-as-errors from upstream sources to avoid
+  # depending on gcc13.
+  NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types -Wno-implicit-function-declaration";
+
+  makeFlags = [
+    "-C optee/samples/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+    "OPTEE_CLIENT_EXPORT=${opteeClient}"
+    "OPTEE_OS_DIR=$(PWD)/optee/optee_os"
+    "O=$(PWD)/out"
+    "CFG_USE_PLATFORM_EPS=y"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out out/early_ta/ms-tpm/*.stripped.elf
+
+    runHook postInstall
+  '';
+  meta.platforms = [ "aarch64-linux" ];
+}

--- a/pkgs/optee/msTpm20RefTa.nix
+++ b/pkgs/optee/msTpm20RefTa.nix
@@ -2,13 +2,20 @@
 , taDevKit
 , opteeClient
 , l4tMajorMinorPatchVersion
+, lib
 , buildPackages
 , gitRepos
 }:
-# TODO: r38 refactored fTPM compilation to use the CFG_MS_TPM_20_REF flag in
-# the optee-os build itself, which would make this separate TA derivation
-# obsolete on r38. Add an r38 code path here (or replace this with the
-# optee-os flag) once r38 fTPM support is wired up.
+let
+  l4tMajorVersion = lib.versions.major l4tMajorMinorPatchVersion;
+  # r38 split NVIDIA's platform glue out of the in-tree MS reference TA at
+  # optee/samples/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta into a new
+  # top-level optee/optee_ftpm/, and consumes the MS reference as a library
+  # via CFG_MS_TPM_20_REF. The build output also moved from early_ta/ms-tpm/
+  # to early_ta/optee_ftpm/. The OP-TEE TA UUID is the same on both
+  # (bc50d971-d4c9-42c4-82cb-343fb7f37896), so consumers don't need to care.
+  isR38OrLater = lib.versionAtLeast l4tMajorVersion "38";
+in
 stdenv.mkDerivation {
   pname = "ms-tpm-20-ref-ta";
   version = l4tMajorMinorPatchVersion;
@@ -16,24 +23,30 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ (buildPackages.python3.withPackages (p: [ p.cryptography ])) ];
   enableParallelBuilding = true;
 
-  # Suppress GCC 13+ warnings-as-errors from upstream sources to avoid
-  # depending on gcc13.
+  # Suppress GCC 13+ warnings-as-errors. r36's ms-tpm-20-ref reference
+  # sources trip these; r38's optee_ftpm/sub.mk already adds per-file
+  # -Wno- flags, so this is belt-and-suspenders there.
   NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types -Wno-implicit-function-declaration";
 
   makeFlags = [
-    "-C optee/samples/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
     "OPTEE_CLIENT_EXPORT=${opteeClient}"
     "OPTEE_OS_DIR=$(PWD)/optee/optee_os"
-    "O=$(PWD)/out"
     "CFG_USE_PLATFORM_EPS=y"
-  ];
+  ] ++ (if isR38OrLater then [
+    "-C optee/optee_ftpm"
+    "O=$(PWD)/out/early_ta/optee_ftpm"
+    "CFG_MS_TPM_20_REF=$(PWD)/optee/samples/ms-tpm-20-ref"
+  ] else [
+    "-C optee/samples/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta"
+    "O=$(PWD)/out"
+  ]);
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out out/early_ta/ms-tpm/*.stripped.elf
+    install -Dm755 -t $out out/early_ta/${if isR38OrLater then "optee_ftpm" else "ms-tpm"}/*.stripped.elf
 
     runHook postInstall
   '';

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -37,7 +37,16 @@ in
   ftpmHelperTa = null;
   msTpm20RefTa = null;
 
-  earlyTaPaths = lib.optionals (finalAttrs.ftpmHelperTa != null) [
+  # Stripped ELFs are used here rather than signed .ta files. Early TAs
+  # are embedded directly in the OP-TEE binary image and do not require
+  # signing — they inherit the same trust level as OP-TEE OS itself.
+  # Only REE (file-system-loaded) TAs need to be signed.
+  # See: https://optee.readthedocs.io/en/latest/building/trusted_applications.html#signing-of-tas
+  #
+  # Using enableFTPM (rather than ftpmHelperTa != null) ensures that if
+  # enableFTPM = true but the TA paths weren't provided, you get an
+  # immediate eval error instead of a silent disable of fTPM.
+  earlyTaPaths = lib.optionals finalAttrs.enableFTPM [
     "${finalAttrs.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
     "${finalAttrs.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
   ];
@@ -85,15 +94,15 @@ in
     "CFG_STMM_PATH=${jetsonStandaloneMMOptee}/standalonemm_optee.bin"
   ])
   ++ (lib.optional (finalAttrs.taPublicKeyFile != null) "TA_PUBLIC_KEY=${finalAttrs.taPublicKeyFile}")
-  ++ lib.optionals finalAttrs.enableFTPM [
+  ++ lib.optionals finalAttrs.enableFTPM ([
     "CFG_REE_STATE=y"
     "CFG_JETSON_FTPM_HELPER_PTA=y"
   ]
-  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.measuredBoot) "CFG_CORE_TPM_EVENT_LOG=y"
-  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.unsecureInjectEPS)
+  ++ lib.optional finalAttrs.measuredBoot "CFG_CORE_TPM_EVENT_LOG=y"
+  ++ lib.optional finalAttrs.unsecureInjectEPS
     (lib.warn
       "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
-      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y")
+      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y"))
   ;
 
   dontInstall = true;

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -21,7 +21,6 @@ in
   version = l4tMajorMinorPatchVersion;
 
   # Override-able arguments
-  earlyTaPaths = [ ];
   socType =
     if l4tMajorVersion == "35" then "t194"
     else if l4tMajorVersion == "36" then "t234"
@@ -30,6 +29,18 @@ in
   coreLogLevel = 2;
   taLogLevel = finalAttrs.coreLogLevel;
   taPublicKeyFile = null;
+
+  # fTPM — set ftpmHelperTa/msTpm20RefTa to the TA derivations to embed them as early TAs
+  enableFTPM = false;
+  measuredBoot = false;
+  unsecureInjectEPS = false;
+  ftpmHelperTa = null;
+  msTpm20RefTa = null;
+
+  earlyTaPaths = lib.optionals (finalAttrs.ftpmHelperTa != null) [
+    "${finalAttrs.ftpmHelperTa}/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf"
+    "${finalAttrs.msTpm20RefTa}/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf"
+  ];
 
   src = gitRepos."tegra/optee-src/nv-optee";
   patches = [
@@ -74,6 +85,15 @@ in
     "CFG_STMM_PATH=${jetsonStandaloneMMOptee}/standalonemm_optee.bin"
   ])
   ++ (lib.optional (finalAttrs.taPublicKeyFile != null) "TA_PUBLIC_KEY=${finalAttrs.taPublicKeyFile}")
+  ++ lib.optionals finalAttrs.enableFTPM [
+    "CFG_REE_STATE=y"
+    "CFG_JETSON_FTPM_HELPER_PTA=y"
+  ]
+  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.measuredBoot) "CFG_CORE_TPM_EVENT_LOG=y"
+  ++ lib.optional (finalAttrs.enableFTPM && finalAttrs.unsecureInjectEPS)
+    (lib.warn
+      "fTPM is using UNSECURE Endorsement Primary Seed (EPS) injection."
+      "CFG_JETSON_FTPM_HELPER_INJECT_EPS=y")
   ;
 
   dontInstall = true;

--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -55,6 +55,7 @@ in
   patches = [
     ./remove-force-log-level.diff
     ./0003-Add-pre-sign-hook.patch
+    ./0001-jetson_ftpm_helper_pta-Return-SHORT_BUFFER-when-EPS-.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
         url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
         stripLen = 1;
         extraPrefix = "optee/optee_client/";
-        hash = "sha256-85DYu8BmWgpeowLMptLwXb77MWytNgvwqSZuPGtBFG4=";
+        hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
     ];
 

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   src = gitRepos."tegra/optee-src/nv-optee";
 
   patches =
-    if l4tAtLeast "36" then [ ] else [
+    (if l4tAtLeast "36" then [ ] else [
       ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch
       (fetchpatch {
         name = "tee-supplicant-Allow-for-TA-load-path-to-be-specified-at-runtime.patch";
@@ -20,6 +20,14 @@ stdenv.mkDerivation {
         stripLen = 1;
         extraPrefix = "optee/optee_client/";
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
+      })
+    ]) ++ [
+      (fetchpatch {
+        name = "tee-supplicant-add-systemd-sd_notify-support.patch";
+        url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
+        stripLen = 1;
+        extraPrefix = "optee/optee_client/";
+        hash = "sha256-85DYu8BmWgpeowLMptLwXb77MWytNgvwqSZuPGtBFG4=";
       })
     ];
 

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
       })
     ]) ++ [
+      ./0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
       (fetchpatch {
         name = "tee-supplicant-add-systemd-sd_notify-support.patch";
         url = "https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c.patch";
@@ -29,6 +30,7 @@ stdenv.mkDerivation {
         extraPrefix = "optee/optee_client/";
         hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
+      ./0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
     ];
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/optee/opteeClient.nix
+++ b/pkgs/optee/opteeClient.nix
@@ -11,6 +11,21 @@ stdenv.mkDerivation {
   version = l4tMajorMinorPatchVersion;
   src = gitRepos."tegra/optee-src/nv-optee";
 
+  # Patching strategy for nv-optee's optee_client (forked from upstream
+  # OP-TEE/optee_client).
+  #
+  # r35 only: Upstream tee-supplicant prepends hardcoded paths. Patch
+  # 0001 removes that behaviour, and we backport the runtime TA-load-path
+  # feature (f3845d8). Both are already present in r36+.
+  #
+  # r35 & r36 only: nv-optee carries an extra nvme_rpmb.c source that
+  # isn't in upstream OP-TEE/optee_client, so a straight fetchpatch of the
+  # sd_notify commit (a5b1ffcd) would fail. Instead we:
+  #   1. Drop nvme_rpmb.c from the Makefile (0002)
+  #   2. Apply the sd_notify fetchpatch (a5b1ffcd)
+  #   3. Restore nvme_rpmb.c in the Makefile (0003)
+  # r38 already includes a5b1ffcd in its nv-optee baseline, so this
+  # drop-fetchpatch-restore dance is unnecessary there.
   patches =
     (if l4tAtLeast "36" then [ ] else [
       ./0001-Don-t-prepend-foo-bar-baz-to-TEEC_LOAD_PATH.patch
@@ -21,7 +36,7 @@ stdenv.mkDerivation {
         extraPrefix = "optee/optee_client/";
         hash = "sha256-XjFpMbyXy74sqnc8l+EgTaPXqwwHcvni1Z68ShokTGc=";
       })
-    ]) ++ [
+    ]) ++ (if l4tAtLeast "38" then [ ] else [
       ./0002-tee-supplicant-Makefile-drop-nvme-rpmb.patch
       (fetchpatch {
         name = "tee-supplicant-add-systemd-sd_notify-support.patch";
@@ -31,7 +46,7 @@ stdenv.mkDerivation {
         hash = "sha256-QDE6wKxA3kvLfcb5ILZZqgJ7WC3UGFmuKtrRP7MwPfM=";
       })
       ./0003-tee-supplicant-Makefile-restore-nvme-rpmb.patch
-    ];
+    ]);
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libuuid ];

--- a/pkgs/optee/opteeXtest.nix
+++ b/pkgs/optee/opteeXtest.nix
@@ -16,7 +16,11 @@ stdenv.mkDerivation {
   version = l4tMajorMinorPatchVersion;
 
   src = gitRepos."tegra/optee-src/nv-optee";
-  patches = [ ./0001-GCC-15-compile-fix.patch ];
+  patches = [ ./0001-GCC-15-compile-fix.patch ]
+    ++ (if l4tAtLeast "39" then
+    [ ./0002-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set.patch ]
+  else
+    [ ./0003-build-tpm_log_test-TA-when-CFG_CORE_TPM_EVENT_LOG-is-set-pre-gmake.patch ]);
 
   # Multiple outputs: xtest binary, TAs, and plugins
   outputs = [

--- a/pkgs/optee/taDevKit.nix
+++ b/pkgs/optee/taDevKit.nix
@@ -1,5 +1,6 @@
 { optee-os }:
 optee-os.overrideAttrs (finalAttrs: {
   pname = "optee-ta-dev-kit";
+  uefi-firmware = null;
   makeFlags = finalAttrs.makeFlags or [ ] ++ [ "ta_dev_kit" ];
 })

--- a/pkgs/optee/taDevKit.nix
+++ b/pkgs/optee/taDevKit.nix
@@ -2,5 +2,7 @@
 optee-os.overrideAttrs (finalAttrs: {
   pname = "optee-ta-dev-kit";
   uefi-firmware = null;
+  ftpmHelperTa = null;
+  msTpm20RefTa = null;
   makeFlags = finalAttrs.makeFlags or [ ] ++ [ "ta_dev_kit" ];
 })

--- a/pkgs/optee/taDevKit.nix
+++ b/pkgs/optee/taDevKit.nix
@@ -1,8 +1,14 @@
 { optee-os }:
+# Break the optee-os → fTPM TA → taDevKit → optee-os evaluation cycle by
+# nulling out the fTPM TA refs taDevKit doesn't need, and clamping
+# earlyTaPaths to [] explicitly. Without the earlyTaPaths override,
+# optee-os.nix would compute it from finalAttrs.enableFTPM (inherited
+# from the overlay) and try to interpolate the null TA refs.
 optee-os.overrideAttrs (finalAttrs: {
   pname = "optee-ta-dev-kit";
   uefi-firmware = null;
   ftpmHelperTa = null;
   msTpm20RefTa = null;
+  earlyTaPaths = [ ];
   makeFlags = finalAttrs.makeFlags or [ ] ++ [ "ta_dev_kit" ];
 })

--- a/pkgs/uefi-firmware/r39/default.nix
+++ b/pkgs/uefi-firmware/r39/default.nix
@@ -15,6 +15,12 @@
   # The root certificate (in PEM format) for authenticating capsule updates. By
   # default, EDK2 authenticates using a test keypair commited upstream.
 , trustedPublicCertPemFile ? null
+  # When false, force-disable UEFI's fTPM stack via disable-ftpm.diff
+  # (upstream r38 BuildGeneral.conf implies DEFAULT_SECURITY_TPM_FIRMWARE, and
+  # UEFI hangs at boot if it cannot reach a fTPM TA). Set to true together with
+  # hardware.nvidia-jetpack.firmware.optee.ftpm.enable so the patch is skipped
+  # and UEFI uses the fTPM TA we embed into OP-TEE OS.
+, enableFTPM ? false
 , ...
 }@args:
 
@@ -70,8 +76,11 @@ let
       patches = [
         ./stuart-passthru-compiler-prefix.diff
         ./repeatability.diff
-
-        # UEFI firmware fail fails to boot unless we have a fTPM in OP-TEE. Disabling for now until we build/ship the fTPM TA.
+      ] ++ lib.optionals (!enableFTPM) [
+        # UEFI hangs at boot on r38 if it cannot reach a fTPM TA, and
+        # upstream BuildGeneral.conf implies DEFAULT_SECURITY_TPM_FIRMWARE.
+        # When fTPM is enabled, we ship the TA in tos.img and drop this
+        # patch so UEFI can talk to it.
         ./disable-ftpm.diff
       ] ++ lib.optionals (trustedPublicCertPemFile != null) [
         ./capsule-authentication.diff


### PR DESCRIPTION
## Summary

Supersedes #496. Incorporates all review feedback from that PR plus additional fixes:

- Adds `hardware.nvidia-jetpack.firmware.optee.ftpm` options that build the MS TPM 2.0 reference TA + fTPM helper TA, embed them as early TAs in `tos.img`, and load `tpm_ftpm_tee` after `tee-supplicant`
- Supports l4t r35.5+ (JP5.1), r36.x (JP6), and r38.x (JP7)
- Fixes `CFG_TA_LOG_LEVEL` → `CFG_TEE_TA_LOG_LEVEL` (incorrect make variable name)
- Fixes fTPM TA panic on shutdown by unloading `tpm_ftpm_tee` before `tee-supplicant` stops
- Patches `nvftpm-helper-app` to skip `prov_mode` gate for `inject_eps` on unfused r36+ devices
- Runs `nixpkgs-fmt` on all changed files

Based on work by @zengraf (#496), @zacharyweiss (r38 support), and @TanelDettenborn (shutdown fix).

## Test plan

- [x] Build with fTPM enabled/disabled on JP6 (r36.x, Orin)
- [x] Build with fTPM enabled on JP7 (r38.x, Thor)
- [x] Verify `tpm2_unseal` works after reboot
- [x] Verify clean shutdown (no TA panic)
- [x] Verify `unsecureInjectEPS` on unfused device
- [x] Build JP5 (r35.5+) with fTPM enabled