### PR TITLE
Bump to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768505959,
-        "narHash": "sha256-oFCx/ApQ+S1/apUKWsvT9vq+Eo1m2vINWEDkW7/nckA=",
+        "lastModified": 1779836515,
+        "narHash": "sha256-X/AwJZeTjxetRM7JG2BXeffKa1PIg/uo8AP5TX/+kb0=",
         "owner": "nixos-cuda",
         "repo": "cuda-legacy",
-        "rev": "86ad7e2c2e314f0234539cbbc66b5cd7746bcd32",
+        "rev": "baf22622e1114bb36412e5cebe2303f302edb882",
         "type": "github"
       },
       "original": {
@@ -25,16 +25,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768773494,
-        "narHash": "sha256-XsM7GP3jHlephymxhDE+/TKKO1Q16phz/vQiLBGhpF4=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77ef7a29d276c6d8303aece3444d61118ef71ac2",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
 
     cuda-legacy = {
       url = "github:nixos-cuda/cuda-legacy";
@@ -25,6 +25,8 @@
         ];
         # Avoids a bunch of extra modules we don't have in the tegra_defconfig, like "ata_piix",
         hardware.enableAllHardware = lib.mkForce false;
+        # Suppress nix eval warning in 26.05
+        boot.zfs.forceImportRoot = false;
 
         hardware.nvidia-jetpack.enable = true;
       };
@@ -83,6 +85,7 @@
           fileSystems."/".fsType = "tmpfs";
           boot.loader.grub.enable = false;
           boot.loader.systemd-boot.enable = false;
+          boot.zfs.forceImportRoot = false;
         }
       ];
 
@@ -160,7 +163,6 @@
         x86_64-linux =
           let
             flashScripts = lib.mapAttrs' (n: c: lib.nameValuePair "flash-${n}" c.config.system.build.flashScript) supportedNixOSCrossConfigurations;
-            initrdFlashScripts = lib.mapAttrs' (n: c: lib.nameValuePair "initrd-flash-${n}" c.config.system.build.initrdFlashScript) supportedNixOSCrossConfigurations;
           in
           {
             iso_minimal = self.nixosConfigurations.installer_minimal_cross.config.system.build.isoImage;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,6 +25,7 @@ let
     message = "Jetpack ${majorVersion} only supports som families: ${lib.strings.concatStringsSep " " soms} (or generic). Configured som: ${cfg.som}.";
   };
 
+  jetpackOlder = lib.versionOlder cfg.majorVersion;
   jetpackAtLeast = lib.versionAtLeast cfg.majorVersion;
 in
 {
@@ -290,6 +291,8 @@ in
         "af_alg"
         "algif_skcipher"
       ];
+
+      boot.initrd.systemd.tpm2.enable = lib.mkIf (jetpackOlder "7") (lib.mkDefault false);
 
       boot.kernelModules = if (jetpackAtLeast "7") then [ "nvidia-uvm" ] else [ "nvgpu" ];
 


### PR DESCRIPTION
###### Description of changes

nix flake update to 26.05.
- Disable tpm2 by default on JetPack 5/6 since relevant kernel module are not enabled by default.
- Fixes eval warning with boot.zfs.forceImportRoot
- remove unused let-binding.

###### Testing

- [x] `nix flake check`
- [x] `nix build .\#packages.x86_64-linux.iso_minimal .#packages.x86_64-linux.iso_minimal_jp5 .#packages.x86_64-linux.iso_minimal_jp7 .#packages.x86_64-linux.flash-orin-agx-devkit .#packages.aarch64-linux.iso_minimal .#packages.aarch64-linux.iso_minimal_jp7`
