### PR TITLE
fix: shebang of debian sign-module script

### DIFF
--- a/pkgs/kernels/fix-module-signing.sh
+++ b/pkgs/kernels/fix-module-signing.sh
@@ -1,0 +1,9 @@
+# NVIDIA's Tegra kernels gate scripts/sign-file behind debian/scripts/sign-module
+# in scripts/Makefile.modinst. That script's `#!/bin/bash -eu` shebang fails in
+# the Nix sandbox (no /bin/bash), so signing silently no-ops and every module
+# installs unsigned despite CONFIG_MODULE_SIG_ALL=y.
+#
+# Patch the shebang to an absolute bash path so the script runs.
+if [ -f debian/scripts/sign-module ]; then
+  patchShebangs debian/scripts/sign-module
+fi

--- a/pkgs/kernels/r36/default.nix
+++ b/pkgs/kernels/r36/default.nix
@@ -31,7 +31,10 @@ buildLinux (args // {
 
   # Using applyPatches here since it's not obvious how to append an extra
   # postPatch. This is not very efficient.
-  src = gitRepos."kernel/kernel-jammy-src";
+  src = applyPatches {
+    src = gitRepos."kernel/kernel-jammy-src";
+    postPatch = builtins.readFile ../fix-module-signing.sh;
+  };
   autoModules = false;
   features = { }; # TODO: Why is this needed in nixpkgs master (but not NixOS 22.05)?
 

--- a/pkgs/kernels/r38/default.nix
+++ b/pkgs/kernels/r38/default.nix
@@ -1,4 +1,5 @@
 { lib
+, applyPatches
 , realtime ? false
 , kernelPatches ? [ ]
 , structuredExtraConfig ? { }
@@ -29,7 +30,10 @@ buildLinux (args // {
 
   # Using applyPatches here since it's not obvious how to append an extra
   # postPatch. This is not very efficient.
-  src = gitRepos."kernel/kernel-noble";
+  src = applyPatches {
+    src = gitRepos."kernel/kernel-noble";
+    postPatch = builtins.readFile ../fix-module-signing.sh;
+  };
   autoModules = false;
   features = { }; # TODO: Why is this needed in nixpkgs master (but not NixOS 22.05)?
 


### PR DESCRIPTION
NVIDIA's Tegra kernels gate scripts/sign-file behind debian/scripts/sign-module in scripts/Makefile.modinst. That script's `#!/bin/bash -eu` shebang fails in the Nix sandbox (/bin/sh is present but not /bin/bash), so signing silently no-ops and every module installs unsigned despite CONFIG_MODULE_SIG_ALL=y.

Tested on fused orin-nano-devkit.