### PR TITLE
Fix generic installer eval for JetPack 6 and 7

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -43,8 +43,9 @@ let
 in
 {
   config = lib.mkIf cfg.enable (lib.mkMerge [{
-    # Turn on nvpmodel if we have a config for it.
-    services.nvpmodel.enable = mkDefault true;
+    # Generic installer-style configs do not identify a concrete SoM, and
+    # some Jetson packages behind nvpmodel require one during evaluation.
+    services.nvpmodel.enable = mkIf (cfg.som != "generic") (mkDefault true);
 
     # Set fan control service if we have a config for it
     services.nvfancontrol.configFile = mkIf (nvfancontrolConf ? "${cfg.som}") (mkDefault nvfancontrolConf.${cfg.som});

--- a/modules/graphics.nix
+++ b/modules/graphics.nix
@@ -177,7 +177,7 @@ in
         })
       ];
     })
-    (lib.mkIf (checkValidSoms [ "thor" ]) {
+    (lib.mkIf (lib.hasPrefix "thor" cfg.som && jetpackAtLeast "7") {
       boot.kernelModules = [ "nvidia-uvm" ];
       boot.blacklistedKernelModules = [ "nvgpu" ];
 


### PR DESCRIPTION
The generic installer configuration was evaluating SoM-specific paths that require a concrete Jetson target.

###### Description of changes

In modules/graphics.nix, som = "generic" was matching the Thor block. On JetPack 6 this tried to evaluate l4t-firmware-openrm, which is not present before r38. On JetPack 7 it caused the generic installer to pull in both the Orin and Thor depmod overrides, producing a buildEnv file conflict at etc/depmod.d/openrm-l4t-display.conf.

Restrict the Thor graphics configuration to actual Thor SoMs and require JetPack 7+.

In modules/devices.nix, the generic installer was also default-enabling nvpmodel, which pulls in packages that expect a concrete SoC and caused Unknown SoC type during evaluation. Only default-enable nvpmodel for non-generic SoMs.

###### Testing
Tested with:
- nix build --builders '' .#iso_minimal
- nix build --builders '' .#iso_minimal_jp5
- nix build --builders '' .#iso_minimal_jp7
- nix build --dry-run --builders '' .#flash-orin-agx-devkit
- nix build --dry-run --builders '' .#flash-orin-agx-devkit-jp5
- nix build --dry-run --builders '' .#flash-thor-agx-devkit