### PR TITLE
Package CUDA 12.6 compute libs for aarch64 JetPack 6 (#507)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,54 @@ To make `jetpack-nixos`'s CUDA package set the default, provide Nixpkgs with thi
 final: _: { inherit (final.nvidia-jetpack) cudaPackages; }
 ```
 
+### JetPack 6 native ML (CUDA 12.6 compute libraries)
+
+JetPack 6 systems should use `cudaPackages_12_6` (not the default `cudaPackages_11_4`). On `aarch64-linux`, the overlay replaces upstream CUDA redistributables with Jetson debs from `sourceinfo/r36.5-debs.json` — the same `debWrapBuildRedist` pattern used for CUDA 11.4 on JetPack 5.
+
+This wires `libcublas`, `cudnn`, `libcufft`, `cuda_nvrtc`, `libnvjitlink`, `cuda_cupti`, and related libraries into the Nix store so native Python ML packages (e.g. PyTorch) can load CUDA dependencies without containers.
+
+**Verify on an Orin (JetPack 6):**
+
+```shell
+# After enabling the jetpack-nixos overlay and cudaPackages_12_6:
+nix eval .#legacyPackages.aarch64-linux.cudaPackages_12_6.libcublas.name
+# Should NOT be cuda11.4-libcublas-*
+
+nix build .#legacyPackages.aarch64-linux.cudaPackages_12_6.libcublas
+```
+
+**devShell sketch** (see `examples/jp6-ml-devshell/flake.nix`):
+
+```nix
+{
+  inputs.jetpack-nixos.url = "github:anduril/jetpack-nixos";
+  outputs = { jetpack-nixos, nixpkgs, ... }: {
+    devShells.aarch64-linux.default = let
+      pkgs = import nixpkgs {
+        system = "aarch64-linux";
+        config = {
+          allowUnfree = true;
+          cudaSupport = true;
+          cudaCapabilities = [ "8.7" ];
+        };
+        overlays = [
+          jetpack-nixos.overlays.default
+          (final: _: { cudaPackages = final.cudaPackages_12_6; })
+        ];
+      };
+    in pkgs.mkShell {
+      packages = with pkgs.cudaPackages; [
+        libcublas cudnn libcufft cuda_cudart cuda_nvrtc libnvjitlink
+      ];
+    };
+  };
+}
+```
+
+PyTorch wheels may still expect libraries under `site-packages/nvidia/*/lib/`; symlink or set `LD_LIBRARY_PATH` to the `cudaPackages` outputs until wheel layout helpers land.
+
+Known gaps: `nccl` and `libcusparseLt` are not in the Jetson deb manifest and may require follow-up packaging from NVIDIA's SBSA apt repo.
+
 ## Additional Links
 
 Much of this is inspired by the great work done by [OpenEmbedded for Tegra](https://github.com/OE4T).

--- a/cuda-packages-12-6-extension.nix
+++ b/cuda-packages-12-6-extension.nix
@@ -1,0 +1,168 @@
+{ lib, system }:
+finalCudaPackages: prevCudaPackages:
+let
+  inherit (lib)
+    elem
+    filter
+    genAttrs
+    getAttr
+    hasAttr
+    mapAttrs
+    optionalAttrs
+    versions
+    ;
+
+  debWrapBuildRedist = import ./pkgs/cuda-packages-11-4/debWrapBuildRedist.nix {
+    inherit (finalCudaPackages) cudaMajorMinorVersion normalizeDebs;
+    inherit (finalCudaPackages.pkgs) lib nvidia-jetpack;
+  };
+
+  wrap = debWrapBuildRedist;
+
+  # Packages torch / ctranslate2 expect from cudaPackages on JetPack 6.
+  debWrappedNames = filter (name: hasAttr name prevCudaPackages) [
+    "cuda_cudart"
+    "cuda_cuobjdump"
+    "cuda_cuxxfilt"
+    "cuda_gdb"
+    "cuda_nvcc"
+    "cuda_nvdisasm"
+    "cuda_nvml_dev"
+    "cuda_nvprune"
+    "cuda_nvrtc"
+    "cuda_nvtx"
+    "cuda_sanitizer_api"
+    "libcublas"
+    "libcufft"
+    "libcurand"
+    "libcusolver"
+    "libcusparse"
+    "libnpp"
+    "libnvjitlink"
+    "libcufile"
+  ];
+
+  newCudaPackages =
+    genAttrs debWrappedNames (name: wrap { drv = prevCudaPackages.${name}; })
+    // {
+      inherit debWrapBuildRedist;
+    }
+    // optionalAttrs (hasAttr "cuda_cupti" prevCudaPackages) {
+      cuda_cupti = wrap {
+        drv = prevCudaPackages.cuda_cupti;
+        postDebNormalization = ''
+          pushd "$NIX_BUILD_TOP/$sourceRoot" >/dev/null
+          mv \
+            --verbose \
+            --no-clobber \
+            --target-directory "$PWD" \
+            "$PWD/extras/CUPTI/samples"
+          echo "removing $PWD/extras"
+          rm --recursive --dir "$PWD/extras" || {
+            nixErrorLog "$PWD/extras contains non-empty directories: $(ls -laR "$PWD/extras")"
+            exit 1
+          }
+          popd >/dev/null
+        '';
+      };
+    }
+    // optionalAttrs (hasAttr "cudnn" prevCudaPackages) {
+      cudnn = wrap {
+        drv = prevCudaPackages.cudnn;
+        extension = finalAttrs: prevAttrs: {
+          postFixup =
+            let
+              cudnnMajorVersion = versions.major finalAttrs.version;
+            in
+            prevAttrs.postFixup or ""
+            + ''
+              nixLog "creating symlinks for header files in include without the _v${cudnnMajorVersion} suffix before the file extension"
+              pushd "''${!outputInclude:?}/include" >/dev/null
+              for file in *.h; do
+                nixLog "symlinking $file to $(basename "$file" "_v${cudnnMajorVersion}.h").h"
+                ln -s "$file" "$(basename "$file" "_v${cudnnMajorVersion}.h").h"
+              done
+              unset -v file
+              popd >/dev/null
+            '';
+        };
+      };
+    }
+    // optionalAttrs (hasAttr "tensorrt" prevCudaPackages) {
+      tensorrt = wrap {
+        drv = prevCudaPackages.tensorrt;
+        postDebNormalization = ''
+          pushd "$NIX_BUILD_TOP/$sourceRoot" >/dev/null
+          if [[ -d "$PWD/src/tensorrt" ]]; then
+            mv --verbose --no-clobber "$PWD/src/tensorrt" "$PWD/samples"
+            nixLog "removing $PWD/src"
+            rm --recursive --dir "$PWD/src" || {
+              nixErrorLog "$PWD/src contains non-empty directories: $(ls -laR "$PWD/src")"
+              exit 1
+            }
+          fi
+          if [[ -d "$PWD/samples/bin" ]]; then
+            nixLog "moving trtexec to top-level bin directory"
+            mkdir -p "$PWD/bin"
+            mv --verbose --no-clobber "$PWD/samples/bin"/* "$PWD/bin/" || true
+          fi
+          mkdir -p "$PWD/python"
+          touch "$PWD/python/DELETE_ME.whl"
+          mkdir -p "$PWD/lib/stubs"
+          popd >/dev/null
+        '';
+        extension = finalAttrs: prevAttrs: {
+          buildInputs = (prevAttrs.buildInputs or [ ]) ++ [
+            finalCudaPackages.cuda_nvrtc
+            finalCudaPackages.cudnn
+            finalCudaPackages.libcublas
+          ];
+          passthru = prevAttrs.passthru // {
+            release = null;
+            supportedNixSystems = [ "aarch64-linux" ];
+            supportedRedistSystems = [ "linux-aarch64" ];
+          };
+        };
+      };
+    }
+    // optionalAttrs (hasAttr "cuda_cccl" prevCudaPackages) {
+      cuda_cccl = wrap {
+        sourceName = "cuda-cccl";
+        drv = prevCudaPackages.cuda_cccl;
+      };
+    }
+    // optionalAttrs (hasAttr "cuda_compat" prevCudaPackages && prevCudaPackages.cuda_compat != null) {
+      cuda_compat = wrap {
+        sourceName = "cuda-compat";
+        drv = prevCudaPackages.cuda_compat;
+      };
+    }
+    // optionalAttrs (hasAttr "libcudla" prevCudaPackages) {
+      libcudla = wrap {
+        drv = prevCudaPackages.libcudla;
+        extension = prevAttrs: {
+          outputs = filter (output: output != "stubs") prevAttrs.outputs;
+          buildInputs = prevAttrs.buildInputs or [ ] ++ [
+            finalCudaPackages.pkgs.nvidia-jetpack.l4t-core
+          ];
+          autoPatchelfIgnoreMissingDeps = lib.filter
+            (name: name != "libnvdla_runtime.so")
+            (prevAttrs.autoPatchelfIgnoreMissingDeps or [ ]);
+        };
+      };
+    };
+
+  canUseOurPackageVersion = finalCudaPackages.cudaMajorMinorVersion == "12.6";
+  canUseOurPackagePlatform = finalCudaPackages.backendStdenv.hostRedistSystem == "linux-aarch64";
+in
+mapAttrs
+  (name: value:
+  if
+    !hasAttr name prevCudaPackages
+    || (canUseOurPackageVersion && (elem name [ "tensorrt" ] || canUseOurPackagePlatform))
+  then
+    value
+  else
+    getAttr name prevCudaPackages
+  )
+  newCudaPackages

--- a/examples/jp6-ml-devshell/flake.nix
+++ b/examples/jp6-ml-devshell/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "JetPack 6 devShell with CUDA 12.6 compute libraries (see jetpack-nixos#507)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    jetpack-nixos.url = "path:../..";
+  };
+
+  outputs =
+    { jetpack-nixos, nixpkgs, ... }:
+    let
+      system = "aarch64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        config = {
+          allowUnfree = true;
+          cudaSupport = true;
+          cudaCapabilities = [ "8.7" ];
+        };
+        overlays = [
+          jetpack-nixos.overlays.default
+          (final: _: {
+            cudaPackages = final.cudaPackages_12_6;
+          })
+        ];
+      };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        name = "jp6-ml-devshell";
+
+        packages = with pkgs.cudaPackages; [
+          cuda_cudart
+          libcublas
+          cudnn
+          libcufft
+          libcurand
+          libcusparse
+          libcusolver
+          cuda_nvrtc
+          libnvjitlink
+          cuda_cupti
+          libcufile
+        ];
+
+        shellHook = ''
+          echo "JetPack 6 ML devShell — CUDA ''${pkgs.cudaPackages.cudaMajorMinorVersion}"
+          echo "libcublas: ''${pkgs.cudaPackages.libcublas.name}"
+          echo ""
+          echo "Smoke test (after installing torch in this shell):"
+          echo "  python -c \"import torch; print('cuda:', torch.cuda.is_available())\""
+        '';
+      };
+
+      packages.${system}.smoke-eval = pkgs.writeShellScriptBin "jp6-cuda-smoke" ''
+        set -euo pipefail
+        echo "libcublas derivation: ${pkgs.cudaPackages.libcublas.name}"
+        test -e "${pkgs.lib.getLib pkgs.cudaPackages.libcublas}/lib/libcublas.so" \
+          || test -n "$(find "${pkgs.lib.getLib pkgs.cudaPackages.libcublas}/lib" -name 'libcublas.so*' -print -quit)"
+        echo "OK: libcublas present in store"
+      '';
+    };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -166,9 +166,9 @@ in
       # `cudaPackages.pkgs.cudaPackages.debs` will not -- the extension provided to `overrideScope` is not threaded
       # through!
       # For now, we just conditionally apply extensions.
-      # Replace CUDA packages from manifests with our own, which are built from debian installers, if we're using
-      # CUDA 11.4.
+      # Replace CUDA packages from manifests with our own, which are built from debian installers.
       (import ./cuda-packages-11-4-extension.nix { inherit (final) lib; inherit system; })
+      (import ./cuda-packages-12-6-extension.nix { inherit (final) lib; inherit system; })
     ];
   });
 }


### PR DESCRIPTION
## Summary

- Add `cuda-packages-12-6-extension.nix` to wire Jetson CUDA 12.6 compute debs from `sourceinfo/r36.5-debs.json` into `cudaPackages_12_6` on `linux-aarch64`, using the existing `debWrapBuildRedist` pattern from JetPack 5 / CUDA 11.4
- Register the extension in `overlay.nix` so `libcublas`, `cudnn`, `libcufft`, `cuda_nvrtc`, `libnvjitlink`, `cuda_cupti`, `libcufile`, and related libraries are available in the Nix store for native ML workloads (PyTorch, ctranslate2, etc.)
- Add `examples/jp6-ml-devshell/flake.nix` and README documentation for the JetPack 6 native ML workflow

Closes the packaging gap described in #507: the debs were already in the Jetson manifest but not exposed through `cudaPackages` for CUDA 12.6 on aarch64.

Known follow-ups (not in Jetson deb manifest): `nccl`, `libcusparseLt` — may need SBSA apt repo packaging.

## Test plan

- [ ] `nix eval .#legacyPackages.aarch64-linux.cudaPackages_12_6.libcublas.name` — should **not** return `cuda11.4-libcublas-*`
- [ ] `nix build .#legacyPackages.aarch64-linux.cudaPackages_12_6.libcublas`
- [ ] `cd examples/jp6-ml-devshell && nix run .#smoke-eval` on aarch64
- [ ] On Orin AGX (JP 6.2 / L4T 36.5.0): `nix develop` → `python -c "import torch; print(torch.cuda.is_available())"` with torch wheel + `LD_LIBRARY_PATH` or wheel-layout symlinks
- [ ] Confirm Hydra `orin.nvidia-jetpack6` package set still evaluates