### PR TITLE
Add preSignCommands to fuseScript.

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -146,7 +146,10 @@ let
       inherit lib l4tAtLeast;
       inherit (nvidia-jetpack) flash-tools socFamily;
       flashCommands = ''
-        ./odmfuse.sh -i ${chipId} "$@" ${builtins.toString cfg.flashScriptOverrides.fuseArgs}
+        (
+          ${cfg.firmware.secureBoot.preSignCommands buildPackages}
+          ./odmfuse.sh -i ${chipId} "$@" ${builtins.toString cfg.flashScriptOverrides.fuseArgs}
+        )
       '';
 
       # Fuse script needs device tree files, which aren't already present for


### PR DESCRIPTION
###### Description of changes

Add `preSignCommands` to fuse script invocation. Fusing a board with fuses
already burnt may require this depending on the use case.

###### Testing

Manually fused an orin-nano-devkit with fuses already burnt using this script.
