### PR TITLE
optee: fTPM provisioning support

### DIFF
--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -10,6 +10,7 @@ let
     ;
 
   cfg = config.hardware.nvidia-jetpack.firmware.optee;
+  cfgFw = config.hardware.nvidia-jetpack.firmware;
 
   inherit (pkgs.nvidia-jetpack) l4tAtLeast;
 
@@ -413,6 +414,67 @@ in
         systemd.services.tpm2-abrmd = lib.mkIf config.security.tpm2.abrmd.enable {
           after = [ "ftpm-driver.service" ];
           requires = [ "ftpm-driver.service" ];
+        };
+
+        # Provision fTPM EK certs from EKB into NV memory on first boot (fused devices only).
+        systemd.services.ftpm-device-provision = lib.mkIf (cfgFw.eksFile != null) {
+          description = "Provision fTPM EK certificates from EKB";
+          after = [ "ftpm-driver.service" ];
+          requires = [ "ftpm-driver.service" ];
+          before = [ "tpm2.target" "shutdown.target" ];
+          conflicts = [ "shutdown.target" ];
+          wantedBy = [ "tpm2.target" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          environment.TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
+          path = [
+            pkgs.tpm2-tools
+            pkgs.openssl
+            pkgs.diffutils
+            pkgs.nvidia-jetpack.ftpmHelperTa
+            pkgs.nvidia-jetpack.ftpmDeviceProvisioning
+          ];
+          script = ''
+            set -euo pipefail
+
+            # Commit marker; NVIDIA's cert handles are written midway so can't serve this role.
+            PROVISIONED_HANDLE="0x01800100"
+            OWNER_PW="owner"
+
+            if tpm2_nvreadpublic "$PROVISIONED_HANDLE" &>/dev/null; then
+              echo "[ftpm-provision] Already provisioned. Skipping."
+              exit 0
+            fi
+
+            echo "[ftpm-provision] First boot — running fTPM provisioning..."
+
+            WORKDIR=$(mktemp -d)
+            trap 'rm -rf "$WORKDIR"' EXIT
+
+            on_failure() {
+              echo "[ftpm-provision] FAILED — clearing TPM so the next boot retries cleanly" >&2
+              tpm2_clear || \
+                echo "[ftpm-provision] WARNING: tpm2_clear failed; TPM may need manual recovery" >&2
+            }
+            trap on_failure ERR
+
+            RSA_CERT="$WORKDIR/rsa_ek_cert.der"
+            EC_CERT="$WORKDIR/ec_ek_cert.der"
+
+            nvftpm-helper-app -a "$RSA_CERT" -b "$EC_CERT"
+            ftpm-device-provision -r "$RSA_CERT" -e "$EC_CERT" -p "$OWNER_PW"
+
+            # systemd's TPM2 SRK setup and tpm2-tools expect no auth set.
+            tpm2_changeauth -c o -p "$OWNER_PW"
+            tpm2_changeauth -c e -p "$OWNER_PW"
+
+            tpm2_nvdefine "$PROVISIONED_HANDLE" -C o -s 1 -a "ownerread|ownerwrite"
+
+            echo "[ftpm-provision] Done."
+          '';
         };
       }
     ))

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -408,6 +408,12 @@ in
             StateDirectory = "optee/ftpm";
           };
         };
+
+        # tpm2-abrmd must wait for ftpm-driver to provide /dev/tpm0
+        systemd.services.tpm2-abrmd = lib.mkIf config.security.tpm2.abrmd.enable {
+          after = [ "ftpm-driver.service" ];
+          requires = [ "ftpm-driver.service" ];
+        };
       }
     ))
 

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -371,6 +371,13 @@ in
         # tpm_ftpm_tee must load after tee-supplicant is up.
         boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
 
+        # r38.4's ms-tpm-20-ref update made RSA keygen constant-time, so it now
+        # takes ~12s (measured on tpm2_createek) with the CPU stuck in secure
+        # world -- past the 10s hard lockup default. Set via kernelParams (not
+        # boot.kernel.sysctl) since keygen also happens outside provisioning
+        # (tpm2_createak, systemd-cryptenroll) and needs to hold from boot.
+        boot.kernelParams = lib.optional (l4tAtLeast "38.4") "watchdog_thresh=30";
+
         boot.kernelPatches = [{
           name = "fTPM_tee";
           patch = null;

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -28,6 +28,14 @@ let
   fsParentPathArgs = lib.optional (cfg.supplicant.fsParentPath != null)
     "--fs-parent-path=${cfg.supplicant.fsParentPath}";
 
+  # Binaries used directly in the ftpm-device-provision script.
+  tpm2_nvreadpublic = lib.getExe' pkgs.tpm2-tools "tpm2_nvreadpublic";
+  tpm2_clear = lib.getExe' pkgs.tpm2-tools "tpm2_clear";
+  tpm2_changeauth = lib.getExe' pkgs.tpm2-tools "tpm2_changeauth";
+  tpm2_nvdefine = lib.getExe' pkgs.tpm2-tools "tpm2_nvdefine";
+  nvftpm-helper-app = lib.getExe' pkgs.nvidia-jetpack.ftpmHelperTa "nvftpm-helper-app";
+  ftpm-device-provision-bin = lib.getExe' pkgs.nvidia-jetpack.ftpmDeviceProvisioning "ftpm-device-provision";
+
   supplicantArgs = lib.escapeShellArgs (
     [
       "--ta-path=${teeApplications}"
@@ -430,13 +438,6 @@ in
             RemainAfterExit = true;
           };
           environment.TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
-          path = [
-            pkgs.tpm2-tools
-            pkgs.openssl
-            pkgs.diffutils
-            pkgs.nvidia-jetpack.ftpmHelperTa
-            pkgs.nvidia-jetpack.ftpmDeviceProvisioning
-          ];
           script = ''
             set -euo pipefail
 
@@ -444,7 +445,7 @@ in
             PROVISIONED_HANDLE="0x01800100"
             OWNER_PW="owner"
 
-            if tpm2_nvreadpublic "$PROVISIONED_HANDLE" &>/dev/null; then
+            if ${tpm2_nvreadpublic} "$PROVISIONED_HANDLE" &>/dev/null; then
               echo "[ftpm-provision] Already provisioned. Skipping."
               exit 0
             fi
@@ -470,7 +471,7 @@ in
 
             on_failure() {
               echo "[ftpm-provision] FAILED — clearing TPM so the next boot retries cleanly" >&2
-              tpm2_clear || \
+              ${tpm2_clear} || \
                 echo "[ftpm-provision] WARNING: tpm2_clear failed; TPM may need manual recovery" >&2
             }
             trap on_failure ERR
@@ -478,14 +479,14 @@ in
             RSA_CERT="$WORKDIR/rsa_ek_cert.der"
             EC_CERT="$WORKDIR/ec_ek_cert.der"
 
-            nvftpm-helper-app -a "$RSA_CERT" -b "$EC_CERT"
-            ftpm-device-provision -r "$RSA_CERT" -e "$EC_CERT" -p "$OWNER_PW"
+            ${nvftpm-helper-app} -a "$RSA_CERT" -b "$EC_CERT"
+            ${ftpm-device-provision-bin} -r "$RSA_CERT" -e "$EC_CERT" -p "$OWNER_PW"
 
             # systemd's TPM2 SRK setup and tpm2-tools expect no auth set.
-            tpm2_changeauth -c o -p "$OWNER_PW"
-            tpm2_changeauth -c e -p "$OWNER_PW"
+            ${tpm2_changeauth} -c o -p "$OWNER_PW"
+            ${tpm2_changeauth} -c e -p "$OWNER_PW"
 
-            tpm2_nvdefine "$PROVISIONED_HANDLE" -C o -s 1 -a "ownerread|ownerwrite"
+            ${tpm2_nvdefine} "$PROVISIONED_HANDLE" -C o -s 1 -a "ownerread|ownerwrite"
 
             echo "[ftpm-provision] Done."
           '';

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -188,6 +188,18 @@ in
             '';
           };
         };
+
+        autoProvision = mkOption {
+          type = types.bool;
+          default = cfgFw.eksFile != null;
+          description = ''
+            Automatically provision fTPM EK certificates from the EKB
+            (hardware.nvidia-jetpack.firmware.eksFile) into TPM NV memory
+            on first boot. Defaults to true whenever eksFile is set, since
+            without it there's nothing to provision from. Enabling this
+            without eksFile set is a configuration error.
+          '';
+        };
       };
 
       patches = mkOption {
@@ -255,6 +267,13 @@ in
           message = ''
             supplicant.earlyBoot requires ftpm.enable (the initrd
             services are only useful for fTPM-based LUKS unlock).
+          '';
+        }
+        {
+          assertion = !cfg.ftpm.autoProvision || cfgFw.eksFile != null;
+          message = ''
+            hardware.nvidia-jetpack.firmware.optee.ftpm.autoProvision
+            requires hardware.nvidia-jetpack.firmware.eksFile to be set.
           '';
         }
         {
@@ -417,7 +436,7 @@ in
         };
 
         # Provision fTPM EK certs from EKB into NV memory on first boot (fused devices only).
-        systemd.services.ftpm-device-provision = lib.mkIf (cfgFw.eksFile != null) {
+        systemd.services.ftpm-device-provision = lib.mkIf cfg.ftpm.autoProvision {
           description = "Provision fTPM EK certificates from EKB";
           after = [ "ftpm-driver.service" ];
           requires = [ "ftpm-driver.service" ];

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -371,13 +371,6 @@ in
         # tpm_ftpm_tee must load after tee-supplicant is up.
         boot.blacklistedKernelModules = [ "tpm_ftpm_tee" ];
 
-        # r38.4's ms-tpm-20-ref update made RSA keygen constant-time, so it now
-        # takes ~12s (measured on tpm2_createek) with the CPU stuck in secure
-        # world -- past the 10s hard lockup default. Set via kernelParams (not
-        # boot.kernel.sysctl) since keygen also happens outside provisioning
-        # (tpm2_createak, systemd-cryptenroll) and needs to hold from boot.
-        boot.kernelParams = lib.optional (l4tAtLeast "38.4") "watchdog_thresh=30";
-
         boot.kernelPatches = [{
           name = "fTPM_tee";
           patch = null;
@@ -459,7 +452,21 @@ in
             echo "[ftpm-provision] First boot — running fTPM provisioning..."
 
             WORKDIR=$(mktemp -d)
-            trap 'rm -rf "$WORKDIR"' EXIT
+
+            # r38.4's ms-tpm-20-ref update made RSA keygen constant-time, so
+            # tpm2_createek (invoked by ftpm-device-provision below) now takes
+            # ~12s with the CPU stuck in secure world -- past the 10s hard
+            # lockup default. Raise the threshold for the duration of this
+            # service and restore it on exit, rather than system-wide.
+            WATCHDOG_THRESH_FILE="/proc/sys/kernel/watchdog_thresh"
+            ORIG_WATCHDOG_THRESH="$(cat "$WATCHDOG_THRESH_FILE")"
+            echo 30 > "$WATCHDOG_THRESH_FILE"
+
+            cleanup() {
+              echo "$ORIG_WATCHDOG_THRESH" > "$WATCHDOG_THRESH_FILE"
+              rm -rf "$WORKDIR"
+            }
+            trap cleanup EXIT
 
             on_failure() {
               echo "[ftpm-provision] FAILED — clearing TPM so the next boot retries cleanly" >&2

--- a/modules/optee.nix
+++ b/modules/optee.nix
@@ -28,14 +28,6 @@ let
   fsParentPathArgs = lib.optional (cfg.supplicant.fsParentPath != null)
     "--fs-parent-path=${cfg.supplicant.fsParentPath}";
 
-  # Binaries used directly in the ftpm-device-provision script.
-  tpm2_nvreadpublic = lib.getExe' pkgs.tpm2-tools "tpm2_nvreadpublic";
-  tpm2_clear = lib.getExe' pkgs.tpm2-tools "tpm2_clear";
-  tpm2_changeauth = lib.getExe' pkgs.tpm2-tools "tpm2_changeauth";
-  tpm2_nvdefine = lib.getExe' pkgs.tpm2-tools "tpm2_nvdefine";
-  nvftpm-helper-app = lib.getExe' pkgs.nvidia-jetpack.ftpmHelperTa "nvftpm-helper-app";
-  ftpm-device-provision-bin = lib.getExe' pkgs.nvidia-jetpack.ftpmDeviceProvisioning "ftpm-device-provision";
-
   supplicantArgs = lib.escapeShellArgs (
     [
       "--ta-path=${teeApplications}"
@@ -436,60 +428,9 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
+            ExecStart = lib.getExe pkgs.nvidia-jetpack.ftpmAutoProvision;
           };
           environment.TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
-          script = ''
-            set -euo pipefail
-
-            # Commit marker; NVIDIA's cert handles are written midway so can't serve this role.
-            PROVISIONED_HANDLE="0x01800100"
-            OWNER_PW="owner"
-
-            if ${tpm2_nvreadpublic} "$PROVISIONED_HANDLE" &>/dev/null; then
-              echo "[ftpm-provision] Already provisioned. Skipping."
-              exit 0
-            fi
-
-            echo "[ftpm-provision] First boot — running fTPM provisioning..."
-
-            WORKDIR=$(mktemp -d)
-
-            # r38.4's ms-tpm-20-ref update made RSA keygen constant-time, so
-            # tpm2_createek (invoked by ftpm-device-provision below) now takes
-            # ~12s with the CPU stuck in secure world -- past the 10s hard
-            # lockup default. Raise the threshold for the duration of this
-            # service and restore it on exit, rather than system-wide.
-            WATCHDOG_THRESH_FILE="/proc/sys/kernel/watchdog_thresh"
-            ORIG_WATCHDOG_THRESH="$(cat "$WATCHDOG_THRESH_FILE")"
-            echo 30 > "$WATCHDOG_THRESH_FILE"
-
-            cleanup() {
-              echo "$ORIG_WATCHDOG_THRESH" > "$WATCHDOG_THRESH_FILE"
-              rm -rf "$WORKDIR"
-            }
-            trap cleanup EXIT
-
-            on_failure() {
-              echo "[ftpm-provision] FAILED — clearing TPM so the next boot retries cleanly" >&2
-              ${tpm2_clear} || \
-                echo "[ftpm-provision] WARNING: tpm2_clear failed; TPM may need manual recovery" >&2
-            }
-            trap on_failure ERR
-
-            RSA_CERT="$WORKDIR/rsa_ek_cert.der"
-            EC_CERT="$WORKDIR/ec_ek_cert.der"
-
-            ${nvftpm-helper-app} -a "$RSA_CERT" -b "$EC_CERT"
-            ${ftpm-device-provision-bin} -r "$RSA_CERT" -e "$EC_CERT" -p "$OWNER_PW"
-
-            # systemd's TPM2 SRK setup and tpm2-tools expect no auth set.
-            ${tpm2_changeauth} -c o -p "$OWNER_PW"
-            ${tpm2_changeauth} -c e -p "$OWNER_PW"
-
-            ${tpm2_nvdefine} "$PROVISIONED_HANDLE" -C o -s 1 -a "ownerread|ownerwrite"
-
-            echo "[ftpm-provision] Done."
-          '';
         };
       }
     ))

--- a/pkgs/optee/ftpmAutoProvision.nix
+++ b/pkgs/optee/ftpmAutoProvision.nix
@@ -1,11 +1,11 @@
 { writeShellApplication
 , tpm2-tools
 , ftpmHelperTa
-, ftpmDeviceProvisioning
+, ftpmDeviceProvisioningTools
 }:
 writeShellApplication {
   name = "ftpm-auto-provision";
-  runtimeInputs = [ tpm2-tools ftpmHelperTa ftpmDeviceProvisioning ];
+  runtimeInputs = [ tpm2-tools ftpmHelperTa ftpmDeviceProvisioningTools ];
   text = ''
     # Commit marker; NVIDIA's cert handles are written midway so can't serve this role.
     PROVISIONED_HANDLE="0x01800100"

--- a/pkgs/optee/ftpmAutoProvision.nix
+++ b/pkgs/optee/ftpmAutoProvision.nix
@@ -1,0 +1,64 @@
+{ writeShellApplication
+, tpm2-tools
+, ftpmHelperTa
+, ftpmDeviceProvisioning
+}:
+writeShellApplication {
+  name = "ftpm-auto-provision";
+  runtimeInputs = [ tpm2-tools ftpmHelperTa ftpmDeviceProvisioning ];
+  text = ''
+    # Commit marker; NVIDIA's cert handles are written midway so can't serve this role.
+    PROVISIONED_HANDLE="0x01800100"
+    OWNER_PW="owner"
+
+    on_failure() {
+      echo "[ftpm-provision] FAILED — clearing TPM so the next boot retries cleanly" >&2
+      tpm2_clear || \
+        echo "[ftpm-provision] WARNING: tpm2_clear failed; TPM may need manual recovery" >&2
+    }
+    trap on_failure ERR
+
+    if tpm2_nvreadpublic "$PROVISIONED_HANDLE" &>/dev/null; then
+      echo "[ftpm-provision] Already provisioned. Skipping."
+      exit 0
+    fi
+
+    echo "[ftpm-provision] First boot — running fTPM provisioning..."
+
+    WORKDIR=$(mktemp -d)
+
+    # r38.4's ms-tpm-20-ref update made RSA keygen constant-time, so
+    # tpm2_createek (invoked by ftpm-device-provision below) now takes
+    # ~12s with the CPU stuck in secure world -- past the 10s hard
+    # lockup default. Raise the threshold for the duration of this
+    # service and restore it on exit, rather than system-wide.
+    WATCHDOG_THRESH_FILE="/proc/sys/kernel/watchdog_thresh"
+    ORIG_WATCHDOG_THRESH="$(cat "$WATCHDOG_THRESH_FILE")"
+    echo 30 > "$WATCHDOG_THRESH_FILE"
+
+    cleanup() {
+      echo "$ORIG_WATCHDOG_THRESH" > "$WATCHDOG_THRESH_FILE"
+      rm -rf "$WORKDIR"
+    }
+    trap cleanup EXIT
+
+    RSA_CERT="$WORKDIR/rsa_ek_cert.der"
+    EC_CERT="$WORKDIR/ec_ek_cert.der"
+
+    nvftpm-helper-app -a "$RSA_CERT" -b "$EC_CERT"
+    ftpm-device-provision -r "$RSA_CERT" -e "$EC_CERT" -p "$OWNER_PW"
+
+    # systemd's TPM2 SRK setup and tpm2-tools expect no auth set.
+    tpm2_changeauth -c o -p "$OWNER_PW"
+    tpm2_changeauth -c e -p "$OWNER_PW"
+
+    tpm2_nvdefine "$PROVISIONED_HANDLE" -C o -s 1 -a "ownerread|ownerwrite"
+
+    echo "[ftpm-provision] Done."
+  '';
+
+  meta = {
+    description = "Provision fTPM EK certificates from the EKB into TPM NV memory on first boot";
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/optee/ftpmDeviceProvisioning.nix
+++ b/pkgs/optee/ftpmDeviceProvisioning.nix
@@ -1,0 +1,38 @@
+{ lib
+, runCommand
+, writeShellScript
+, runtimeShell
+, gitRepos
+, l4tMajorMinorPatchVersion
+}:
+let
+  toolSrc = "${gitRepos."tegra/optee-src/nv-optee"}/optee/samples/ftpm-helper/host/tool";
+
+  # #!/bin/bash shebang does not resolve on NixOS, so run through runtimeShell.
+  mkWrapper =
+    name: script:
+    writeShellScript name ''
+      exec ${runtimeShell} ${toolSrc}/${script} "$@"
+    '';
+
+  wrappers = {
+    ftpm-device-provision = mkWrapper "ftpm-device-provision" "ftpm_device_provision.sh";
+    ftpm-offline-verify = mkWrapper "ftpm-offline-verify" "ftpm_offline_provisioning_verify.sh";
+    ftpm-test-attestation = mkWrapper "ftpm-test-attestation" "ftpm_test_local_attestation.sh";
+  };
+in
+runCommand "ftpm-device-provisioning-${l4tMajorMinorPatchVersion}"
+{
+  meta = {
+    description = "NVIDIA fTPM on-device provisioning and verification scripts";
+    platforms = [ "aarch64-linux" ];
+  };
+}
+  ''
+    mkdir -p $out/bin
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: script: ''
+        install -m755 ${script} $out/bin/${name}
+      '') wrappers
+    )}
+  ''

--- a/pkgs/optee/ftpmDeviceProvisioning.nix
+++ b/pkgs/optee/ftpmDeviceProvisioning.nix
@@ -1,38 +1,38 @@
-{ lib
-, runCommand
-, writeShellScript
+{ stdenvNoCC
+, makeWrapper
 , runtimeShell
 , gitRepos
 , l4tMajorMinorPatchVersion
 }:
 let
   toolSrc = "${gitRepos."tegra/optee-src/nv-optee"}/optee/samples/ftpm-helper/host/tool";
-
-  # #!/bin/bash shebang does not resolve on NixOS, so run through runtimeShell.
-  mkWrapper =
-    name: script:
-    writeShellScript name ''
-      exec ${runtimeShell} ${toolSrc}/${script} "$@"
-    '';
-
-  wrappers = {
-    ftpm-device-provision = mkWrapper "ftpm-device-provision" "ftpm_device_provision.sh";
-    ftpm-offline-verify = mkWrapper "ftpm-offline-verify" "ftpm_offline_provisioning_verify.sh";
-    ftpm-test-attestation = mkWrapper "ftpm-test-attestation" "ftpm_test_local_attestation.sh";
-  };
 in
-runCommand "ftpm-device-provisioning-${l4tMajorMinorPatchVersion}"
-{
+stdenvNoCC.mkDerivation {
+  pname = "ftpm-device-provisioning";
+  version = l4tMajorMinorPatchVersion;
+
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  # #!/bin/bash does not resolve on NixOS, so run each script through
+  # runtimeShell rather than relying on its own shebang.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    makeWrapper ${runtimeShell} $out/bin/ftpm-device-provision \
+      --add-flags ${toolSrc}/ftpm_device_provision.sh
+    makeWrapper ${runtimeShell} $out/bin/ftpm-offline-verify \
+      --add-flags ${toolSrc}/ftpm_offline_provisioning_verify.sh
+    makeWrapper ${runtimeShell} $out/bin/ftpm-test-attestation \
+      --add-flags ${toolSrc}/ftpm_test_local_attestation.sh
+
+    runHook postInstall
+  '';
+
   meta = {
     description = "NVIDIA fTPM on-device provisioning and verification scripts";
     platforms = [ "aarch64-linux" ];
   };
 }
-  ''
-    mkdir -p $out/bin
-    ${lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (name: script: ''
-        install -m755 ${script} $out/bin/${name}
-      '') wrappers
-    )}
-  ''

--- a/pkgs/optee/ftpmDeviceProvisioning.nix
+++ b/pkgs/optee/ftpmDeviceProvisioning.nix
@@ -1,11 +1,17 @@
 { stdenvNoCC
+, lib
 , makeWrapper
 , runtimeShell
 , gitRepos
 , l4tMajorMinorPatchVersion
+, tpm2-tools
+, openssl
+, diffutils
+, ftpmHelperTa
 }:
 let
   toolSrc = "${gitRepos."tegra/optee-src/nv-optee"}/optee/samples/ftpm-helper/host/tool";
+  runtimePath = lib.makeBinPath [ tpm2-tools openssl diffutils ftpmHelperTa ];
 in
 stdenvNoCC.mkDerivation {
   pname = "ftpm-device-provisioning";
@@ -15,18 +21,23 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   # #!/bin/bash does not resolve on NixOS, so run each script through
-  # runtimeShell rather than relying on its own shebang.
+  # runtimeShell rather than relying on its own shebang. Each script needs
+  # tpm2-tools and diffutils; ftpm_device_provision.sh also needs openssl
+  # and calls nvftpm-helper-app (from ftpmHelperTa) internally by name.
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
 
     makeWrapper ${runtimeShell} $out/bin/ftpm-device-provision \
-      --add-flags ${toolSrc}/ftpm_device_provision.sh
+      --add-flags ${toolSrc}/ftpm_device_provision.sh \
+      --prefix PATH : ${runtimePath}
     makeWrapper ${runtimeShell} $out/bin/ftpm-offline-verify \
-      --add-flags ${toolSrc}/ftpm_offline_provisioning_verify.sh
+      --add-flags ${toolSrc}/ftpm_offline_provisioning_verify.sh \
+      --prefix PATH : ${runtimePath}
     makeWrapper ${runtimeShell} $out/bin/ftpm-test-attestation \
-      --add-flags ${toolSrc}/ftpm_test_local_attestation.sh
+      --add-flags ${toolSrc}/ftpm_test_local_attestation.sh \
+      --prefix PATH : ${runtimePath}
 
     runHook postInstall
   '';

--- a/pkgs/optee/ftpmDeviceProvisioningTools.nix
+++ b/pkgs/optee/ftpmDeviceProvisioningTools.nix
@@ -14,7 +14,7 @@ let
   runtimePath = lib.makeBinPath [ tpm2-tools openssl diffutils ftpmHelperTa ];
 in
 stdenvNoCC.mkDerivation {
-  pname = "ftpm-device-provisioning";
+  pname = "ftpm-device-provisioning-tools";
   version = l4tMajorMinorPatchVersion;
 
   dontUnpack = true;

--- a/pkgs/optee/ftpmManufacturingTools.nix
+++ b/pkgs/optee/ftpmManufacturingTools.nix
@@ -1,0 +1,100 @@
+{ lib
+, runCommand
+, writeShellScript
+, runtimeShell
+, python3
+, openssl
+, coreutils
+, gitRepos
+, l4tMajorMinorPatchVersion
+}:
+let
+  nvOpteeSrc = gitRepos."tegra/optee-src/nv-optee";
+  toolSrc = "${nvOpteeSrc}/optee/samples/ftpm-helper/host/tool";
+  genEkbSrc = "${nvOpteeSrc}/optee/samples/hwkey-agent/host/tool/gen_ekb/gen_ekb.py";
+
+  # ecdsa is required by NVIDIA's tools; nixpkgs marks it insecure
+  # (CVE-2024-23342, wontfix), so building needs NIXPKGS_ALLOW_INSECURE=1.
+  pythonEnv = python3.withPackages (ps: [
+    ps.cryptography
+    ps.pyaes
+    ps.numpy
+    ps.asn1crypto
+    ps.oscrypto
+    ps.pycryptodome
+    ps.pycryptodomex
+    ps.ecdsa
+  ]);
+
+  runtimePath = lib.makeBinPath [
+    pythonEnv
+    openssl
+    coreutils
+  ];
+
+  # Output directories the tools may produce.
+  outputDirs = "odm_out oem_out ftpm_out ca_out ftpm_kdk";
+
+  # NVIDIA's tools chdir to their own directory and write output alongside
+  # themselves, so we symlink sources into a per-invocation tmpdir. The .sh
+  # tools need an explicit interpreter since #!/bin/bash doesn't resolve on NixOS.
+  mkWrapper =
+    name: cmd:
+    writeShellScript name ''
+      set -euo pipefail
+      _ORIG_DIR="$(pwd)"
+      _WORKSPACE="$(mktemp -d)"
+      _cleanup() { rm -rf "$_WORKSPACE"; }
+      trap _cleanup EXIT
+
+      export PATH="${runtimePath}:$PATH"
+
+      # Refuse to clobber an earlier run's output (EKB/KDK material isn't reproducible).
+      for _outdir in ${outputDirs}; do
+        if [ -e "$_ORIG_DIR/$_outdir" ]; then
+          echo "error: $_ORIG_DIR/$_outdir already exists; move or remove it first" >&2
+          exit 1
+        fi
+      done
+
+      for _f in ${toolSrc}/*; do
+        ln -sf "$_f" "$_WORKSPACE/$(basename "$_f")"
+      done
+      ln -sf ${genEkbSrc} "$_WORKSPACE/gen_ekb.py"
+
+      ${cmd}
+
+      for _outdir in ${outputDirs}; do
+        if [ -d "$_WORKSPACE/$_outdir" ]; then
+          mv "$_WORKSPACE/$_outdir" "$_ORIG_DIR/$_outdir"
+        fi
+      done
+    '';
+
+  wrappers = {
+    ftpm-odm-ekb-gen = mkWrapper "ftpm-odm-ekb-gen"
+      ''${pythonEnv}/bin/python3 "$_WORKSPACE/odm_ekb_gen.py" "$@"'';
+    ftpm-oem-ekb-gen = mkWrapper "ftpm-oem-ekb-gen"
+      ''${pythonEnv}/bin/python3 "$_WORKSPACE/oem_ekb_gen.py" "$@"'';
+    ftpm-kdk-gen = mkWrapper "ftpm-kdk-gen"
+      ''${pythonEnv}/bin/python3 "$_WORKSPACE/kdk_gen.py" "$@"'';
+    ftpm-gen-ek-csr = mkWrapper "ftpm-gen-ek-csr"
+      ''${runtimeShell} "$_WORKSPACE/ftpm_manufacturer_gen_ek_csr.sh" "$@"'';
+    ftpm-ca-simulator = mkWrapper "ftpm-ca-simulator"
+      ''${runtimeShell} "$_WORKSPACE/ftpm_manufacturer_ca_simulator.sh" "$@"'';
+    gen-ekb = mkWrapper "gen-ekb"
+      ''${pythonEnv}/bin/python3 "$_WORKSPACE/gen_ekb.py" "$@"'';
+  };
+in
+runCommand "ftpm-manufacturing-tools-${l4tMajorMinorPatchVersion}"
+{
+  meta = {
+    description = "NVIDIA fTPM ODM/OEM manufacturing tools (KDK and EKB generation, EK CSR generation, CA simulator)";
+    platforms = lib.platforms.linux;
+  };
+} ''
+  mkdir -p $out/bin
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: script: ''
+    install -m755 ${script} $out/bin/${name}
+  '') wrappers)}
+''

--- a/pkgs/optee/ftpmManufacturingTools.nix
+++ b/pkgs/optee/ftpmManufacturingTools.nix
@@ -1,7 +1,6 @@
 { lib
-, runCommand
-, writeShellScript
-, runtimeShell
+, stdenvNoCC
+, makeWrapper
 , python3
 , openssl
 , coreutils
@@ -31,70 +30,108 @@ let
     openssl
     coreutils
   ];
-
-  # Output directories the tools may produce.
-  outputDirs = "odm_out oem_out ftpm_out ca_out ftpm_kdk";
-
-  # NVIDIA's tools chdir to their own directory and write output alongside
-  # themselves, so we symlink sources into a per-invocation tmpdir. The .sh
-  # tools need an explicit interpreter since #!/bin/bash doesn't resolve on NixOS.
-  mkWrapper =
-    name: cmd:
-    writeShellScript name ''
-      set -euo pipefail
-      _ORIG_DIR="$(pwd)"
-      _WORKSPACE="$(mktemp -d)"
-      _cleanup() { rm -rf "$_WORKSPACE"; }
-      trap _cleanup EXIT
-
-      export PATH="${runtimePath}:$PATH"
-
-      # Refuse to clobber an earlier run's output (EKB/KDK material isn't reproducible).
-      for _outdir in ${outputDirs}; do
-        if [ -e "$_ORIG_DIR/$_outdir" ]; then
-          echo "error: $_ORIG_DIR/$_outdir already exists; move or remove it first" >&2
-          exit 1
-        fi
-      done
-
-      for _f in ${toolSrc}/*; do
-        ln -sf "$_f" "$_WORKSPACE/$(basename "$_f")"
-      done
-      ln -sf ${genEkbSrc} "$_WORKSPACE/gen_ekb.py"
-
-      ${cmd}
-
-      for _outdir in ${outputDirs}; do
-        if [ -d "$_WORKSPACE/$_outdir" ]; then
-          mv "$_WORKSPACE/$_outdir" "$_ORIG_DIR/$_outdir"
-        fi
-      done
-    '';
-
-  wrappers = {
-    ftpm-odm-ekb-gen = mkWrapper "ftpm-odm-ekb-gen"
-      ''${pythonEnv}/bin/python3 "$_WORKSPACE/odm_ekb_gen.py" "$@"'';
-    ftpm-oem-ekb-gen = mkWrapper "ftpm-oem-ekb-gen"
-      ''${pythonEnv}/bin/python3 "$_WORKSPACE/oem_ekb_gen.py" "$@"'';
-    ftpm-kdk-gen = mkWrapper "ftpm-kdk-gen"
-      ''${pythonEnv}/bin/python3 "$_WORKSPACE/kdk_gen.py" "$@"'';
-    ftpm-gen-ek-csr = mkWrapper "ftpm-gen-ek-csr"
-      ''${runtimeShell} "$_WORKSPACE/ftpm_manufacturer_gen_ek_csr.sh" "$@"'';
-    ftpm-ca-simulator = mkWrapper "ftpm-ca-simulator"
-      ''${runtimeShell} "$_WORKSPACE/ftpm_manufacturer_ca_simulator.sh" "$@"'';
-    gen-ekb = mkWrapper "gen-ekb"
-      ''${pythonEnv}/bin/python3 "$_WORKSPACE/gen_ekb.py" "$@"'';
-  };
 in
-runCommand "ftpm-manufacturing-tools-${l4tMajorMinorPatchVersion}"
-{
+stdenvNoCC.mkDerivation {
+  pname = "ftpm-manufacturing-tools";
+  version = l4tMajorMinorPatchVersion;
+
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  # NVIDIA's tools assume they're run from their own source directory:
+  # odm_ekb_gen.py/oem_ekb_gen.py chdir to their own location before doing
+  # relative-path I/O, and the shell tools reference sibling scripts/config
+  # by relative path. Since we copy everything into $out/libexec (a
+  # read-only store path), drop the chdir calls and make those references
+  # absolute, so the tools instead read/write relative to the caller's cwd.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec/ftpm $out/bin
+    cp -r ${toolSrc}/. $out/libexec/ftpm/
+    cp ${genEkbSrc} $out/libexec/ftpm/gen_ekb.py
+    chmod -R u+w $out/libexec/ftpm
+
+    substituteInPlace $out/libexec/ftpm/odm_ekb_gen.py \
+      --replace-fail \
+        'os.path.dirname(os.path.abspath(__file__))' \
+        'os.getcwd()' \
+      --replace-fail \
+        'os.chdir(wd)' \
+        'pass' \
+      --replace-warn \
+        'cmd_gen_ek_csr = "./ftpm_manufacturer_gen_ek_csr.sh"' \
+        'cmd_gen_ek_csr = "'"$out"'/libexec/ftpm/ftpm_manufacturer_gen_ek_csr.sh"' \
+      --replace-warn \
+        'cmd_gen_ek_certs = "./ftpm_manufacturer_ca_simulator.sh"' \
+        'cmd_gen_ek_certs = "'"$out"'/libexec/ftpm/ftpm_manufacturer_ca_simulator.sh"' \
+      --replace-warn \
+        'cmd_sign_sid_csr = "./ftpm_manufacturer_ca_sign_sid_csr.sh"' \
+        'cmd_sign_sid_csr = "'"$out"'/libexec/ftpm/ftpm_manufacturer_ca_sign_sid_csr.sh"'
+    substituteInPlace $out/libexec/ftpm/oem_ekb_gen.py \
+      --replace-fail \
+        'os.path.dirname(os.path.abspath(__file__))' \
+        'os.getcwd()' \
+      --replace-fail \
+        'os.chdir(wd)' \
+        'pass' \
+      --replace-fail \
+        'cmd_gen_ekb = "./gen_ekb.py"' \
+        'cmd_gen_ekb = "'"$out"'/libexec/ftpm/gen_ekb.py"'
+
+    if [ -f "$out/libexec/ftpm/ftpm_manufacturer_gen_ek_csr.sh" ]; then
+      substituteInPlace $out/libexec/ftpm/ftpm_manufacturer_gen_ek_csr.sh \
+        --replace-fail \
+          'FTPM_GEN_EK_CSR_PYTHON_SCRIPT="./ftpm_manufacturer_gen_ek_csr_tool.py"' \
+          'FTPM_GEN_EK_CSR_PYTHON_SCRIPT="'"$out"'/libexec/ftpm/ftpm_manufacturer_gen_ek_csr_tool.py"'
+    fi
+    if [ -f "$out/libexec/ftpm/ftpm_manufacturer_ca_simulator.sh" ]; then
+      substituteInPlace $out/libexec/ftpm/ftpm_manufacturer_ca_simulator.sh \
+        --replace-fail \
+          'CONF_PATH="./conf"' \
+          'CONF_PATH="'"$out"'/libexec/ftpm/conf"' \
+        --replace-fail \
+          'CA_SIM_PYTHON_SCRIPT="./ftpm_manufacturer_ca_simulator.py"' \
+          'CA_SIM_PYTHON_SCRIPT="'"$out"'/libexec/ftpm/ftpm_manufacturer_ca_simulator.py"'
+    fi
+    if [ -f "$out/libexec/ftpm/ftpm_manufacturer_ca_sign_sid_csr.sh" ]; then
+      substituteInPlace $out/libexec/ftpm/ftpm_manufacturer_ca_sign_sid_csr.sh \
+        --replace-fail \
+          'CONF_PATH="./conf"' \
+          'CONF_PATH="'"$out"'/libexec/ftpm/conf"' \
+        --replace-fail \
+          'CA_SIM_PYTHON_SCRIPT="./ftpm_manufacturer_ca_sign_sid_csr.py"' \
+          'CA_SIM_PYTHON_SCRIPT="'"$out"'/libexec/ftpm/ftpm_manufacturer_ca_sign_sid_csr.py"'
+    fi
+
+    patchShebangs $out/libexec/ftpm
+
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/ftpm-odm-ekb-gen \
+      --add-flags $out/libexec/ftpm/odm_ekb_gen.py \
+      --prefix PATH : ${runtimePath}
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/ftpm-oem-ekb-gen \
+      --add-flags $out/libexec/ftpm/oem_ekb_gen.py \
+      --prefix PATH : ${runtimePath}
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/ftpm-kdk-gen \
+      --add-flags $out/libexec/ftpm/kdk_gen.py \
+      --prefix PATH : ${runtimePath}
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/gen-ekb \
+      --add-flags $out/libexec/ftpm/gen_ekb.py \
+      --prefix PATH : ${runtimePath}
+    if [ -f "$out/libexec/ftpm/ftpm_manufacturer_gen_ek_csr.sh" ]; then
+      makeWrapper $out/libexec/ftpm/ftpm_manufacturer_gen_ek_csr.sh $out/bin/ftpm-gen-ek-csr \
+        --prefix PATH : ${runtimePath}
+    fi
+    if [ -f "$out/libexec/ftpm/ftpm_manufacturer_ca_simulator.sh" ]; then
+      makeWrapper $out/libexec/ftpm/ftpm_manufacturer_ca_simulator.sh $out/bin/ftpm-ca-simulator \
+        --prefix PATH : ${runtimePath}
+    fi
+
+    runHook postInstall
+  '';
+
   meta = {
     description = "NVIDIA fTPM ODM/OEM manufacturing tools (KDK and EKB generation, EK CSR generation, CA simulator)";
     platforms = lib.platforms.linux;
   };
-} ''
-  mkdir -p $out/bin
-  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: script: ''
-    install -m755 ${script} $out/bin/${name}
-  '') wrappers)}
-''
+}


### PR DESCRIPTION
Follow-up to #521. Adds first-boot EK certificate provisioning and the supporting packages.

## Changes

- **`tpm2-abrmd` ordering** — order after `ftpm-driver` so abrmd doesn't start against a missing `/dev/tpm0`.
- **`ftpmDeviceProvisioning` package** — Nix wrappers for NVIDIA's on-device provisioning scripts (`ftpm_device_provision.sh`, `ftpm-offline-verify`, `ftpm-test-attestation`). No Python dependency.
- **`ftpm-device-provision` service** — first-boot oneshot that extracts RSA and EC EK certificates from the EKB via the OP-TEE PTA, stores them in TPM NV memory, and clears hierarchy auth so `systemd-tpm2-setup` and `tpm2-tools` work without `-P` flags. Uses an owner-defined NV sentinel written last for atomicity — a failed run clears the TPM so the next boot retries cleanly. Gated on `firmware.eksFile` (fused devices only).
- **`ftpmManufacturingTools` package** — host-side ODM/OEM toolchain (KDK/EKB generation, EK CSR generation, CA simulator). Not referenced by any module; host use only. Requires `NIXPKGS_ALLOW_INSECURE=1` due to `ecdsa` dependency.
- **Watchdog threshold** — raise hard lockup threshold to 30s on r38.4+. JP7's constant-time modexp implementation makes RSA keygen take ~12s in secure world, tripping the 10s default.

## Tested

- JP6 (Orin, fused): full provisioning flow, LUKS unlock, `tpm2_getekcertificate`
- JP7 (Thor, fused): provisioning + watchdog threshold

## Known limitations

- REE-FS secure storage still requires `CFG_INSECURE=y` without RPMB. RPMB support is future work (requires OEM_K1 fuse + NVIDIA tooling).