### PR TITLE
optee: Gate SHORT_BUFFER EPS patch on r36+

### DIFF
--- a/pkgs/optee/optee-os.nix
+++ b/pkgs/optee/optee-os.nix
@@ -55,6 +55,7 @@ in
   patches = [
     ./remove-force-log-level.diff
     ./0003-Add-pre-sign-hook.patch
+  ] ++ lib.optionals (lib.versionAtLeast l4tMajorMinorPatchVersion "36") [
     ./0001-jetson_ftpm_helper_pta-Return-SHORT_BUFFER-when-EPS-.patch
   ];
 


### PR DESCRIPTION
The `jetson_ftpm_helper_pta` SHORT_BUFFER fix landed in #521 but was applied unconditionally. The hunk context doesn't match the r35 source (different line offset), so building JP5 fails with a patch rejection.

r35 is EOL and fTPM isn't used on JP5, so gate the patch on r36+.

Verified:
- JP5 (`35.6.4`): builds cleanly, patch skipped
- JP6 (`36.5.0`): builds, patch applies correctly
- JP7 (`39.2.0`): builds, patch applies correctly