### PR TITLE
cudaPackages: tensorrt: Clear executable permission bit from stack in libraries

### DIFF
--- a/cuda-packages-11-4-extension.nix
+++ b/cuda-packages-11-4-extension.nix
@@ -202,7 +202,7 @@ let
             ];
 
             postFixup =
-              prevAttrs.prevAttrs or ""
+              prevAttrs.postFixup or ""
               + ''
                 nixLog "patchelf-ing ''${!outputLib:?}/lib/libnvinfer.so with runtime dependencies"
                 patchelf \

--- a/pkgs/cuda-extensions/default.nix
+++ b/pkgs/cuda-extensions/default.nix
@@ -47,10 +47,29 @@ in
   # of TensorRT don't fail (e.g., multimedia-samples). We only need to do this on Jetson devices with a DLA, so it is
   # sufficient to guard on the availability of libcudla, which is only available on Xavier and Orin.
   tensorrt =
+    let
+      tensorrt =
+        if finalCudaPackages.cudaAtLeast "13" then
+          prevCudaPackages.tensorrt
+        else
+          prevCudaPackages.tensorrt.overrideAttrs
+            (prevAttrs: {
+              postFixup =
+                prevAttrs.postFixup or ""
+                + ''
+                  for f in "''${!outputLib:?}"/lib/*.so* ; do
+                    if [ -f "$f" ] ; then
+                      nixLog "clearing execstack of $f"
+                      ${lib.getExe finalCudaPackages.pkgs.buildPackages.patchelfUnstable} --clear-execstack "$f"
+                    fi
+                  done
+                '';
+            });
+    in
     if !finalCudaPackages.libcudla.meta.available then
-      prevCudaPackages.tensorrt
+      tensorrt
     else
-      prevCudaPackages.tensorrt.overrideAttrs (prevAttrs: {
+      tensorrt.overrideAttrs (prevAttrs: {
         buildInputs =
           prevAttrs.buildInputs or [ ]
           ++ (


### PR DESCRIPTION
###### Description of changes

TensorRT's shared objects (notably libnvinfer_builder_resource.so) request an executable stack (PT_GNU_STACK = RWE). glibc >= 2.41 makes dlopen() of such objects a hard error instead of silently granting an executable stack, and TensorRT lazily dlopen()s the builder resource at engine-build time, so this surfaces as an opaque runtime failure:

Error Code 6: Internal Error
(Unable to load library: libnvinfer_builder_resource.so.8.5.2)

Clear the exec-stack bit from the libs so they load on newer glibc.

###### Testing

Observe exec stack bit cleared on:
- [x] `readelf -l result-lib/lib/libnvinfer_builder_resource.so.10.7.0` (cuda 12)
- [x] `result-lib/lib/libnvinfer_builder_resource.so.8.5.2` (cuda 11)
