### PR TITLE
uefi: add firmware.uefi.edk2ExtraPackages

### DIFF
--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -66,6 +66,15 @@ in
             default = [ ];
           };
 
+          edk2ExtraPackages = mkOption {
+            type = types.listOf types.package;
+            description = ''
+              Extra edk2 package trees for the UEFI build. Each derivation is
+              unpacked under its name and prepended to PACKAGES_PATH. Requires L4T r36 or newer.
+            '';
+            default = [ ];
+          };
+
           secureBoot = {
             enrollDefaultKeys = lib.mkEnableOption "enroll default UEFI keys";
             defaultPkEslFile = mkOption {
@@ -462,6 +471,10 @@ in
       {
         assertion = (cfg.firmware.fskp.enable && (cfg.firmware.fskp.fuseBlob ? insecureClearText) -> cfg.firmware.fskp.fuseBlob.insecureClearText);
         message = "Do not set fskp.fuseBlob.insecureClearText in order to use an encrypted blob";
+      }
+      {
+        assertion = cfg.firmware.uefi.edk2ExtraPackages != [ ] -> pkgs.nvidia-jetpack.l4tAtLeast "36";
+        message = "hardware.nvidia-jetpack.firmware.uefi.edk2ExtraPackages requires L4T r36 or newer; the r35 UEFI firmware builder does not accept extra package trees.";
       }
     ];
 

--- a/overlay-with-config.nix
+++ b/overlay-with-config.nix
@@ -75,6 +75,9 @@ final: prev: (
             })).bup;
           in
           builtins.hashString "sha256" "${cursedBup}";
+      } // lib.optionalAttrs (prevJetpack.l4tAtLeast "36") {
+        # r36+ only: r35's stuart argument set is closed, so it can't accept this.
+        extraPackages = cfg.firmware.uefi.edk2ExtraPackages;
       } // lib.optionalAttrs (prevJetpack.l4tAtLeast "38") {
         # r38-only: when true, skip the disable-ftpm.diff patch so UEFI uses
         # the fTPM TA we embedded in tos.img. r35/r36 builders don't accept

--- a/pkgs/uefi-firmware/stuart.nix
+++ b/pkgs/uefi-firmware/stuart.nix
@@ -26,6 +26,9 @@
   # default, EDK2 authenticates using a test keypair commited upstream.
 , trustedPublicCertPemFile ? null
 , srcs
+, # Extra edk2 package trees, unpacked under their name and prepended to
+  # PACKAGES_PATH -- a derivation named "foo" needs foo/SomePkg/SomePkg.inf.
+  extraPackages ? [ ]
 , ...
 }:
 let
@@ -49,6 +52,18 @@ let
 
   pythonEnv = buildPackages.python312.withPackages (ps: callPackage ./pyenv.nix { inherit ps; inherit (patchedSrcs) edk2-nvidia; });
 
+  # No trailing slash -- GetSourcePackagesPath appends one. Leading space per
+  # flag keeps an empty list byte-identical to the old command line.
+  extraPackagesPathFlags =
+    lib.concatMapStrings (p: " --insert-packages-path ${p.name}") extraPackages;
+
+  # Multi-src unpackPhase fails deep in the sandbox (not with a clear Nix
+  # error) if two srcs share a name, so check upfront.
+  extraPackageNames = builtins.map (p: p.name) extraPackages;
+  collidingPackageNames = lib.intersectLists extraPackageNames (builtins.attrNames patchedSrcs);
+  uniqueExtraPackageNames = lib.unique extraPackageNames;
+  hasDuplicatePackageNames = builtins.length uniqueExtraPackageNames != builtins.length extraPackageNames;
+
   buildTarget = if debugMode then "DEBUG" else "RELEASE";
 
   targetArch =
@@ -67,6 +82,10 @@ let
     else
       throw "Unsupported architecture";
 in
+assert lib.assertMsg (collidingPackageNames == [ ])
+  "extraPackages names must not collide with the built-in edk2 package trees (${toString (builtins.attrNames patchedSrcs)}); colliding names: ${toString collidingPackageNames}";
+assert lib.assertMsg (!hasDuplicatePackageNames)
+  "extraPackages names must be unique; got: ${toString extraPackageNames}";
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
   excludeDrvArgNames = [ "platformBuild" "outputs" "stuartExtraArgs" ];
@@ -78,7 +97,7 @@ lib.extendMkDerivation {
       pname = "${platformBuild}-edk2-uefi-${buildTarget}";
       version = l4tMajorMinorPatchVersion;
 
-      srcs = builtins.attrValues patchedSrcs;
+      srcs = builtins.attrValues patchedSrcs ++ extraPackages;
 
       sourceRoot = ".";
 
@@ -167,7 +186,7 @@ lib.extendMkDerivation {
 
       buildPhase = ''
         stuart_setup -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py"
-        stuart_build -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py" ${stuartExtraArgs} --target ${buildTarget}
+        stuart_build -c "edk2-nvidia/Platform/NVIDIA/${platformBuild}/PlatformBuild.py" ${extraPackagesPathFlags} ${stuartExtraArgs} --target ${buildTarget}
       '';
 
       installPhase = ''


### PR DESCRIPTION
###### Description of changes

Add `hardware.nvidia-jetpack.firmware.uefi.edk2ExtraPackages`, allowing boards to add out-of-tree EDK2 package trees to the UEFI build workspace.
Each package is unpacked into the workspace and added to EDK2's `PACKAGES_PATH` through Stuart's `--insert-packages-path`. This lets board-specific DSC/FDF patches reference packages such as `IntelUndiPkg` without patching an existing EDK2 source tree.

The option defaults to an empty list, so existing UEFI builds are unchanged. It is restricted to L4T r36+, since the r35 firmware builder does not support the Stuart-based package-path flow. Evaluation assertions reject duplicate package names and collisions with built-in EDK2 source trees.

###### Testing

- [x] `nix flake check --no-build`
- [x] Build JP7 UEFI firmware with a non-empty `edk2ExtraPackages`
- [x] Confirm an external EDK2 driver package is compiled into the resulting firmware build
