### PR TITLE
Fix edk2-nvidia-non-osi hash

### DIFF
--- a/pkgs/uefi-firmware/r39/default.nix
+++ b/pkgs/uefi-firmware/r39/default.nix
@@ -42,7 +42,7 @@ let
     edk2-infineon.sha256 = "sha256-47UJfEd4ViTenx5dvy2G75NFSgmcsyIWpN0Lv1QlvA8=";
     edk2-redfish-client.sha256 = "sha256-Tq6dZu90T10FBVMYjYolm2WfAZc/cQe8dNuKXrK3RbE=";
     edk2-nvidia.sha256 = "sha256-1qFt5wv5Ay3/rB6JecyKdc3ldHhpdOeNLcdWvsUuK3U=";
-    edk2-nvidia-non-osi.sha256 = "sha256-xdIcdgmvFZgF2R8sjDVIrW8w2XLeDhI8kGpoW8gdNgE=";
+    edk2-nvidia-non-osi.sha256 = "sha256-QdwDTzA23GGXY1jqgzbc6oTnOmhJJY5cm5NgWLH1VE8=";
   };
 
   fetchRepo = name: value: fetchFromGitHub (defaultOrigin // { inherit name; repo = name; } // value);


### PR DESCRIPTION
###### Description of changes

```
error: hash mismatch in fixed-output derivation '/nix/store/qcws52xvfxli7rmpkfl48g2bh41pshri-edk2-nvidia-non-osi.drv':
         specified: sha256-xdIcdgmvFZgF2R8sjDVIrW8w2XLeDhI8kGpoW8gdNgE=
            got:    sha256-QdwDTzA23GGXY1jqgzbc6oTnOmhJJY5cm5NgWLH1VE8=
```
The hash for edk2-nvidia-non-osi.sha256 is incorrect.

###### Testing

```
• Updated input 'jetpack':
    'github:anduril/jetpack-nixos/393550603a3fa6dc470c26a4db2e909b8e84c787?narHash=sha256-SftMCEtbhWXFbu1s%2Bd89NLa05ONrxQIlfCxjA6WfDc8%3D' (2026-08-27)
  → 'github:kornev/jetpack-nixos/a8899274d23e27188c10603a2d9296a5299d1143?narHash=sha256-faGwLvNP1J7KwvlCqqrAf829S/XjaL3hU%2BzK%2B0Myr5o%3D' (2026-08-30)
building the system configuration...
```
