### PR TITLE
l4t-multimedia: apply dequeue race fix to all versions

### DIFF
--- a/pkgs/l4t/l4t-multimedia.nix
+++ b/pkgs/l4t/l4t-multimedia.nix
@@ -50,20 +50,23 @@ buildFromDebs {
   ];
   buildInputs = [ l4t-core l4t-cuda l4t-nvsci pango alsa-lib ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ]);
 
-  patches = lib.optionals (l4tOlder "36") [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/af0a93313c13e9eac4e80082d8a8e8ac5f7ad6e8/recipes-multimedia/argus/files/0005-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch";
-      hash = "sha256-2PvlpGiz9evu3lc2R8nGYmC1jn8rqLo23dQ1cDvuCyo=";
-      stripLen = 1;
-      extraPrefix = "src/jetson_multimedia_api/";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/cc1c28f05fbd1b511d3bca3795dd9b6a35df5914/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch";
-      hash = "sha256-4Sm2kPP44LRPVMFrLmowvWPec1sIV2LHATsNmIGKExo=";
-      stripLen = 1;
-      extraPrefix = "src/jetson_multimedia_api/";
-    })
-  ];
+  patches =
+    lib.optionals (l4tOlder "36") [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/OE4T/meta-tegra/af0a93313c13e9eac4e80082d8a8e8ac5f7ad6e8/recipes-multimedia/argus/files/0005-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch";
+        hash = "sha256-2PvlpGiz9evu3lc2R8nGYmC1jn8rqLo23dQ1cDvuCyo=";
+        stripLen = 1;
+        extraPrefix = "src/jetson_multimedia_api/";
+      })
+    ]
+    ++ [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/OE4T/meta-tegra/cc1c28f05fbd1b511d3bca3795dd9b6a35df5914/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch";
+        hash = "sha256-4Sm2kPP44LRPVMFrLmowvWPec1sIV2LHATsNmIGKExo=";
+        stripLen = 1;
+        extraPrefix = "src/jetson_multimedia_api/";
+      })
+    ];
   postPatch = ''
     cp -r src/jetson_multimedia_api/{argus,include,samples} .
     rm -rf src


### PR DESCRIPTION
## Description of changes

Apply the dequeue data-race patch to `l4t-multimedia` on JetPack 5, 6, and 7.

Keep the unrelated multimedia header patch limited to JetPack 5.

This change makes `l4t-multimedia` consistent with `l4t-multimedia-samples`.

Fixes #445

## Testing

- Ran the repository formatting check
- Ran the default, NixOS 25.11, and unstable CI commands locally.
- Built `l4t-multimedia` for JetPack 5, 6, and 7
- Confirmed that the patch applies to the normalized source for each version
- Disabled remote builders during all builds
