### PR TITLE
containers: fix build for JP5/JP6

### DIFF
--- a/pkgs/containers/deps.nix
+++ b/pkgs/containers/deps.nix
@@ -5,7 +5,7 @@
 , l4tMajorMinorPatchVersion
 , l4tAtLeast
 , l4t-cuda
-, l4t-video-codec-openrm
+, l4t-video-codec-openrm ? null
 }:
 
 runCommand "container-deps" { nativeBuildInputs = [ dpkg ]; }


### PR DESCRIPTION
###### Description of changes

l4t-video-codec-openrm is available only on JP7.

###### Testing

- [x] build container tests
