### PR TITLE
Extend FSKP support to all jetpack 7 boards.

### DIFF
--- a/device-pkgs/default.nix
+++ b/device-pkgs/default.nix
@@ -177,10 +177,10 @@ let
           LDK_DIR="$(realpath .)"
           export LDK_DIR
 
-          cd l4t/tools/flashtools/fuseburn
+          cd tools/flashtools/fuseburn
           ./fskp_fuseburn.py \
             --board-spec ${lib.escapeShellArg "${cfg.firmware.fskp.boardSpecFile}"} \
-            -B ${lib.escapeShellArg "../../../../${cfg.firmware.fskp.boardConfigFilename}"} \
+            -B ${lib.escapeShellArg "../../../${cfg.firmware.fskp.boardConfigFilename}"} \
             -c ${chipId} \
             ${if cfg.firmware.fskp.fuseBlob ? encrypted then
               lib.concatStringsSep " " [
@@ -196,6 +196,21 @@ let
       '';
       dtbsDir = config.hardware.deviceTree.package;
     };
+    # Board config file must be located in the BSP due to assumptions about relative paths and
+    # sourcing other files from it.
+    derivationArgs.postCheck = ''
+      if ! [[ \
+        -e "$(realpath ${lib.escapeShellArg "${nvidia-jetpack.flash-tools}/tools/flashtools/fuseburn/${cfg.firmware.fskp.boardSpecFile}"})" || \
+        -e ${lib.escapeShellArg "${cfg.firmware.fskp.boardSpecFile}"} \
+      ]]; then
+        echo "ERROR: board spec file ${lib.escapeShellArg "${cfg.firmware.fskp.boardSpecFile}"} not found" >&2
+        exit 1
+      fi
+      if ! [ -e "$(realpath ${lib.escapeShellArg "${nvidia-jetpack.flash-tools}/${cfg.firmware.fskp.boardConfigFilename}"})" ]; then
+        echo "ERROR: board config file ${lib.escapeShellArg "${cfg.firmware.fskp.boardConfigFilename}"} not found relative to BSP root dir" >&2
+        exit 1
+      fi
+    '';
     meta.platforms = [ "x86_64-linux" ];
   };
 

--- a/modules/flash-script.nix
+++ b/modules/flash-script.nix
@@ -258,7 +258,14 @@ in
 
           boardSpecFile = mkOption {
             type = types.oneOf [ lib.types.path types.str ];
-            default = "${cfg.som}-board-spec.txt";
+            default = (
+              if cfg.som == "orin-nano" then
+                "orinnano-board-spec.txt"
+              else if cfg.som == "orin-nx" then
+                "orinnx-board-spec.txt"
+              else
+                "${cfg.som}-board-spec.txt"
+            );
             description = ''
               Path to the board-spec.txt file passed to `fskp_fuseburn.py` via `--board-spec`.
               Defaults can be found in the bsp repo at `tools/flashtools/fuseburn/*-board-spec.txt`.
@@ -465,8 +472,8 @@ in
 
     assertions = [
       {
-        assertion = !cfg.firmware.fskp.enable || (cfg.som != null && lib.hasPrefix "thor-" cfg.som);
-        message = "FSKP support currently limited to Thor-family boards";
+        assertion = !cfg.firmware.fskp.enable || (lib.versionAtLeast cfg.majorVersion "7");
+        message = "FSKP support currently limited to Jetpack 7+ boards";
       }
       {
         assertion = (cfg.firmware.fskp.enable && (cfg.firmware.fskp.fuseBlob ? insecureClearText) -> cfg.firmware.fskp.fuseBlob.insecureClearText);
@@ -478,8 +485,8 @@ in
       }
     ];
 
-    # On thor, fskpFuseScript is the preferred method for fusing so enable it by default.
-    hardware.nvidia-jetpack.firmware.fskp.enable = lib.mkDefault (lib.hasPrefix "thor-" cfg.som);
+    # On jetpack 7, fskpFuseScript is the supported method for fusing so enable it by default.
+    hardware.nvidia-jetpack.firmware.fskp.enable = lib.mkDefault (lib.versionAtLeast cfg.majorVersion "7");
 
     # These are from l4t_generate_soc_bup.sh, plus some additional ones found in the wild.
     hardware.nvidia-jetpack.firmware.variants =

--- a/overlay.nix
+++ b/overlay.nix
@@ -80,12 +80,13 @@ in
 
         bspHash = "sha256-LlYZCIuojoXaslJH8DPXBlm29nb/g1F2oHdm3LD9vms=";
         bspPrePatch = ''
-          cp --no-preserve=all -r ${hostOverlayFskpTools}/Linux_for_Tegra/. ./
-          find ${hostOverlayFskpTools}/Linux_for_Tegra/. -type f -perm -u+x -printf '%P\0' \
+          overlayRoot=${hostOverlayFskpTools}/Linux_for_Tegra/l4t
+          cp --no-preserve=all -r "$overlayRoot"/. ./
+          find "$overlayRoot"/. -type f -perm -u+x -printf '%P\0' \
             | xargs -0 -I{} chmod +x "./{}"
 
           # Remove NVIDIA's bundled pyusb so we use nix's version. See `fskp_helper_t264.py`.
-          find l4t/tools/flashtools -type d -name pyusb -path '*/external/pyusb' -exec rm -rf {} +
+          find tools/flashtools -type d -name pyusb -path '*/external/pyusb' -exec rm -rf {} +
         '';
         bspPatches = [
           ./pkgs/r38-bsp.patch

--- a/pkgs/r39-bsp-firmware-variants.patch
+++ b/pkgs/r39-bsp-firmware-variants.patch
@@ -4,13 +4,13 @@ Date: Tue, 18 Aug 2026 11:20:28 -0700
 Subject: [PATCH] Allow override of LDK_DIR in convert.sh
 
 ---
- l4t/tools/flashtools/fuseburn/convert.sh | 2 +-
+ tools/flashtools/fuseburn/convert.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/l4t/tools/flashtools/fuseburn/convert.sh b/tools/flashtools/fuseburn/convert.sh
+diff --git a/tools/flashtools/fuseburn/convert.sh b/tools/flashtools/fuseburn/convert.sh
 index ae9a127..e597bfe 100644
---- a/l4t/tools/flashtools/fuseburn/convert.sh
-+++ b/l4t/tools/flashtools/fuseburn/convert.sh
+--- a/tools/flashtools/fuseburn/convert.sh
++++ b/tools/flashtools/fuseburn/convert.sh
 @@ -8,7 +8,7 @@
  # and any modifications thereto.  Any use, reproduction, disclosure or
  # distribution of this software and related documentation without an express

--- a/pkgs/r39-bsp-pkc-list-fixes.patch
+++ b/pkgs/r39-bsp-pkc-list-fixes.patch
@@ -85,10 +85,10 @@ index f5d88dd..bbd3e50 100644
          # Restore the active key label for L4T HSM
          # This is the key label for the key in HSM for signing
 
-diff --git a/l4t/tools/flashtools/flash/tegrasign_v3_internal.py b/l4t/tools/flashtools/flash/tegrasign_v3_internal.py
+diff --git a/tools/flashtools/flash/tegrasign_v3_internal.py b/tools/flashtools/flash/tegrasign_v3_internal.py
 index f5d88dd..bbd3e50 100755
---- a/l4t/tools/flashtools/flash/tegrasign_v3_internal.py
-+++ b/l4t/tools/flashtools/flash/tegrasign_v3_internal.py
+--- a/tools/flashtools/flash/tegrasign_v3_internal.py
++++ b/tools/flashtools/flash/tegrasign_v3_internal.py
 @@ -1241,22 +1241,54 @@ def is_key_list(filelistname, p_key, verbose):
          else:
              xml_str = comment + ElementTree.tostring(root)


### PR DESCRIPTION
###### Description of changes

Extend FSKP support to all jetpack 7 boards.

* Moves FSKP overlay out of vestigial `l4t` directory and update r39 bsp patches accordingly.
* Allows non-thor jetpack 7 boards to use FSKP.

###### Testing

Dry run fused an orin-nano-devkit with FSKP on jetpack 7.